### PR TITLE
Allow to bootstrap libiocage with `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 ZPOOL=""
 SERVER=""
+SVN_REL_URL=https://svn.freebsd.org/base/releng/11.1
 
 install:
 	python3.6 -m ensurepip
-	pkg install -q -y libgit2 libucl cython3
-	pip3.6 install -U .
+	pkg install -q -y libgit2 libucl cython3 rsync
+	( cd /usr/src && svnlite checkout $(SVN_REL_URL)/cddl/ && \
+		mkdir -p sys && cd sys && svnlite checkout $(SVN_REL_URL)/sys/cddl )
+	pip3.6 install -Ur requirements.txt # properly install libzfs
+	pip3.6 install -e . # install libiocage from source / for testing.
 uninstall:
 	pip3.6 uninstall -y libiocage
 test:


### PR DESCRIPTION
This should be all that it now takes to get rolling with libiocage