### PR TITLE
Fix: jail start stop without jail selector affects all jails

### DIFF
--- a/libiocage/cli/start.py
+++ b/libiocage/cli/start.py
@@ -47,7 +47,11 @@ def cli(ctx, rc, jails):
         "print_function": ctx.parent.print_events
     }
 
-    if rc is True:
+    if len(jails) == 0:
+        logger.error("No jail selector provided")
+        exit(1)
+
+    elif rc is True:
         if len(jails) > 0:
             logger.error("Cannot use --rc and jail selectors simultaniously")
             exit(1)

--- a/libiocage/cli/stop.py
+++ b/libiocage/cli/stop.py
@@ -46,6 +46,11 @@ def cli(ctx, rc, log_level, force, jails):
     location to stop_jail.
     """
     logger = ctx.parent.logger
+
+    if len(jails) == 0:
+        logger.error("No jail selector provided")
+        exit(1)
+
     ioc_jails = libiocage.lib.Jails.JailsGenerator(
         logger=logger,
         filters=jails


### PR DESCRIPTION
The CLI commands start and stop now exit with an error when no jail filter was provided by the user. The previous implementation did not set any filter and thus matched all jails on the host, which is unexpected behavior.