### PR TITLE
Python tracing for better performance

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -33,5 +33,32 @@ import click
 
 from libiocage.cli import cli
 
+
+def main_safe():
+  try:
+    main()
+  except BaseException as e:
+    return e
+
+
+def main():
+  cli(prog_name="iocage")
+
+
 if __name__ == "__main__":
-    cli(prog_name="iocage")
+
+  debug = False
+
+  try:
+    coverdir = os.environ["IOCAGE_TRACE"]
+    import trace
+    tracer = trace.Trace(
+      ignoredirs=[sys.prefix, sys.exec_prefix],
+      trace=0,
+      count=1)
+    tracer.run("main_safe()")
+    r = tracer.results()
+    r.write_results(show_missing=True, coverdir=coverdir)
+    print(f"Iocage Trace written to: {coverdir}")
+  except:
+    main()

--- a/__main__.py
+++ b/__main__.py
@@ -46,11 +46,10 @@ def main():
 
 
 if __name__ == "__main__":
-
-  debug = False
-
-  try:
-    coverdir = os.environ["IOCAGE_TRACE"]
+  coverdir = os.environ.get("IOCAGE_TRACE", None)
+  if coverdir is None:
+    main()
+  else:
     import trace
     tracer = trace.Trace(
       ignoredirs=[sys.prefix, sys.exec_prefix],
@@ -60,5 +59,3 @@ if __name__ == "__main__":
     r = tracer.results()
     r.write_results(show_missing=True, coverdir=coverdir)
     print(f"Iocage Trace written to: {coverdir}")
-  except:
-    main()


### PR DESCRIPTION
The environment variable `IOCAGE_TRACE` can point to a directory where iocage will store simple trace logs counting the number of function calls.

```sh
setenv IOCAGE_TRACE=/tmp/iocage-trace
python3.6 . list
cat /tmp/iocage-trace/*
```

Looking at this traces will improve our performance in the long run 🏅 