### PR TITLE
remove dependency on libgit2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ZPOOL=""
 SERVER=""
 
 install:
-	pkg install -q -y libgit2 libucl cython3 rsync python36 py36-libzfs
+	pkg install -q -y libucl cython3 rsync python36 py36-libzfs
 	python3.6 -m ensurepip
 	pip3.6 install -Ur requirements.txt
 	pip3.6 install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ requests==2.17.3
 tqdm==4.14.0
 coloredlogs==7.0
 verboselogs==1.6
-pygit2==0.25.1
 cffi==1.9.1
 ucl


### PR DESCRIPTION
We did never use this library, so it can be removed.