### PR TITLE
Fix Resolver and Resource Limits

### DIFF
--- a/libiocage/lib/Config/Jail/Properties/Resolver.py
+++ b/libiocage/lib/Config/Jail/Properties/Resolver.py
@@ -53,10 +53,13 @@ class ResolverProp(list):
 
     @property
     def method(self):
-        if self.value == "/etc/resolv.conf":
+        return self._get_method(self.value)
+
+    def _get_method(self, value: str) -> str:
+        if value == "/etc/resolv.conf":
             return "copy"
 
-        elif self.value == "/dev/null":
+        elif value == "/dev/null":
             return "skip"
 
         else:
@@ -88,10 +91,10 @@ class ResolverProp(list):
             self.logger.verbose("resolv.conf not touched")
 
     def set(self, value=None, notify=True):
-        value = value if value is not None else self.value
-        self.clear()
 
-        if self.method == "manual":
+        self.clear()
+        method = self._get_method(value)
+        if method == "manual":
             if isinstance(value, str):
                 self += value.split(";")
             elif isinstance(value, list):

--- a/libiocage/lib/Host.py
+++ b/libiocage/lib/Host.py
@@ -108,7 +108,6 @@ class HostGenerator:
         release_version_string = os.uname()[2]
         release_version_fragments = release_version_string.split("-")
 
-        print(release_version_fragments)
         if len(release_version_fragments) < 3:
             return 0
 

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -958,9 +958,7 @@ class JailGenerator(JailResource):
         value: str
     ) -> libiocage.lib.Types.AbsolutePath:
 
-        return libiocage.lib.Types.AbsolutePath(
-            sequence=f"{self.root_path}{value}"
-        )
+        return libiocage.lib.Types.AbsolutePath(f"{self.root_path}{value}")
 
     def _resolve_name(self, text) -> str:
 

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -867,43 +867,48 @@ class JailGenerator(JailResource):
 
         self.exec(command)
 
-    def require_jail_not_existing(self) -> None:
+    def require_jail_not_existing(self, **kwargs) -> None:
         """
         Raise JailAlreadyExists exception if the jail already exists
         """
         if self.exists:
             raise libiocage.lib.errors.JailAlreadyExists(
-                jail=self, logger=self.logger
+                jail=self,
+                logger=self.logger,
+                **kwargs
             )
 
-    def require_jail_existing(self) -> None:
+    def require_jail_existing(self, **kwargs) -> None:
         """
         Raise JailDoesNotExist exception if the jail does not exist
         """
         if not self.exists:
             raise libiocage.lib.errors.JailDoesNotExist(
                 jail=self,
-                logger=self.logger
+                logger=self.logger,
+                **kwargs
             )
 
-    def require_jail_stopped(self) -> None:
+    def require_jail_stopped(self, **kwargs) -> None:
         """
         Raise JailAlreadyRunning exception if the jail is runninhg
         """
         if self.running:
             raise libiocage.lib.errors.JailAlreadyRunning(
                 jail=self,
-                logger=self.logger
+                logger=self.logger,
+                **kwargs
             )
 
-    def require_jail_running(self) -> None:
+    def require_jail_running(self, **kwargs) -> None:
         """
         Raise JailNotRunning exception if the jail is stopped
         """
         if not self.running:
             raise libiocage.lib.errors.JailNotRunning(
                 jail=self,
-                logger=self.logger
+                logger=self.logger,
+                **kwargs
             )
 
     def update_jail_state(self) -> None:

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -810,7 +810,10 @@ class JailGenerator(JailResource):
 
     def _limit_resources(self) -> None:
 
-        for limit, action in map(self._get_resource_limit, self._resource_limit_config_keys):
+        for limit, action in map(
+            self._get_resource_limit,
+            self._resource_limit_config_keys
+        ):
 
             if (limit is None) and (action is None):
                 # this resource is not limited (limit disabled)

--- a/libiocage/lib/Jail.py
+++ b/libiocage/lib/Jail.py
@@ -810,8 +810,8 @@ class JailGenerator(JailResource):
 
     def _limit_resources(self) -> None:
 
-        for limit, action in map(
-            self._get_resource_limit,
+        for key, limit, action in map(
+            lambda name: (name, ) + self._get_resource_limit(name),
             self._resource_limit_config_keys
         ):
 
@@ -856,15 +856,18 @@ class JailGenerator(JailResource):
             "writeiops"
         ]
 
-    def _get_resource_limit(self, key: str) -> libiocage.lib.Types.UserInput:
+    def _get_resource_limit(self, key: str) -> typing.Tuple[str, str]:
         try:
-            return self._parse_resource_limit(self.config[key])
+            if isinstance(self.config[key], str):
+                return self._parse_resource_limit(self.config[key])
         except:
-            return None, None
+            pass
+
+        return None, None
 
     def _parse_resource_limit(
         self,
-        value: libiocage.lib.Types.UserInput
+        value: str
     ) -> typing.Tuple[str, str]:
 
         limit, action = value.split(":", maxsplit=1)
@@ -1109,7 +1112,7 @@ class JailGenerator(JailResource):
         """
         return f"{self.host.datasets.logs.mountpoint}-console.log"
 
-    def __getattribute__(self, key):
+    def __getattribute__(self, key: str):
 
         try:
             return object.__getattribute__(self, key)

--- a/libiocage/lib/Network.py
+++ b/libiocage/lib/Network.py
@@ -75,8 +75,7 @@ class Network:
 
     @property
     def nic_local_name(self):
-        self.jail.require_jail_running()
-
+        self.jail.require_jail_running(silent=True)
         return f"{self.nic}:{self.jail.jid}"
 
     @property

--- a/libiocage/lib/Types.py
+++ b/libiocage/lib/Types.py
@@ -36,7 +36,7 @@ class AbsolutePath(str):
     ) -> None:
         if self.unix_path.fullmatch(sequence) is None:
             raise TypeError("Invalid value for AbsolutePath")
-        str.__init__(self, sequence)
+        self = sequence
 
 
 class UserInput:

--- a/libiocage/lib/Types.py
+++ b/libiocage/lib/Types.py
@@ -36,7 +36,7 @@ class AbsolutePath(str):
     ) -> None:
         if self.unix_path.fullmatch(sequence) is None:
             raise TypeError("Invalid value for AbsolutePath")
-        self = sequence
+        self = sequence  # type: ignore
 
 
 class UserInput:

--- a/libiocage/lib/errors.py
+++ b/libiocage/lib/errors.py
@@ -21,6 +21,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import typing
 
 # MyPy
 import libzfs  # noqa: F401
@@ -36,13 +37,14 @@ class IocageException(Exception):
         message: str,
         logger: 'libiocage.lib.Logger.Logger'=None,
         level: str="error",
+        silent: bool=False,
         append_warning: bool=False,
-        warning: bool=None
+        warning: typing.Optional[str]=None
     ) -> None:
 
-        if logger is not None:
+        if (logger is not None) and (silent is False):
             logger.__getattribute__(level)(message)
-            if append_warning is True:
+            if (append_warning is True) and (warning is not None):
                 logger.warn(warning)
         else:
             super().__init__(message)


### PR DESCRIPTION
When no user configured resolver was set or resource limits were disabled, the library failed to start and stop jails on HardenedBSD (and probably FreeBSD).