### PR TITLE
fix vnet network teardown on jail stop

### DIFF
--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -69,7 +69,7 @@ class Network:
             # down host_if
             iocage.lib.NetworkInterface.NetworkInterface(
                 name=self.nic_local_name,
-                extra_settings=["down"],
+                extra_settings=["destroy"],
                 logger=self.logger
             )
 


### PR DESCRIPTION
Instead of taking a stopped jails network interface down, it should be destroyed.