### PR TITLE
use None as default for arrays

### DIFF
--- a/libiocage/lib/JailConfigAddresses.py
+++ b/libiocage/lib/JailConfigAddresses.py
@@ -61,7 +61,10 @@ class JailConfigAddresses(dict):
                 if self.skip_on_error is False:
                     exit(1)
 
-    def add(self, nic, addresses=[], notify=True):
+    def add(self, nic, addresses=None, notify=True):
+
+        if addresses is None or addresses == [] or addresses == "":
+            return
 
         if isinstance(addresses, str):
             addresses = [addresses]

--- a/libiocage/lib/JailConfigInterfaces.py
+++ b/libiocage/lib/JailConfigInterfaces.py
@@ -33,7 +33,10 @@ class JailConfigInterfaces(dict):
             jail_if, bridge_if = nic_pair.split(":", maxsplit=1)
             self.add(jail_if, bridge_if, notify=False)
 
-    def add(self, jail_if, bridges=[], notify=True):
+    def add(self, jail_if, bridges=None, notify=True):
+
+        if bridges is None or bridges == [] or bridges == "":
+            return
 
         if isinstance(bridges, str):
             bridges = [bridges]


### PR DESCRIPTION
a non-None default causes the parameters to be pass-by-reference, and
hence mutable! We don't generally want that.

This partially(??) addresses #38