### PR TITLE
install libzfs from pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,8 @@ ZPOOL=""
 SERVER=""
 SVN_REL_URL=https://svn.freebsd.org/base/releng/11.1
 
-/usr/src/cddl:
-	( cd /usr/src && svnlite checkout $(SVN_REL_URL)/cddl/ )
-/usr/src/sys/cddl:
-	( mkdir -p /usr/src/sys && cd /usr/src/sys && \
-		svnlite checkout $(SVN_REL_URL)/sys/cddl/ )
 install: /usr/src/cddl /usr/src/sys/cddl
-	pkg install -q -y libgit2 libucl cython3 rsync python36
+	pkg install -q -y libgit2 libucl cython3 rsync python36 py36-libzfs
 	python3.6 -m ensurepip
 	pip3.6 install -Ur requirements.txt # properly install libzfs
 	pip3.6 install -e . # install libiocage from source / for testing.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+git+https://github.com/freenas/py-libzfs.git#egg=libzfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ verboselogs==1.6
 pygit2==0.25.1
 cffi==1.9.1
 ucl
-git+https://github.com/freenas/py-libzfs.git#egg=libzfs


### PR DESCRIPTION
By installing py-libzfs from a FreeBSD/HardenedBSD package using pkg we no longer require to build Cython and to propagate parts of /usr/src.

@igalic we should give your solution to to partially download /usr/src upstream to py-libzfs 👍 