### PR TITLE
fix first time zfs pool activation

### DIFF
--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -157,9 +157,12 @@ class Datasets:
         self,
         pool: libzfs.ZFSPool,
         prop: str
-    ) -> str:
+    ) -> typing.Optional[str]:
 
-        return pool.root_dataset.properties[prop].value
+        if prop in pool.root_dataset.properties:
+            return pool.root_dataset.properties[prop].value
+
+        return None
 
     def _get_dataset_property(
         self,


### PR DESCRIPTION
The function checking if a ZFS pool was activated relied on the existence of the `org.freebsd.ioc:active` property. This fix checks if it exists first and returns None if it does not at all.