### PR TITLE
Feature: Rename Jails

### DIFF
--- a/libiocage/cli/rename.py
+++ b/libiocage/cli/rename.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""rename a jail."""
+import click
+
+import libiocage.lib.Jail
+
+__rootcmd__ = True
+
+
+@click.command(name="rename", help="Rename a stopped jail.")
+@click.pass_context
+@click.argument("jail", nargs=1)
+@click.argument("name", nargs=1)
+def cli(ctx, jail, name):
+    """
+    Rename a stopped jail.
+    """
+
+    logger = ctx.parent.logger
+    try :
+        ioc_jail = libiocage.lib.Jail.Jail(jail, logger=logger)
+        ioc_jail.rename(name)
+    except libiocage.lib.errors.IocageException:
+        exit(1)

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -289,6 +289,23 @@ class JailGenerator:
 
         self.storage.delete_dataset_recursive(self.dataset)
 
+    def rename(self, new_name: str):
+        """
+        Change the name of a jail
+        """
+
+        self.require_jail_existing()
+        self.require_jail_stopped()
+
+        current_id = self.config["id"]
+        dataset = self.dataset
+        self.config["name"] = new_name  # validates new_name
+        try:
+            dataset.rename(self.dataset_name)
+        except:
+            self.config["name"] = current_id
+            raise
+
     def _force_stop(self):
 
         successful = True


### PR DESCRIPTION
closes #52

### Changes
- Introduced ioc command `rename`
- Renames a dataset if the jail was stopped and the new name is valid

### Usage
```
ioc rename my-jail new-jail-name
```