### PR TITLE
claim /iocage mountpoint when creating a new iocage dataset

### DIFF
--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -22,6 +22,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
+import os.path
 import libzfs
 
 import iocage.lib.errors
@@ -135,17 +136,17 @@ class Datasets:
 
         self._activate_pool(pool)
 
-        if mountpoint is not None:
-            self._root = self._get_or_create_dataset(
-                "iocage",
-                pool=pool,
-                mountpoint=mountpoint
+        if (mountpoint is None) and (os.path.ismount('/iocage') is False):
+            self.logger.spam(
+                "Claiming /iocage as mountpoint of the activated zpool"
             )
-        else:
-            self._root = self._get_or_create_dataset(
-                "iocage",
-                pool=pool
-            )
+            mountpoint = iocage.lib.Types.AbsolutePath('/iocage')
+
+        self._root = self._get_or_create_dataset(
+            "iocage",
+            pool=pool,
+            mountpoint=mountpoint
+        )
 
     def _is_pool_active(self, pool: libzfs.ZFSPool) -> bool:
         return iocage.lib.helpers.parse_user_input(self._get_pool_property(


### PR DESCRIPTION
closes #126

When no `<ZPOOL>/iocage` dataset exists while activating a new zpool, the preferred mountpoint is `/iocage` instead of the system's default. The value can be changed at a later time (while no jail is running).