### PR TITLE
Securely create jails

### DIFF
--- a/libiocage/lib/Resource.py
+++ b/libiocage/lib/Resource.py
@@ -235,6 +235,7 @@ class Resource:
         Creates the dataset
         """
         self.dataset = self.zfs.create_dataset(self.dataset_name)
+        os.chmod(self.dataset.mountpoint, 0o700)
 
     def get_dataset(self, name: str) -> libzfs.ZFSDataset:
         dataset_name = f"{self.dataset_name}/{name}"


### PR DESCRIPTION
closes #57

- create jails resource with 0700 directory mode
- existing jails are not modified

Attackers with access to a jail and an account on the host system could use their root account in the jail to set the SUID bit on an executable and elevate permissions on the host.