### PR TITLE
Fix inconsistencies in fetch and create

### DIFF
--- a/libiocage/cli/stop.py
+++ b/libiocage/cli/stop.py
@@ -60,7 +60,7 @@ def cli(ctx, rc, log_level, force, jails):
             continue
 
         logger.log(f"{jail.name} stopped")
-        change_jails.append(jail)
+        changed_jails.append(jail)
 
     if len(failed_jails) > 0:
         exit(1)

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -390,7 +390,7 @@ class JailGenerator:
 
         backend = None
 
-        is_basejail = self.config["basjail"] == True
+        is_basejail = self.config.get("basejail", False)
         if not is_basejail:
             backend = libiocage.lib.StandaloneJailStorage.StandaloneJailStorage
         if is_basejail and self.config["basejail_type"] == "nullfs":

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -350,6 +350,9 @@ class JailGenerator:
                 The jail is created from the release matching the name provided
         """
 
+        if self.config["id"] is None:
+            self.config["name"] = str(uuid.uuid4())
+
         self.require_jail_not_existing()
 
         # check if release exists
@@ -372,9 +375,6 @@ class JailGenerator:
 
         release = filteres_released[0]
         self.config["release"] = release.name
-
-        if not self.config["id"]:
-            self.config["name"] = str(uuid.uuid4())
 
         self.logger.verbose(
             f"Creating jail '{self.config['id']}'",

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -390,7 +390,7 @@ class JailGenerator:
 
         backend = None
 
-        is_basejail = self.config["type"] == "basejail"
+        is_basejail = self.config["basjail"] == True
         if not is_basejail:
             backend = libiocage.lib.StandaloneJailStorage.StandaloneJailStorage
         if is_basejail and self.config["basejail_type"] == "nullfs":
@@ -866,7 +866,7 @@ class JailGenerator:
             return f"{self.host.datasets.root.name}/jails/{self.config['id']}"
 
     @dataset_name.setter
-    def dataset_name(self, value=None):
+    def dataset_name(self, value: str):
         self._dataset_name = value
 
     @property

--- a/libiocage/lib/JailConfig.py
+++ b/libiocage/lib/JailConfig.py
@@ -523,8 +523,9 @@ class JailConfig(dict, object):
 
         # data with mappings
         try:
-            return self.__getattribute__(f"_get_{key}")()
-        except:
+            get_method = self.__getattribute__(f"_get_{key}")
+            return get_method()
+        except AttributeError:
             pass
 
         # plain data attribute

--- a/libiocage/lib/JailConfigDefaults.py
+++ b/libiocage/lib/JailConfigDefaults.py
@@ -31,6 +31,7 @@ class JailConfigDefaults(dict):
 
     DEFAULTS = {
         "id": None,
+        "release": None,
         "boot": False,
         "legacy": False,
         "priority": 0,

--- a/libiocage/lib/JailConfigLegacy.py
+++ b/libiocage/lib/JailConfigLegacy.py
@@ -45,7 +45,6 @@ class JailConfigLegacy:
                     data["basejail"] = "on"
                     data["clonejail"] = "off"
                     data["basejail_type"] = "zfs"
-                    data["type"] = "jail"
             except:
                 pass
 

--- a/libiocage/lib/Logger.py
+++ b/libiocage/lib/Logger.py
@@ -193,7 +193,10 @@ class Logger:
             "\r",
             f"\033[{delta}F",  # CPL - Cursor Previous Line
             "\r",               # CR - Carriage Return
-            self._indent(f"{log_entry.message}: {delta}"),
+            self._indent(
+                f"{log_entry.message}: {delta}",
+                log_entry.indent
+            ),
             "\033[K",           # EL - Erase in Line
             "\n" * (delta),
             "\r"


### PR DESCRIPTION
This patchset is the product of a debugging session with @gronke, in
which we fixed the fetching (and extraction!) of releases.

Speeding it up by orders of magnitude, by using rsync. It does a much
better job of preserving hardlinks, rather than duplicating the same
file 140 times.

We've also fixed the handling of the release - it can now be None, which
will eventually allow us to create EMPTY jails.

On the other end, Jail.create() now will never create a jail named None.