### PR TITLE
Feature: Templates

### DIFF
--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -99,6 +99,12 @@ def cli(ctx, dataset_type, header, _long, remote, plugins,
         resources_class = iocage.lib.Releases.ReleasesGenerator
         columns = ["name"]
     else:
+
+        if dataset_type == "template":
+            filters += ("template=yes",)
+        else:
+            filters += ("template=no",)
+
         resources_class = iocage.lib.Jails.JailsGenerator
         columns = _list_output_comumns(output, _long)
 

--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -95,8 +95,8 @@ def start_jails(jails, logger, print_function):
     failed_jails = []
     for jail in jails:
         try:
+            jail.require_jail_not_template()
             print_function(jail.start())
-
         except iocage.lib.errors.IocageException:
             failed_jails.append(jail)
             continue

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -68,13 +68,14 @@ class BaseConfig(dict):
         'iocage.lib.Config.Jail.'
         'JailConfigProperties.JailConfigProperties'
     )
-    data: dict = {}
+    data: dict
 
     def __init__(
         self,
         logger: 'iocage.lib.Logger.Logger'=None
     ) -> None:
 
+        self.data = {}
         dict.__init__(self)
 
         self.logger = iocage.lib.helpers.init_logger(self, logger)

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -112,6 +112,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "mount_fdescfs": "1",
         "securelevel": "2",
         "tags": [],
+        "template": False,
         "jail_zfs": False
     }
 
@@ -128,6 +129,10 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
     @property
     def data(self) -> DefaultsUserData:
         return self._user_data
+
+    @data.setter
+    def data(self, value: dict):
+        pass
 
     @property
     def user_data(self) -> dict:

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -132,6 +132,20 @@ class JailUnknownIdentifier(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+class JailIsTemplate(IocageException):
+
+    def __init__(self, jail, *args, **kwargs) -> None:
+        msg = f"The jail '{jail.name}' is a template"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
+class JailNotTemplate(IocageException):
+
+    def __init__(self, jail, *args, **kwargs) -> None:
+        msg = f"The jail '{jail.name}' is not a template"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # Security
 
 


### PR DESCRIPTION
implements #14 

- [x] allow to flag jails as template
- [x] `ioc list -t` lists templates
- [x] a template may not be started
- [x] create new jails from template
- [ ] update existing jails from a template *

* requires usage of `rsync --compare-dest` as commented [here](https://github.com/iocage/libiocage/issues/14#issuecomment-334738301)

### Usage
```
ioc create -n mytemplate
ioc start mytemplate
ioc console mytemplate
mytemplate$ # ... install things
mytemplate$ exit
ioc set template=yes mytemplate
ioc list -t
# verify the template is listed
ioc create -b -t mytemplate -n somejail
# done
```