### PR TITLE
fix getting jail type

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -412,14 +412,10 @@ class BaseConfig(dict):
             return self.special_properties.get_or_create(key)
 
         # data with mappings
-        get_method = None
-        try:
-            get_method = self.__getattribute__(f"_get_{key}")
+        method_name = f"_get_{key}"
+        if method_name in dict.__dir__(self):   # type: ignore
+            get_method = self.__getattribute__(method_name)
             return get_method()
-        except AttributeError:
-            if get_method is not None:
-                raise
-            pass
 
         # plain data attribute
         if key in self.data.keys():

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -65,6 +65,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "legacy": False,
         "priority": 0,
         "basejail": False,
+        "clonejail": False,
         "defaultrouter": None,
         "defaultrouter6": None,
         "mac_prefix": "02ff60",


### PR DESCRIPTION
fixes #143 

The dynamic jail config property `type` relied on `clonejail` which was removed in previously. We still need it for legacy support.