### PR TITLE
DHCP and dynamic devfs rules

### DIFF
--- a/libiocage/lib/DevfsRules.py
+++ b/libiocage/lib/DevfsRules.py
@@ -1,0 +1,382 @@
+import re
+import os.path
+
+import libiocage.lib.errors
+import libiocage.lib.helpers
+
+
+class DevfsRulesFilter:
+
+    def __init__(self, source, active_filters=[]):
+        self.source = source
+        self.active_filters = active_filters
+
+    def with_rule(self, rule):
+        return DevfsRulesFilter(filter(
+            lambda x: x.has_rule(rule),
+            self.source
+        ), self.active_filters + [rule])
+
+    def with_include(self, rule_name):
+        rule = f"add include ${rule_name}"
+        return self.with_rule(rule)
+
+    def create_ruleset(self, ruleset_name, ruleset_number):
+        """
+        Create a ruleset from the provided filters
+
+        Args:
+
+            ruleset_name (string):
+                Name of the rule that get's created
+
+            ruleset_number (int):
+                Number of the rule that get's created
+        """
+
+        ruleset = DevfsRuleset(ruleset_name, ruleset_number)
+        for line in self.active_filters:
+            ruleset.append(line)
+        return ruleset
+
+
+class DevfsRuleset(list):
+    """
+    Representation of a devfs ruleset in the devfs.rules file
+
+    DevfsRuleset instances behave like standard lists and can store strings
+    that multiple lines (string)
+    """
+
+    PATTERN = re.compile(r"""^\[(?P<name>[a-z](?:[a-z0-9\-_]*[a-z0-9])?)=
+                (?P<number>[0-9]+)\]\s*(?:\#\s*(?P<comment>.*))?$""", re.X)
+
+    def __init__(self, value=None, number=None, comment=None):
+        """
+        Initialize DevfsRuleset
+
+        Args:
+
+            value (string): (optional)
+                If specified in combination with a number, this parameter is
+                interpreted as the ruleset name. Otherwise it is parsed with
+                the expectation to find a [<name>=<number>] ruleset definition.
+
+                When value is not specified or None, DevfsRuleset is assumed
+                to be new or unspecified (cannot be exported before name and
+                number were assigned at a later time)
+
+            number (int): (optional)
+                The number of the ruleset. Must be specified to export the
+                ruleset, but is like the name not required to compare the
+                ruleset with another
+        """
+
+        # when only one argument is passed, it's a line that need to be parsed
+        if value is None and number is None:
+            # name and number will be assigned later
+            name = None
+        elif number is None:
+            name, number, comment = self._parse_line(value)
+        else:
+            name = int(value)
+
+        self.name = name
+        self.number = number
+        self.comment = comment
+        list.__init__(self)
+
+    def has_rule(self, rule):
+        """
+        Returns true if the rule is part of the current ruleset
+
+        Args:
+
+            rule (string):
+                The rule string to be compared with current rules of the
+                ruleset instance
+        """
+        return rule in self
+
+    def append(self, rule):
+        if rule not in self:
+            list.append(self, rule)
+
+    def clone(self, source_ruleset):
+        """
+        Clones the rules from another ruleset
+
+        Args:
+
+            source_ruleset (libiocage.lib.DevfsRules.DevfsRuleset):
+                Ruleset to copy all rules from
+        """
+        for rule in source_ruleset:
+            self.append(rule)
+
+    def _parse_line(self, line):
+
+        # marks beginning of a new ruleset
+        ruleset_match = re.search(DevfsRuleset.PATTERN, line)
+        if ruleset_match is not None:
+            name = str(ruleset_match.group("name"))
+            number = int(ruleset_match.group("number"))
+            comment = ruleset_match.group("comment")
+            return name, number, comment
+
+        raise SyntaxError("DevfsRuleset line parsing failed")
+
+    def __str__(self):
+        ruleset_line = f"[{self.name}={self.number}]"
+        if self.comment is not None:
+            ruleset_line += f" # {self.comment}"
+        output = [ruleset_line] + [str(x) for x in self]
+        return "\n".join(output) + "\n"
+
+
+class DevfsRules(list):
+    """
+    Abstraction for the hosts /etc/devfs.rules
+
+    Read and edit devfs rules in a programmatic way.
+    Restarts devfs service after applying changes.
+    """
+
+    def __init__(self, rules_file="/etc/devfs.rules", logger=None):
+        """
+        Initializes a DevfsRules manager for devfs.rules files
+
+        Args:
+
+            rules_file (string): (default=/etc/devfs.rules)
+                Path of the devfs.rules file
+
+            logger (libiocage.Logger): (optional)
+                Instance of the logger that is passed to occuring errors
+        """
+
+        self.logger = logger
+
+        # index rulesets to find duplicated and provide easy access
+        self._ruleset_number_index = {}
+        self._ruleset_name_index = {}
+
+        # remember all lines that were loaded from defaults (system)
+        self._system_rule_lines = []
+
+        list.__init__(self)
+
+        # will automatically read from file - needs to be the last item
+        self.rules_file = rules_file
+
+    def append(self, ruleset, is_system_rule=False):
+        """
+        Add a DevfsRuleset to the list
+
+        The rulesets added become indexed, so that lookups and duplication
+        checks are easy and fast
+
+        Args:
+
+            ruleset (libiocage.lib.DevfsRules.DevfsRuleset|string):
+                The ruleset that gets added if it is not already in the list
+        """
+
+        next_line_index = len(self)
+
+        if ruleset is None or isinstance(ruleset, str):
+            list.append(self, ruleset)
+            if is_system_rule is True:
+                self._system_rule_lines.append(next_line_index)
+            return ruleset
+
+        if ruleset.name in self._ruleset_name_index.keys():
+            raise libiocage.lib.errors.DuplicateDevfsRuleset(
+                reason=f"Ruleset named '{ruleset.name}' already present",
+                devfs_rules_file=self.rules_file,
+                logger=self.logger
+            )
+
+        if ruleset.number in self._ruleset_number_index.keys():
+            raise libiocage.lib.errors.DuplicateDevfsRuleset(
+                reason=f"Ruleset number '{ruleset.number}' already present",
+                devfs_rules_file=self.rules_file,
+                logger=self.logger
+            )
+
+        # build indexes
+        self._ruleset_number_index[ruleset.number] = next_line_index
+        self._ruleset_name_index[ruleset.name] = next_line_index
+        if is_system_rule is True:
+            self._system_rule_lines.append(next_line_index)
+
+        list.append(self, ruleset)
+        return ruleset
+
+    def new_ruleset(self, ruleset):
+        """
+        Append a new ruleset
+
+        Similar to append(), but automatically assigns a new number
+
+        Args:
+
+            ruleset (libiocage.lib.DevfsRules.DevfsRuleset):
+                The new devfs ruleset that is going to be added
+
+        Returns:
+
+            int: The devfs ruleset number of the created ruleset
+        """
+
+        ruleset.number = self.next_number
+
+        if ruleset.name is None:
+            ruleset.name = f"iocage_auto_{ruleset.number}"
+
+        self.append(ruleset)
+        return ruleset.number
+
+    def find_by_name(self, rule_name):
+        return self._find_by_index(rule_name, self._ruleset_name_index)
+
+    def find_by_number(self, rule_number):
+        return self._find_by_index(rule_number, self._ruleset_number_index)
+
+    def _find_by_index(self, rule_name, index):
+        return self[index[rule_name]]
+
+    @property
+    def default_rules_file(self):
+        return "/etc/defaults/devfs.rules"
+
+    @property
+    def rules_file(self):
+        """
+        Path of the devfs.rules file
+        """
+        return self._rules_file
+
+    @rules_file.setter
+    def rules_file(self, devfs_rules_path):
+        """
+        When setting a new devfs.rules source, it is read automatically
+        """
+        self._rules_file = devfs_rules_path
+        try:
+            self.read_rules()
+        except FileNotFoundError:
+            pass
+
+    @property
+    def next_number(self):
+        """
+        The next highest ruleset number that is available
+
+        This counting includes the systems default devfs rulesets
+        """
+        return len(self._ruleset_name_index.keys()) + 1
+
+    def read_rules(self):
+        """
+        Read existing devfs.rules file
+
+        Existing devfs rules get reset and read from the rules_file
+        """
+
+        if self.logger:
+            self.logger.debug(f"Reading devfs.rules from {self.rules_file}")
+
+        self.clear()
+        self._read_rules_file(self.default_rules_file, system=True)
+        self._read_rules_file(self.rules_file)
+
+    def _read_rules_file(self, file, system=False):
+
+        f = open(file, "r")
+
+        current_ruleset = None
+
+        for line in f.readlines():
+
+            line = line.strip().rstrip("\n")
+
+            # add comments and empty lines as string
+            if line.startswith("#") or (line == ""):
+                self.append(line, is_system_rule=system)
+                continue
+
+            try:
+                current_ruleset = DevfsRuleset(line)
+                self.append(current_ruleset, is_system_rule=system)
+                continue
+            except SyntaxError:
+                pass
+
+            # the first item must be a ruleset
+            if current_ruleset is None:
+                raise libiocage.lib.errors.InvalidDevfsRulesSyntax(
+                    devfs_rules_file=self.rules_file,
+                    reason="Rules must follow a ruleset declaration",
+                    logger=self.logger
+                )
+
+            current_ruleset.append(line)
+
+        f.close()
+
+    def save(self):
+        """
+        Apply changes to the devfs.rules file
+
+        Automatically restarts devfs service when the file was changed
+        """
+
+        content_before = None
+
+        if os.path.isfile(self.rules_file):
+            f = open(self.rules_file, "r+")
+            content_before = f.read()
+            f.seek(0)
+        else:
+            f = open(self.rules_file, "w")
+
+        new_content = self.__str__()
+
+        if content_before == new_content:
+            if self.logger is not None:
+                self.logger.verbose(
+                    f"devfs.rules file {self.rules_file} unchanged"
+                )
+        else:
+            if self.logger is not None:
+                self.logger.verbose(
+                    f"Writing devfs.rules to {self.rules_file}"
+                )
+                self.logger.spam(new_content, indent=1)
+
+            f.write(new_content)
+            f.truncate()
+            self._restart_devfs_service()
+
+        f.close()
+
+    def _restart_devfs_service(self):
+        """
+        Restart devfs service after changing devfs.rules
+        """
+        if self.logger is not None:
+            self.logger.debug("Restarting devfs service")
+        libiocage.lib.helpers.exec(["service", "devfs", "restart"])
+
+    def __str__(self):
+        """
+        Output the devfs.rules content as string
+        """
+
+        out_lines = []
+        for i, line in enumerate(self):
+            if i not in self._system_rule_lines:
+                out_lines.append(str(line))
+
+        return "\n".join(out_lines)

--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -2,6 +2,7 @@ import os
 import platform
 
 import libiocage.lib.Datasets
+import libiocage.lib.DevfsRules
 import libiocage.lib.Distribution
 import libiocage.lib.helpers
 
@@ -21,7 +22,19 @@ class Host:
             logger=self.logger
         )
 
+        self._devfs = None
         self.releases_dataset = None
+
+    @property
+    def devfs(self):
+        """
+        Lazy-loaded DevfsRules instance
+        """
+        if self._devfs is None:
+            self._devfs = libiocage.lib.DevfsRules.DevfsRules(
+                logger=self.logger
+            )
+        return self._devfs
 
     @property
     def userland_version(self):

--- a/libiocage/lib/JailConfigAddresses.py
+++ b/libiocage/lib/JailConfigAddresses.py
@@ -77,6 +77,16 @@ class JailConfigAddresses(dict):
         if notify:
             self.__notify()
 
+    @property
+    def networks(self):
+        """
+        Flat list of all networks configured across all nics
+        """
+        networks = []
+        for nic, addresses in self.items():
+            networks += addresses
+        return networks
+
     def __setitem__(self, key, values):
 
         try:

--- a/libiocage/lib/Logger.py
+++ b/libiocage/lib/Logger.py
@@ -138,7 +138,7 @@ class Logger:
 
     def _indent(self, message, level):
         indent = Logger.INDENT_PREFIX * level
-        return f"{indent}{message}"
+        return "\n".join(map(lambda x: f"{indent}{x}", message.split("\n")))
 
     # ToDo: support file logging
     # def _write(self, message, level, jail=None):

--- a/libiocage/lib/NetworkInterface.py
+++ b/libiocage/lib/NetworkInterface.py
@@ -3,6 +3,7 @@ import libiocage.lib.helpers
 
 class NetworkInterface:
     ifconfig_command = "/sbin/ifconfig"
+    dhclient_command = "/sbin/dhclient"
 
     def __init__(self,
                  name="vnet0",
@@ -81,7 +82,10 @@ class NetworkInterface:
     def __apply_addresses(self, addresses, ipv6=False):
         family = "inet6" if ipv6 else "inet"
         for address in addresses:
-            command = [self.ifconfig_command, self.name, family, address]
+            if address.lower() == "dhcp":
+                command = [self.dhclient_command, self.name]
+            else:
+                command = [self.ifconfig_command, self.name, family, address]
             self.exec(command)
 
     def exec(self, command, force_local=False):

--- a/libiocage/lib/errors.py
+++ b/libiocage/lib/errors.py
@@ -257,6 +257,7 @@ class ReleaseUpdateBranchLookup(IocageException):
             msg += ": {reason}"
         super.__init__(msg, *args, **kwargs)
 
+
 # Prompts
 
 
@@ -266,6 +267,30 @@ class DefaultReleaseNotFound(IocageException):
             f"Release '{host_release_name}' not found: "
             "Could not determine a default source"
         )
+        super().__init__(msg, *args, **kwargs)
+
+
+# DevfsRules
+
+
+class DevfsRuleException(IocageException):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+class InvalidDevfsRulesSyntax(DevfsRuleException):
+    def __init__(self, devfs_rules_file, reason=None, *args, **kwargs):
+        msg = f"Invalid devfs rules in {devfs_rules_file}"
+        if reason is not None:
+            msg += f": {reason}"
+        super().__init__(msg, *args, **kwargs)
+
+
+class DuplicateDevfsRuleset(DevfsRuleException):
+    def __init__(self, devfs_rules_file, reason=None, *args, **kwargs):
+        msg = "Cannot add duplicate ruleset"
+        if reason is not None:
+            msg += f": {reason}"
         super().__init__(msg, *args, **kwargs)
 
 


### PR DESCRIPTION
implements #15 

- use dhclient to assign a nic's address when `ip4_addr="vnet0|dhcp"` is used
- devfs.rules management tool:
  - read system default rules from `/etc/defaults/devfs.rules`
  - read existing rules from `/etc/devfs.rules` (if the file exists)
  - allows to compare rulesets by their content (lines)
  - allows forking rules from a base rule (used to even extend user specified rulesets `devfs_ruleset="123"` with bpf if necessary)
  - finds the next available devfs rule number
  - leaves comments and whitespace lines untouched
  - recognizes changes and restarts the devfs service when changes were applied
- allows users to specify the devfs rule by name (`devfs_rule="my_devfs_rule"`) instead of selection by number only