### PR TITLE
Strict optional

### DIFF
--- a/libiocage/lib/Config/ConfigFile.py
+++ b/libiocage/lib/Config/ConfigFile.py
@@ -29,11 +29,11 @@ import libiocage.lib.Config.Prototype
 
 class ConfigFile(libiocage.lib.Config.Prototype.Prototype):
 
-    _file: str = None
+    _file: str
 
     def __init__(
         self,
-        file: str=None,
+        file: str,
         logger: 'libiocage.lib.Logger.Logger'=None
     ) -> None:
 

--- a/libiocage/lib/Config/Dataset.py
+++ b/libiocage/lib/Config/Dataset.py
@@ -31,7 +31,7 @@ class DatasetConfig(libiocage.lib.Config.ConfigFile.ConfigFile):
 
     def __init__(
         self,
-        dataset: libzfs.ZFSDataset = None,
+        dataset: libzfs.ZFSDataset,
         **kwargs
     ) -> None:
 

--- a/libiocage/lib/Config/Jail/JailConfig.py
+++ b/libiocage/lib/Config/Jail/JailConfig.py
@@ -36,10 +36,11 @@ class JailConfig(libiocage.lib.Config.Jail.BaseConfig.BaseConfig):
 
     legacy: bool = None
     jail: 'libiocage.lib.Jail.JailGenerator' = None
+    data: dict = {}
 
     def __init__(
         self,
-        data: dict={},
+        data: dict=None,
         jail: 'libiocage.lib.Jail.JailGenerator'=None,
         new: bool=False,
         logger: 'libiocage.lib.Logger.Logger'=None,

--- a/libiocage/lib/Config/Jail/Properties/Addresses.py
+++ b/libiocage/lib/Config/Jail/Properties/Addresses.py
@@ -22,6 +22,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
+
 import libiocage.lib.errors
 import libiocage.lib.helpers
 
@@ -30,7 +31,7 @@ _ConfigType = 'libiocage.lib.Config.JailConfig.JailConfig'
 
 class AddressSet(set):
 
-    config: 'libiocage.lib.Config.JailConfig.JailConfig'  # type: ignore
+    config: 'libiocage.lib.Config.Jail.JailConfig.JailConfig'
 
     def __init__(
         self,
@@ -62,13 +63,13 @@ _AddressSetInputType = typing.Union[str, typing.Dict[str, AddressSet]]
 class AddressesProp(dict):
 
     logger: 'libiocage.lib.Logger.Logger'
-    config: 'libiocage.lib.Config.JailConfig.JailConfig'  # type: ignore
+    config: 'libiocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str = "ip4_address"
     skip_on_error: bool
 
     def __init__(
         self,
-        config=None,  # type: ignore
+        config: 'libiocage.lib.Config.Jail.JailConfig.JailConfig'=None,
         property_name: str="ip4_address",
         logger: 'libiocage.lib.Logger.Logger'=None,
         skip_on_error: bool=False

--- a/libiocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/libiocage/lib/Config/Jail/Properties/Interfaces.py
@@ -53,7 +53,7 @@ class BridgeSet(set):
 
 class InterfaceProp(dict):
 
-    config: _ConfigType  # type: ignore
+    config: 'libiocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str = "interfaces"
 
     def __init__(

--- a/libiocage/lib/Config/Jail/Properties/Resolver.py
+++ b/libiocage/lib/Config/Jail/Properties/Resolver.py
@@ -25,11 +25,12 @@ import shutil
 
 import libiocage.lib.helpers
 import libiocage.lib.Config.Jail
+import libiocage.lib.Config.Jail.JailConfig
 
 
 class ResolverProp(list):
 
-    config: 'libiocage.lib.Config.Jail.JailConfig.JailConfig'  # type: ignore
+    config: libiocage.lib.Config.Jail.JailConfig.JailConfig
     property_name: str = "resolver"
 
     def __init__(

--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -63,7 +63,7 @@ class HostGenerator:
             host=self,
             logger=self.logger
         )
-        self._defaults = defaults
+        self._defaults = defaults if defaults is not None else {}
 
     @property
     def defaults(self) -> 'libiocage.lib.Resource.DefaultResource':

--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -40,8 +40,8 @@ class HostGenerator:
 
     _class_distribution = libiocage.lib.Distribution.DistributionGenerator
 
-    _devfs: 'libiocage.lib.DevfsRules.DevfsRules' = None
-    releases_dataset: libzfs.ZFSDataset = None
+    _devfs: 'libiocage.lib.DevfsRules.DevfsRules'
+    releases_dataset: libzfs.ZFSDataset
 
     def __init__(
         self,

--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -63,12 +63,17 @@ class HostGenerator:
             host=self,
             logger=self.logger
         )
-        self._defaults = defaults if defaults is not None else {}
+        self._defaults = defaults if defaults is not None \
+            else libiocage.lib.Resource.DefaultResource(
+                    dataset=self.datasets.root,
+                    logger=self.logger,
+                    zfs=self.zfs
+            )
 
     @property
     def defaults(self) -> 'libiocage.lib.Resource.DefaultResource':
         if self._defaults is None:
-            self._load_defaults()
+            self._defaults = self._load_defaults()
         return self._defaults
 
     @property
@@ -77,14 +82,14 @@ class HostGenerator:
     ) -> 'libiocage.lib.Config.Jail.BaseConfig.BaseConfig':
         return self.defaults.config
 
-    def _load_defaults(self) -> None:
+    def _load_defaults(self) -> 'libiocage.lib.Resource.DefaultResource':
         defaults_resource = libiocage.lib.Resource.DefaultResource(
             dataset=self.datasets.root,
             logger=self.logger,
             zfs=self.zfs
         )
         defaults_resource.config.read(data=defaults_resource.read_config())
-        self._defaults = defaults_resource
+        return defaults_resource
 
     @property
     def devfs(self) -> 'libiocage.lib.DevfsRules.DevfsRules':

--- a/libiocage/lib/Release.py
+++ b/libiocage/lib/Release.py
@@ -38,6 +38,7 @@ import libiocage.lib.ZFS
 import libiocage.lib.errors
 import libiocage.lib.helpers
 import libiocage.lib.events
+import libiocage.lib.Resource
 import libiocage.lib.LaunchableResource
 import libiocage.lib.Jail
 

--- a/libiocage/lib/Resource.py
+++ b/libiocage/lib/Resource.py
@@ -81,10 +81,10 @@ class Resource:
     DEFAULT_JSON_FILE = "config.json"
     DEFAULT_UCL_FILE = "config"
 
-    _dataset_name: str = None
-    _config_type: int = None
-    _config_file: str = None
-    _dataset: libzfs.ZFSDataset = None
+    _dataset_name: typing.Optional[str] = None
+    _config_type: typing.Optional[int] = None
+    _config_file: typing.Optional[str] = None
+    _dataset: typing.Optional[libzfs.ZFSDataset] = None
 
     def __init__(
         self,
@@ -141,8 +141,9 @@ class Resource:
         """
         if self._dataset_name is not None:
             return self._dataset_name
-        else:
+        elif self._dataset is not None:
             return self._dataset.name
+        raise
 
     @property
     def dataset_name(self) -> str:
@@ -179,7 +180,7 @@ class Resource:
     #     return self.dataset.mountpoint
 
     @property
-    def config_type(self) -> str:
+    def config_type(self) -> typing.Optional[int]:
         if self._config_type is None:
             return None
         elif self._config_type == self.CONFIG_TYPES.index("auto"):
@@ -187,7 +188,7 @@ class Resource:
         return self.CONFIG_TYPES[self._config_type]
 
     @config_type.setter
-    def config_type(self, value: str):
+    def config_type(self, value: typing.Optional[int]):
         if value is None:
             self._config_type = None
         else:

--- a/libiocage/lib/ZFS.py
+++ b/libiocage/lib/ZFS.py
@@ -1,22 +1,15 @@
 import libzfs
 
-import libiocage.lib.Logger
-import libiocage.lib.helpers
-
 
 def get_zfs(
-    logger: 'libiocage.lib.Logger.Logger'=None,
     history: bool=True,
     history_prefix: str="<iocage>"
 ):
     zfs = ZFS(history=history, history_prefix=history_prefix)
-    zfs.logger = libiocage.lib.helpers.init_logger(zfs, logger)
     return zfs
 
 
 class ZFS(libzfs.ZFS):
-
-    logger: libiocage.lib.Logger.Logger = None
 
     def create_dataset(
         self,

--- a/libiocage/lib/ZFS.py
+++ b/libiocage/lib/ZFS.py
@@ -42,4 +42,4 @@ class ZFS(libzfs.ZFS):
         for pool in self.pools:
             if pool.name == pool_name:
                 return pool
-        return None
+        raise

--- a/libiocage/lib/helpers.py
+++ b/libiocage/lib/helpers.py
@@ -164,7 +164,7 @@ def validate_name(name: str) -> bool:
     return bool(_validate_name.fullmatch(name))
 
 
-def parse_none(data) -> str:
+def parse_none(data: typing.Any) -> None:
     if data is None:
         return None
 

--- a/libiocage/lib/helpers.py
+++ b/libiocage/lib/helpers.py
@@ -46,7 +46,7 @@ def init_zfs(
     if (zfs is not None) and isinstance(zfs, libiocage.lib.ZFS.ZFS):
         object.__setattr__(self, 'zfs', zfs)
     else:
-        new_zfs = libiocage.lib.ZFS.get_zfs(logger=self.logger)
+        new_zfs = libiocage.lib.ZFS.get_zfs()
         object.__setattr__(self, 'zfs', new_zfs)
 
     try:

--- a/libiocage/lib/helpers.py
+++ b/libiocage/lib/helpers.py
@@ -45,16 +45,14 @@ def init_zfs(
 
     if (zfs is not None) and isinstance(zfs, libiocage.lib.ZFS.ZFS):
         object.__setattr__(self, 'zfs', zfs)
-        return zfs
+    else:
+        new_zfs = libiocage.lib.ZFS.get_zfs(logger=self.logger)
+        object.__setattr__(self, 'zfs', new_zfs)
 
     try:
         return self.zfs
     except AttributeError:
-        pass
-
-    zfs = libiocage.lib.ZFS.get_zfs(logger=self.logger)
-    object.__setattr__(self, 'zfs', zfs)
-    return zfs
+        raise
 
 
 def init_host(


### PR DESCRIPTION
This PR is an attempt to correct type warnings issued by `mypy --strict-optional`
This catches a lot more issues where a variable was previously assigned `None`, or a return type should be `Optional`

Some of the following code is questionable and needs discussion & review.