### PR TITLE
restore forgotten logger level "notice"

### DIFF
--- a/libiocage/lib/Logger.py
+++ b/libiocage/lib/Logger.py
@@ -34,6 +34,7 @@ class Logger:
         "error",
         "warn",
         "info",
+        "notice",
         "verbose",
         "debug",
         "spam",


### PR DESCRIPTION
notice is missing from the actuall logger levels.
If that was on purpose, please ignore this PR