### PR TITLE
Human readable error for non-root execution

### DIFF
--- a/libiocage/cli/__init__.py
+++ b/libiocage/cli/__init__.py
@@ -86,8 +86,8 @@ class IOCageCLI(click.MultiCommand):
                     if len(sys.argv) != 1:
                         if os.geteuid() != 0:
                             logger.error(
-                                f"You need to have root privileges"
-                                f" to run {mod.__name__}"
+                                "You need to have root privileges"
+                                f" to run {mod.__name__.rsplit('.')[-1]}"
                             )
                             exit(1)
             except AttributeError:

--- a/libiocage/cli/__init__.py
+++ b/libiocage/cli/__init__.py
@@ -85,9 +85,10 @@ class IOCageCLI(click.MultiCommand):
                 if mod.__rootcmd__ and "--help" not in sys.argv[1:]:
                     if len(sys.argv) != 1:
                         if os.geteuid() != 0:
+                            app_name = mod.__name__.rsplit(".")[-1]
                             logger.error(
                                 "You need to have root privileges"
-                                f" to run {mod.__name__.rsplit('.')[-1]}"
+                                f" to run {app_name}"
                             )
                             exit(1)
             except AttributeError:


### PR DESCRIPTION
OLD:
```
╰─ ioc create -n test2 -r 11.1-RELEASE
You need to have root privileges to run libiocage.cli.create
```

NEW:
```
╰─ ioc create -n test2 -r 11.1-RELEASE
You need to have root privileges to run create
```