### PR TITLE
Feature: Hook script environment variables

### DIFF
--- a/libiocage/__init__.py
+++ b/libiocage/__init__.py
@@ -21,11 +21,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import libiocage.lib
-# from libiocage.lib import errors, events
-# from libiocage.lib.Host import Host
-# from libiocage.lib.Jail import Jail
-# from libiocage.lib.Jails import Jails
-# from libiocage.lib.Logger import Logger
-# from libiocage.lib.Release import Release
-# from libiocage.lib.Releases import Releases
+from libiocage.lib import errors, events
+from libiocage.lib.Host import Host
+from libiocage.lib.Jail import Jail
+from libiocage.lib.Jails import Jails
+from libiocage.lib.Logger import Logger
+from libiocage.lib.Release import Release
+from libiocage.lib.Releases import Releases

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -1023,6 +1023,8 @@ class JailGenerator(JailResource):
             prop_name = f"IOCAGE_{prop.upper()}"
             jail_env[prop_name] = self.getstring(prop)
 
+        jail_env["IOCAGE_JAIL_PATH"] = self.root_dataset.mountpoint
+
         return jail_env
 
     @property

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -1020,7 +1020,8 @@ class JailGenerator(JailResource):
         jail_env = os.environ.copy()
 
         for prop in self.config.all_properties:
-            jail_env[prop] = self.getstring(prop)
+            prop_name = f"IOCAGE_{prop.upper()}"
+            jail_env[prop_name] = self.getstring(prop)
 
         return jail_env
 

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -25,6 +25,7 @@ import typing
 import os
 import subprocess
 import uuid
+import shlex
 
 import libiocage.lib.DevfsRules
 import libiocage.lib.Host
@@ -329,8 +330,12 @@ class JailGenerator(JailResource):
             f"Running {hook_name} hook for {self.humanreadable_name}"
         )
 
+        lex = shlex.shlex(value)
+        lex.whitespace_split = True
+        command = list(lex)  # type: ignore
+
         return libiocage.lib.helpers.exec(
-            value.split(" "),
+            command,
             logger=self.logger,
             env=self.env
         )

--- a/libiocage/lib/helpers.py
+++ b/libiocage/lib/helpers.py
@@ -97,7 +97,7 @@ def init_logger(
             return new_logger
 
 
-def exec(command, logger=None, ignore_error=False):
+def exec(command, logger=None, ignore_error=False, **subprocess_args):
     if isinstance(command, str):
         command = [command]
 
@@ -106,11 +106,13 @@ def exec(command, logger=None, ignore_error=False):
     if logger:
         logger.log(f"Executing: {command_str}", level="spam")
 
+    subprocess_args["stdout"] = subprocess_args.get("stdout", subprocess.PIPE)
+    subprocess_args["stderr"] = subprocess_args.get("stderr", subprocess.PIPE)
+
     child = subprocess.Popen(
         command,
         shell=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        **subprocess_args
     )
 
     stdout, stderr = child.communicate()


### PR DESCRIPTION
closes #70 

All Jail configuration properties (including defaults if not overridden) are passed as environment variables to the `exec_prestart`, `exec_start`, `exec_poststart` and `exec_prestop` commands.

### Sample of iocage environment variables

```
IOCAGE_DEVFS_RULESET=4
IOCAGE_ALLOW_MOUNT_TMPFS=0
IOCAGE_MOUNT_DEVFS=1
IOCAGE_ALLOW_SOCKET_AF=0
IOCAGE_EXEC_START=/bin/sh /etc/rc
IOCAGE_CHILDREN_MAX=0
IOCAGE_EXEC_STOP=/bin/sh /etc/rc.shutdown
IOCAGE_RESOLVER=/etc/resolv.conf
IOCAGE_EXEC_POSTSTART=/tmp/foo.sh
IOCAGE_ALLOW_MOUNT_ZFS=0
IOCAGE_EXEC_TIMEOUT=60
IOCAGE_CLONEJAIL=yes
IOCAGE_EXEC_PRESTART=/usr/bin/true
IOCAGE_DEFAULTROUTER6=-
IOCAGE_ID=foo2
IOCAGE_EXEC_CLEAN=1
IOCAGE_JAIL_ZFS=no
IOCAGE_ALLOW_CHFLAGS=0
IOCAGE_EXEC_FIB=1
IOCAGE_ENFORCE_STATFS=2
IOCAGE_VNET=no
IOCAGE_DEFAULTROUTER=-
IOCAGE_ALLOW_MOUNT_DEVFS=0
IOCAGE_MOUNT_FDESCFS=1
IOCAGE_NAME=foo2
IOCAGE_IP4=new
IOCAGE_BASEJAIL=yes
IOCAGE_IP4_SADDRSEL=1
IOCAGE_HOST_DOMAINNAME=None
IOCAGE_SYSVMSG=new
IOCAGE_IP6=new
IOCAGE_SYSVSEM=new
IOCAGE_SECURELEVEL=2
IOCAGE_PRIORITY=0
IOCAGE_ALLOW_MOUNT_NULLFS=0
IOCAGE_EXEC_POSTSTOP=/usr/bin/true
IOCAGE_EXEC_PRESTOP=/usr/bin/true
IOCAGE_SYSVSHM=new
IOCAGE_ALLOW_MOUNT_PROCFS=0
IOCAGE_TAGS=-
IOCAGE_IP6_SADDRSEL=1
IOCAGE_ALLOW_SYSVIPC=0
IOCAGE_ALLOW_MOUNT=0
IOCAGE_RELEASE=11.1-RELEASE
IOCAGE_ALLOW_RAW_SOCKETS=0
IOCAGE_MAC_PREFIX=02ff60
IOCAGE_ALLOW_QUOTAS=0
IOCAGE_JAIL_PATH=/iocage/jails/foo2/root
IOCAGE_LEGACY=None
IOCAGE_BOOT=no
IOCAGE_ALLOW_SET_HOSTNAME=1
IOCAGE_STOP_TIMEOUT=30
```