### PR TITLE
Fix iocage_legacy support on HardenedBSD

### DIFF
--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -109,5 +109,5 @@ def start_jails(jails, logger, print_function):
 
     if len(changed_jails) == 0:
         jails_input = " ".join(list(jails))
-        logger.error(f"No jailes matches your input: {jails_input}")
+        logger.error(f"No jails matched your input: {jails_input}")
         exit(1)

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -73,5 +73,5 @@ def cli(ctx, rc, log_level, force, jails):
 
     if len(changed_jails) == 0:
         jails_input = " ".join(list(jails))
-        logger.error(f"No jailes matches your input: {jails_input}")
+        logger.error(f"No jails matched your input: {jails_input}")
         exit(1)

--- a/iocage/lib/Filter.py
+++ b/iocage/lib/Filter.py
@@ -55,13 +55,17 @@ class Term(list):
 
         list.__init__(self, data)
 
+    @property
+    def short(self) -> bool:
+        return (self.key == "name")
+
     def matches_resource(
         self,
         resource: 'iocage.lib.Resource.Resource'
     ) -> bool:
         value = resource.get(self.key)
 
-        return self.matches(value)
+        return self.matches(value, self.short)
 
     def matches(self, value: Any, short: bool=False) -> bool:
         """
@@ -100,7 +104,7 @@ class Term(list):
                 shortname = iocage.lib.helpers.to_humanreadable_name(
                     input_value
                 )
-                if match_filter(shortname, filter_value):
+                if shortname == filter_value:
                     return True
 
         return False

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -265,6 +265,13 @@ class DistributionUnknown(IocageException):
         super().__init__(msg, *args, **kwargs)
 
 
+class HostReleaseUnknown(IocageException):
+
+    def __init__(self, *args, **kwargs) -> None:
+        msg = f"The host release is unknown"
+        super().__init__(msg, *args, **kwargs)
+
+
 class DistributionEOLWarningDownloadFailed(IocageException):
 
     def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
- UUID shortnames did not match jail datasets
- Release detection possible for default releases (non self-compiled)
