### PR TITLE
init localhost on jail start

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -307,6 +307,7 @@ class JailGenerator(JailResource):
 
         self._limit_resources()
         self._configure_nameserver()
+        self._configure_localhost()
 
         if self.config["jail_zfs"] is True:
             yield JailZfsShareMount.begin()
@@ -841,6 +842,9 @@ class JailGenerator(JailResource):
 
     def _configure_nameserver(self) -> None:
         self.config["resolver"].apply(self)
+
+    def _configure_localhost(self) -> None:
+        self.exec(["ifconfig", "lo0", "localhost"])
 
     def _limit_resources(self) -> None:
 


### PR DESCRIPTION
fixes #150 

- Executes `ifconfig lo0 localhost` on jail start
- Prevents services from falling back to `0.0.0.0` because no localhost was uninitialized