### PR TITLE
Feature: Tags

### DIFF
--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -119,31 +119,13 @@ class JailResource(libiocage.lib.LaunchableResource.LaunchableResource):
     def dataset_name(self, value: str):
         self._dataset_name = value
 
-    def get(self, key):
+    def get(self, key: str) -> typing.Any:
         try:
             return self.jail.config[key]
-        except:
+        except KeyError:
             pass
 
-        try:
-            return self.resource.get(key)
-        except:
-            pass
-
-        return None
-
-    def getstring(self, key):
-        """
-        Returns a jail properties string or '-'
-
-        Args:
-            key (string):
-                Name of the jail property to return
-        """
-        return libiocage.lib.helpers.to_string(
-            self.get(key),
-            none="-"
-        )
+        return libiocage.lib.Resource.Resource.get(self, key)
 
 
 class JailGenerator(JailResource):

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -119,6 +119,19 @@ class JailResource(libiocage.lib.LaunchableResource.LaunchableResource):
     def dataset_name(self, value: str):
         self._dataset_name = value
 
+    def get(self, key):
+        try:
+            return self.jail.config[key]
+        except:
+            pass
+
+        try:
+            return self.resource.get(key)
+        except:
+            pass
+
+        return None
+
     def getstring(self, key):
         """
         Returns a jail properties string or '-'
@@ -127,13 +140,10 @@ class JailResource(libiocage.lib.LaunchableResource.LaunchableResource):
             key (string):
                 Name of the jail property to return
         """
-
-        try:
-            return libiocage.lib.helpers.to_string(self.jail.config[key])
-        except:
-            pass
-
-        return libiocage.lib.Resource.Resource.getstring(self, key)
+        return libiocage.lib.helpers.to_string(
+            self.get(key),
+            none="-"
+        )
 
 
 class JailGenerator(JailResource):

--- a/libiocage/lib/JailConfig.py
+++ b/libiocage/lib/JailConfig.py
@@ -244,7 +244,7 @@ class JailConfig(dict, object):
         except KeyError:
             return None
 
-    def _set_tag(self, value: str, **kwargs):
+    def _set_tag(self, value: str, **kwargs) -> None:
 
         if (self._has_legacy_tag is True) or ("tags" not in self.data.keys()):
             # store as deprecated `tag` for downwards compatibility
@@ -261,7 +261,7 @@ class JailConfig(dict, object):
         self.data["tags"] = libiocage.lib.helpers.to_string(tags)
 
     @property
-    def _has_legacy_tag(self):
+    def _has_legacy_tag(self) -> bool:
         return "tag" in self.data.keys()
 
     def _get_tags(self) -> typing.List[str]:

--- a/libiocage/lib/Resource.py
+++ b/libiocage/lib/Resource.py
@@ -264,6 +264,12 @@ class Resource:
         handler = object.__getattribute__(self, f"config_{self.config_type}")
         return handler
 
+    def get(self, key):
+        try:
+            return self.__getattribute__(key)
+        except AttributeError:
+            return None
+
     def getstring(self, key):
         """
         Returns the resource propertiey string or '-'
@@ -272,10 +278,10 @@ class Resource:
             key (string):
                 Name of the jail property to return
         """
-        try:
-            return libiocage.lib.helpers.to_string(self.__getattribute__(key))
-        except AttributeError:
-            return "-"
+        return libiocage.lib.helpers.to_string(
+            self.get(key),
+            none="-"
+        )
 
 
 class DefaultResource(Resource):

--- a/libiocage/lib/Resource.py
+++ b/libiocage/lib/Resource.py
@@ -26,6 +26,7 @@ import os.path
 
 import libzfs
 
+import libiocage.lib.Config
 import libiocage.lib.ConfigJSON
 import libiocage.lib.ConfigUCL
 import libiocage.lib.ConfigZFS
@@ -259,18 +260,17 @@ class Resource:
         return self.config_handler.read()
 
     @property
-    def config_handler(self):
-
+    def config_handler(self) -> libiocage.lib.Config.ConfigFile:
         handler = object.__getattribute__(self, f"config_{self.config_type}")
         return handler
 
-    def get(self, key):
+    def get(self, key: str) -> typing.Any:
         try:
             return self.__getattribute__(key)
         except AttributeError:
             return None
 
-    def getstring(self, key):
+    def getstring(self, key: str) -> str:
         """
         Returns the resource propertiey string or '-'
 


### PR DESCRIPTION
closes #75 

## Requirements (copy)
- [x] a jail can have one or more tags
- [x] a jails tags can be shown in list command output
- [x] jail filters can match individual tags
- [x] jail config property `tags` can be set from a comma separated string
- [x] jail config property `tags` can be set from a list of strings 
- When no user defined `tags` property was found in a jail's configuration
  - [x] setting a `tag` JailConfig item sets the deprecated `tag` property
  - [x] setting `tags` removed any existing `tag` property from the configuration
- When user defined `tags` are already existing
  - [x] setting a `tag` that already exists in `tags` makes it the first item in `tags` 
  - [x] setting a `tag` that does not exist in `tags` yet, adds it as first item