### PR TITLE
This removes a non-existent argument from `create`

### DIFF
--- a/libiocage/cli/create.py
+++ b/libiocage/cli/create.py
@@ -156,7 +156,7 @@ def cli(release, template, count, props, pkglist, basejail, basejail_type,
 
         suffix = f" ({i}/{count})" if count > 1 else ""
         try:
-            jail.create(release.name, auto_download=True)
+            jail.create(release.name)
             msg = f"{jail.humanreadable_name} successfully created!{suffix}"
             logger.log(msg)
         except:


### PR DESCRIPTION
Opening this as a PR, as we may still want this and opt to add it to `create` instead of removing it.