### PR TITLE
run markdownlint against our md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,29 +4,33 @@ Following the contribution guidelines saves everyone time, requires less back
 and forth during the review process, and helps to ensures a consistent codebase.
 I use PyCharm for all of my programming, and these are what I use for my settings, adapt to your editor of choice.
 
-####A few general rules first:
+## A few general rules first:
+
 - Open any pull request against the `master` branch
 - Keep code to 80 characters or less.
 - Comment your code
 - Pull request description should clearly show what the change is including output if relevant.
 - Squash commits before opening a pull request.
-- Test and then test again! Make sure it works with the latest changes in 
-`master`.
+- Test and then test again! Make sure it works with the latest changes in `master`.
 - If adding a function, it must have a type signature. Examples can be found [here](https://www.python.org/dev/peps/pep-0484/) and [here](https://www.python.org/dev/peps/pep-3107/)
 - Spaces instead of Tabs
 - 4 spaces for first indent and each from then on.
 - Spaces around Assignment `(=, +=, …)`, Equality `(==, !=)`, Relational `(<, >, <=, >=)`, Bitwise `(*, |,^)`, Additive  `(+, -)`, Multiplicative `(*, @, /, %)`, Shift `(<<, >>, >>>)` and Power operators `(**)`.
 - Spaces after:
-```
+
+```python
 ,
 :
 #
 ```
+
 - Spaces before:
-```
+
+```python
 \
 #
 ```
+
 - Align multiline method call arguments and method declaration parameters
 - New line after a colon
 - Align multiline import statements
@@ -42,16 +46,19 @@ I use PyCharm for all of my programming, and these are what I use for my setting
 - 1 line before and after `while` loops
 - Run isort on `import` statements, including `from imports`.
 - Keep `from imports` within their own group:
-```
+
+```python
 import bar
 import foo
 
 from baz import foo
 from foobar import morefoo
 ```
+
 - Join `from imports` with the same source
 - Align dictionaries on colons:
-```
+
+```python
 x = max(
     1,
     2,
@@ -62,8 +69,9 @@ x = max(
     "eggs and ham": -0.0e0
 }
 ```
+
 - Add a linefeed at the end of the file
 
-####Documentation for Read The Docs
------
-If you wish to update some of our [documentation] (http://iocage.readthedocs.org), you only need to submit a PR for the files you change in iocage/doc/source. They will automatically be updated when the changes are merged.
+## Documentation for Read The Docs
+
+If you wish to update some of our [documentation](http://iocage.readthedocs.org), you only need to submit a PR for the files you change in iocage/doc/source. They will automatically be updated when the changes are merged.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-libiocage
-=========
+# libiocage
 
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/iocage/libiocage.svg)](http://isitmaintained.com/project/iocage/libiocage "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/iocage/libiocage.svg)](http://isitmaintained.com/project/iocage/libiocage "Percentage of issues still open")
@@ -19,13 +18,13 @@ This library provides programmatic access to iocage features and jails, while be
 
 ### from Source Distribution
 
-```
+```sh
 pip3.6 install libiocage
 ```
 
 ### from Master branch
 
-```
+```sh
 git clone https://github.com/iocage/libiocage
 cd libiocage
 make install
@@ -37,7 +36,7 @@ Please note: this will build `py-libzfs` from source, which will require `/usr/s
 
 ### Library
 
-```
+```python
 import libiocage
 
 jail = libiocage.Jail()
@@ -46,4 +45,4 @@ jail.create("11.1-RELEASE")
 
 ### CLI
 
-Libiocage comes bundles with a CLI tool called `ioc`. It is inspired by the command line interface of https://github.com/iocage/iocage but meant to be developed among with the library and to spike on new features.
+Libiocage comes bundles with a CLI tool called `ioc`. It is inspired by the command line interface of [iocage](https://github.com/iocage/iocage) but meant to be developed along with the library and to spike on new features.


### PR DESCRIPTION
consistently style headers and codeblocks