### PR TITLE
Warn about releases newer than the host

### DIFF
--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -100,18 +100,19 @@ class HostGenerator:
         return self._devfs
 
     @property
-    def userland_version(self):
+    def userland_version(self) -> float:
         return float(self.release_version.partition("-")[0])
 
     @property
-    def release_minor_version(self):
+    def release_minor_version(self) -> int:
         release_version_string = os.uname()[2]
         release_version_fragments = release_version_string.split("-")
 
+        print(release_version_fragments)
         if len(release_version_fragments) < 3:
             return 0
 
-        return int(release_version_fragments[2])
+        return int(release_version_fragments[2].strip("p"))
 
     @property
     def release_version(self):
@@ -122,7 +123,7 @@ class HostGenerator:
             return "-".join(release_version_fragments[0:2])
 
     @property
-    def processor(self):
+    def processor(self) -> str:
         return platform.processor()
 
 

--- a/libiocage/lib/Release.py
+++ b/libiocage/lib/Release.py
@@ -235,6 +235,9 @@ class ReleaseGenerator(ReleaseResource):
         if self.eol is True:
             annotations.add("EOL")
 
+        if self.newer_than_host is True:
+            annotations.add("Newer than Host")
+
         if len(annotations) > 0:
             return f"{self.name} ({', ('.join(annotations)})"
 
@@ -281,6 +284,19 @@ class ReleaseGenerator(ReleaseResource):
                 return False
 
         return True
+
+    @property
+    def newer_than_host(self):
+        host_release_name = self._pad_release_name(self.host.release_version)
+        release_name = self._pad_release_name(self.name)
+        return (host_release_name < release_name)
+
+    def _pad_release_name(self, release_name: str, digits: int=4) -> str:
+        """
+        pads releases with 0 until it has 4 characters before the first .
+        """
+        padding = str("0" * (digits - release_name.index(".")))
+        return padding + release_name
 
     @property
     def zfs_pool(self) -> libzfs.ZFSPool:


### PR DESCRIPTION
A warning message is printed when fetching releases that are newer than the host's release.

#### On a host running 11.0-RELEASE
```
# python3.6 . fetch
[0] 10.1-RELEASE (EOL)
[1] 10.2-RELEASE (EOL)
[2] 10.3-RELEASE
[3] 10.4-RC1
[4] 11.0-RELEASE
[5] 11.1-RELEASE (Newer than Host)
[6] 9.3-RELEASE (EOL)
```