### PR TITLE
Add EOL tags to the fetched list output

### DIFF
--- a/libiocage/lib/Prompts.py
+++ b/libiocage/lib/Prompts.py
@@ -8,21 +8,24 @@ class Prompts:
         libiocage.lib.helpers.init_host(self, host)
 
     def release(self):
-        i = 0
         default = None
         available_releases = self.host.distribution.releases
-        for available_release in available_releases:
+        for i, available_release in enumerate(available_releases):
             if available_release.name == self.host.release_version:
                 default = i
-                print(f"[{i}] \033[1m{available_release.name}\033[0m")
+                print(
+                    f"[{i}] \033[1m{available_release.annotated_name}\033[0m"
+                )
             else:
-                print(f"[{i}] {available_release.name}")
-            i += 1
+                print(f"[{i}] {available_release.annotated_name}")
 
         if default is not None:
             default_release = available_releases[default]
             selection = input(
-                f"Release ({default_release.name}) [{default}]: "
+                # f"Release ({default_release.name}) [{default}]: "
+                "\nType the number of the desired RELEASE\n"
+                "Press [Enter] to fetch the default selection"
+                f" ({default_release.name}) [{default}]: "
             )
         else:
             default_release = None

--- a/libiocage/lib/Release.py
+++ b/libiocage/lib/Release.py
@@ -31,7 +31,8 @@ class Release:
                  logger=None,
                  check_hashes=True,
                  auto_fetch_updates=True,
-                 auto_update=True):
+                 auto_update=True,
+                 eol=False):
 
         libiocage.lib.helpers.init_logger(self, logger)
         libiocage.lib.helpers.init_zfs(self, zfs)
@@ -41,6 +42,7 @@ class Release:
             raise NameError(f"Invalid 'name' for Release: '{name}'")
 
         self.name = name
+        self.eol = eol
         self._hashes = None
         self._dataset = None
         self._root_dataset = None
@@ -144,6 +146,18 @@ class Release:
         if self.host.distribution.name == "HardenedBSD":
             return f"HardenedBSD-{self.name}-{self.host.processor}-LATEST"
         return self.name
+
+    @property
+    def annotated_name(self):
+        annotations = set()
+
+        if self.eol is True:
+            annotations.add("EOL")
+
+        if len(annotations) > 0:
+            return f"{self.name} ({', ('.join(annotations)})"
+
+        return f"{self.name}"
 
     @property
     def mirror_url(self):


### PR DESCRIPTION
This replicates iocage's current output
```
╰─ ioc fetch
[0] 10.1-RELEASE (EOL)
[1] 10.2-RELEASE (EOL)
[2] 10.3-RELEASE
[3] 10.4-BETA2
[4] 11.0-RELEASE
[5] 11.1-RELEASE
[6] 9.3-RELEASE (EOL)

Type the number of the desired RELEASE
Press [Enter] to fetch the default selection (11.1-RELEASE) [5]:
```