### PR TITLE
Enhancement: Call jls command only once for lists of jails

### DIFF
--- a/iocage/cli/activate.py
+++ b/iocage/cli/activate.py
@@ -24,6 +24,7 @@
 """activate module for the cli."""
 import click
 
+import iocage.lib.errors
 import iocage.lib.Datasets
 import iocage.lib.Logger
 import iocage.lib.ZFS
@@ -60,5 +61,5 @@ def cli(ctx, zpool, mountpoint):
         )
         datasets.activate(mountpoint=mountpoint)
         logger.log(f"ZFS pool '{zpool}' activated")
-    except:
+    except iocage.lib.errors.IocageException:
         exit(1)

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -24,6 +24,7 @@
 """create module for the cli."""
 import click
 
+import iocage.lib.errors
 import iocage.lib.Host
 import iocage.lib.Jail
 import iocage.lib.Logger
@@ -170,8 +171,7 @@ def cli(ctx, release, template, count, props, pkglist, basejail, basejail_type,
                 f" from {resource.name}!{suffix}"
             )
             logger.log(msg)
-        except:
-            raise
+        except iocage.lib.errors.IocageException:
             msg = f"{jail.humanreadable_name} could not be created!{suffix}"
             logger.warn(msg)
 

--- a/iocage/cli/destroy.py
+++ b/iocage/cli/destroy.py
@@ -25,6 +25,7 @@
 import click
 import typing
 
+import iocage.lib.errors
 import iocage.lib.Filter
 import iocage.lib.Jail
 import iocage.lib.Jails
@@ -94,7 +95,7 @@ def cli(ctx,
         if isinstance(item, iocage.lib.Jail.JailGenerator):
             try:
                 item.require_jail_stopped()
-            except:
+            except iocage.lib.errors.IocageException:
                 logger.log(
                     f"Jail '{item.name}' must be stopped before destruction"
                 )

--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -82,7 +82,7 @@ def cli(ctx, **kwargs):
                 host=host,
                 logger=logger
             )
-        except:
+        except Exception:
             logger.error(f"Invalid Release '{release_input}'")
             exit(1)
 

--- a/iocage/cli/set.py
+++ b/iocage/cli/set.py
@@ -25,6 +25,7 @@
 import typing
 import click
 
+import iocage.lib.errors
 import iocage.lib.Logger
 import iocage.lib.helpers
 import iocage.lib.Resource
@@ -111,8 +112,7 @@ def set_properties(
             try:
                 del target.config[key]
                 updated_properties.add(key)
-            except:
-                raise
+            except iocage.lib.errors.IocageException:
                 pass
 
     if len(updated_properties) > 0:

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -183,7 +183,7 @@ class BaseConfig(dict):
         else:
             try:
                 self.data["id"] = str(uuid.UUID(name))  # legacy support
-            except:
+            except ValueError:
                 raise iocage.lib.errors.InvalidJailName(logger=self.logger)
 
     def _get_name(self) -> str:
@@ -364,7 +364,7 @@ class BaseConfig(dict):
     def _get_cloned_release(self) -> typing.Optional[str]:
         try:
             return str(self.data["cloned_release"])
-        except:
+        except KeyError:
             release = self["release"]
             if isinstance(release, str):
                 return str(self["release"])

--- a/iocage/lib/Config/Jail/File/RCConf.py
+++ b/iocage/lib/Config/Jail/File/RCConf.py
@@ -108,7 +108,7 @@ class RCConf(
                 data = self._read(silent=silent)
             else:
                 data = {}
-        except:
+        except (FileNotFoundError, ValueError):
             data = {}
 
         existing_keys = set(self.keys())

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -113,7 +113,7 @@ class InterfaceProp(dict):
 
         try:
             prop = dict.__getitem__(self, jail_if)
-        except:
+        except KeyError:
             prop = self.__empty_prop(jail_if)
 
         for bridge_if in bridges:

--- a/iocage/lib/Config/Prototype.py
+++ b/iocage/lib/Config/Prototype.py
@@ -57,7 +57,7 @@ class Prototype:
         try:
             with open(self.file, "r") as data:
                 return self.map_input(data)
-        except:
+        except FileNotFoundError:
             return {}
 
     def write(self, data: dict) -> None:

--- a/iocage/lib/Config/Type/ZFS.py
+++ b/iocage/lib/Config/Type/ZFS.py
@@ -53,7 +53,7 @@ class BaseConfigZFS(iocage.lib.Config.Dataset.DatasetConfig):
     def read(self) -> dict:
         try:
             return self.map_input(self._read_properties())
-        except:
+        except AttributeError:
             return {}
 
     def write(self, data: dict) -> None:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -22,6 +22,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
+import json
 import os
 import subprocess  # nosec: B404
 import uuid
@@ -1055,7 +1056,6 @@ class JailGenerator(JailResource):
         Invoke update of the jail state from jls output
         """
         try:
-            import json
             stdout = subprocess.check_output([
                 "/usr/sbin/jls",
                 "-j",

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -462,7 +462,7 @@ class JailGenerator(JailResource):
             self.logger.verbose(
                 f"Dataset {current_dataset_name} renamed to {new_dataset_name}"
             )
-        except:
+        except BaseException:
             self.config["id"] = current_id
             raise
 
@@ -477,7 +477,7 @@ class JailGenerator(JailResource):
 
         try:
             self._run_hook("prestop")
-        except:
+        except Exception:
             self.logger.warn("pre-stop script failed")
 
         yield jailDestroyEvent.begin()
@@ -851,12 +851,12 @@ class JailGenerator(JailResource):
 
             try:
                 ipv4_addresses = self.config["ip4_addr"][nic]
-            except:
+            except KeyError:
                 ipv4_addresses = []
 
             try:
                 ipv6_addresses = self.config["ip6_addr"][nic]
-            except:
+            except KeyError:
                 ipv6_addresses = []
 
             net = iocage.lib.Network.Network(
@@ -1135,7 +1135,7 @@ class JailGenerator(JailResource):
         """
         try:
             return str(iocage.lib.helpers.to_humanreadable_name(self.name))
-        except:
+        except KeyError:
             raise iocage.lib.errors.JailUnknownIdentifier(
                 logger=self.logger
             )
@@ -1214,7 +1214,7 @@ class JailGenerator(JailResource):
 
         try:
             return object.__getattribute__(self, "state")[key]
-        except KeyError:
+        except (AttributeError, KeyError):
             pass
 
         raise AttributeError(f"Jail property {key} not found")

--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -1,49 +1,74 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import typing
+
 class JailStateData:
 
   # jail.identifier
   name: str;
 
-  devfs_ruleset?: str;
-  dying?: str;
-  enforce_statfs?: str;
-  host?: str;
-  ip4?: str;
-  ip6?: str;
-  jid?: str;
-  osreldate?: str;
-  osrelease?: str;
-  parent?: str;
-  path?: str;
-  persist?: str;
-  securelevel?: str;
-  sysvmsg?: str;
-  sysvsem?: str;
-  sysvshm?: str;
-  vnet?: str;
-  allow.chflags?: str;
-  allow.mount?: str;
-  allow.mount.devfs?: str;
-  allow.mount.fdescfs?: str;
-  allow.mount.linprocfs?: str;
-  allow.mount.linsysfs?: str;
-  allow.mount.nullfs?: str;
-  allow.mount.procfs?: str;
-  allow.mount.tmpfs?: str;
-  allow.mount.zfs?: str;
-  allow.quotas?: str;
-  allow.raw_sockets?: str;
-  allow.set_hostname?: str;
-  allow.socket_af?: str;
-  allow.sysvipc?: str;
-  children.cur?: str;
-  children.max?: str;
-  cpuset.id?: str;
-  host.domainname?: str;
-  host.hostid?: str;
-  host.hostname?: str;
-  host.hostuuid?: str;
-  ip4.saddrsel?: str;
-  ip6.saddrsel?: str;
+  devfs_ruleset: typing.Optional[str];
+  dying: typing.Optional[str];
+  enforce_statfs: typing.Optional[str];
+  host: typing.Optional[str];
+  ip4: typing.Optional[str];
+  ip6: typing.Optional[str];
+  jid: typing.Optional[str];
+  osreldate: typing.Optional[str];
+  osrelease: typing.Optional[str];
+  parent: typing.Optional[str];
+  path: typing.Optional[str];
+  persist: typing.Optional[str];
+  securelevel: typing.Optional[str];
+  sysvmsg: typing.Optional[str];
+  sysvsem: typing.Optional[str];
+  sysvshm: typing.Optional[str];
+  vnet: typing.Optional[str];
+  allow.chflags: typing.Optional[str];
+  allow.mount: typing.Optional[str];
+  allow.mount.devfs: typing.Optional[str];
+  allow.mount.fdescfs: typing.Optional[str];
+  allow.mount.linprocfs: typing.Optional[str];
+  allow.mount.linsysfs: typing.Optional[str];
+  allow.mount.nullfs: typing.Optional[str];
+  allow.mount.procfs: typing.Optional[str];
+  allow.mount.tmpfs: typing.Optional[str];
+  allow.mount.zfs: typing.Optional[str];
+  allow.quotas: typing.Optional[str];
+  allow.raw_sockets: typing.Optional[str];
+  allow.set_hostname: typing.Optional[str];
+  allow.socket_af: typing.Optional[str];
+  allow.sysvipc: typing.Optional[str];
+  children.cur: typing.Optional[str];
+  children.max: typing.Optional[str];
+  cpuset.id: typing.Optional[str];
+  host.domainname: typing.Optional[str];
+  host.hostid: typing.Optional[str];
+  host.hostname: typing.Optional[str];
+  host.hostuuid: typing.Optional[str];
+  ip4.saddrsel: typing.Optional[str];
+  ip6.saddrsel: typing.Optional[str];
 
 class JailState(JailStateData):
 

--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -1,0 +1,78 @@
+class JailStateData:
+
+  # jail.identifier
+  name: str;
+
+  devfs_ruleset?: str;
+  dying?: str;
+  enforce_statfs?: str;
+  host?: str;
+  ip4?: str;
+  ip6?: str;
+  jid?: str;
+  osreldate?: str;
+  osrelease?: str;
+  parent?: str;
+  path?: str;
+  persist?: str;
+  securelevel?: str;
+  sysvmsg?: str;
+  sysvsem?: str;
+  sysvshm?: str;
+  vnet?: str;
+  allow.chflags?: str;
+  allow.mount?: str;
+  allow.mount.devfs?: str;
+  allow.mount.fdescfs?: str;
+  allow.mount.linprocfs?: str;
+  allow.mount.linsysfs?: str;
+  allow.mount.nullfs?: str;
+  allow.mount.procfs?: str;
+  allow.mount.tmpfs?: str;
+  allow.mount.zfs?: str;
+  allow.quotas?: str;
+  allow.raw_sockets?: str;
+  allow.set_hostname?: str;
+  allow.socket_af?: str;
+  allow.sysvipc?: str;
+  children.cur?: str;
+  children.max?: str;
+  cpuset.id?: str;
+  host.domainname?: str;
+  host.hostid?: str;
+  host.hostname?: str;
+  host.hostuuid?: str;
+  ip4.saddrsel?: str;
+  ip6.saddrsel?: str;
+
+class JailState(JailStateData):
+
+  def __init__(
+    self,
+    data: JailStateData
+  ) -> None:
+
+
+    self.name = 
+
+  def update(self) -> None:
+
+    if self.name 
+
+    try:
+        import json
+        stdout = subprocess.check_output([
+            "/usr/sbin/jls",
+            "-j",
+            self.name,
+            "-v",
+            "-h",
+            "--libxo=json"
+        ], shell=False, stderr=subprocess.DEVNULL)  # nosec TODO use helper
+        output = stdout.decode().strip()
+
+        self.jail_state = json.loads(output)["jail-information"]["jail"][0]
+
+    except:
+        self.jail_state = {}
+

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -29,12 +29,11 @@ import iocage.lib.Filter
 import iocage.lib.Resource
 import iocage.lib.helpers
 
-JailStateDict = typing.Dict[str, iocage.lib.JailState.JailState]
 
 class JailsGenerator(iocage.lib.Resource.ListableResource):
 
     _class_jail = iocage.lib.Jail.JailGenerator
-    _jail_states: typing.Optional[JailStateDict]
+    states = iocage.lib.JailState.JailStates()
 
     # Keys that are stored on the Jail object, not the configuration
     JAIL_KEYS = [
@@ -78,40 +77,32 @@ class JailsGenerator(iocage.lib.Resource.ListableResource):
         kwargs["host"] = self.host
         kwargs["zfs"] = self.zfs
         jail = self._class_jail(*args, **kwargs)
-        jail.state = 
+
+        if jail.identifier in self.states:
+            self.logger.spam(
+                f"Injecting pre-loaded state to '{jail.humanreadable_name}'"
+            )
+            jail.jail_state = self.states[jail.identifier]
+
         return jail
 
-    @property
-    def states(self) -> JailStateDict
-        if isinstance(self._states, JailStateDict):
-            return self._jail_states
-        return self.update_jail_states()
+    def __iter__(
+        self
+    ) -> typing.Generator['iocage.lib.Resource.Resource', None, None]:
 
-    def update_jail_states(self) -> JailStateDict:
-        """
-        Invoke update of the jail state from jls output
-        """
-        try:
-            stdout = subprocess.check_output([
-                "/usr/sbin/jls",
-                "-v",
-                "-h",
-                "--libxo=json"
-            ], shell=False, stderr=subprocess.DEVNULL)  # nosec TODO use helper
-            output = stdout.decode().strip()
+        self.states.query()
 
-            import json
-            data = json.loads(output)
+        for jail in iocage.lib.Resource.ListableResource.__iter__(self):
 
-            states: JailStateDict = {}
-            for state_data in data["jail-information"]["jail"]:
-                states[state_data["name"]] = iocage.lib.JailState(state_data)
+            if jail.identifier in self.states:
+                jail.state = self.states[jail.identifier]
+            else:
+                jail.state = iocage.lib.JailState.JailState(
+                    jail.identifier, {}
+                )
 
-            self._states = states
-            return states
+            yield jail
 
-        except BaseException:
-            raise iocage.lib.errors.JailStateUpdateFailed()
 
 class Jails(JailsGenerator):
 

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -78,6 +78,7 @@ class JailsGenerator(iocage.lib.Resource.ListableResource):
         kwargs["host"] = self.host
         kwargs["zfs"] = self.zfs
         jail = self._class_jail(*args, **kwargs)
+        jail.state = 
         return jail
 
     @property

--- a/iocage/lib/Logger.py
+++ b/iocage/lib/Logger.py
@@ -290,7 +290,7 @@ class Logger:
     def _colorize(self, message: str, color_name: str) -> str:
         try:
             color_code = self._get_color_code(color_name)
-        except:
+        except ValueError:
             return message
 
         return f"\033[1;{color_code}m{message}\033[0m"

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -321,7 +321,7 @@ class ReleaseGenerator(ReleaseResource):
         try:
             root_pool = self.root_dataset.pool  # type: libzfs.ZFSPool
             return root_pool
-        except:
+        except AttributeError:
             pool = self.host.datasets.releases.pool  # type: libzfs.ZFSPool
             return pool
 
@@ -712,7 +712,7 @@ class ReleaseGenerator(ReleaseResource):
 
             self.logger.debug(f"Update of release '{self.name}' finished")
 
-        except:
+        except Exception:
 
             raise iocage.lib.errors.ReleaseUpdateFailure(
                 release_name=self.name,

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -142,7 +142,7 @@ class Resource(metaclass=abc.ABCMeta):
     def exists(self) -> bool:
         try:
             return os.path.isdir(self.dataset.mountpoint)
-        except:
+        except (AttributeError, libzfs.ZFSException):
             return False
 
     @property

--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -72,7 +72,7 @@ class ZFSShareStorage:
             try:
                 dataset = self.zfs.get_dataset(name)
                 datasets.add(dataset)
-            except:
+            except libzfs.ZFSException:
                 raise iocage.lib.errors.DatasetNotAvailable(
                     dataset_name=name,
                     logger=self.logger

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -147,6 +147,13 @@ class JailNotTemplate(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+class JailStateUpdateFailed(IocageException):
+
+    def __init__(self, *args, **kwargs) -> None:
+        msg = f"Updating the jail state with jls failed"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # Security
 
 


### PR DESCRIPTION
- adds JailState data structure
- the Jails list iterator invokes update of jails state with jls only once and passes fitting results to jails as it iterates them

A quick comparison with 10 jails on SSD:
- Before: 2.51s real
- After: 0.6s real