### PR TITLE
Remove dependency on Python module uuid

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -23,7 +23,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
 import re
-import uuid
 
 import iocage.lib.Config.Jail.JailConfigProperties
 import iocage.lib.errors
@@ -181,9 +180,9 @@ class BaseConfig(dict):
         if is_valid_name is True:
             self.data["id"] = name
         else:
-            try:
-                self.data["id"] = str(uuid.UUID(name))  # legacy support
-            except ValueError:
+            if iocage.lib.helpers.is_uuid(name) is True:
+                self.data["id"] = name
+            else:
                 raise iocage.lib.errors.InvalidJailName(logger=self.logger)
 
     def _get_name(self) -> str:

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -23,7 +23,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
 import os.path
-import uuid
+import random
 
 import iocage.lib.helpers
 import iocage.lib.Config.Jail.File.Prototype
@@ -71,7 +71,7 @@ class FstabCommentLine(dict):
         return str(self["line"])
 
     def __hash__(self):
-        return hash(uuid.uuid4().hex)
+        return hash('%030x' % random.randrange(16**32))
 
 
 class FstabAutoPlaceholderLine(dict):

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -71,7 +71,7 @@ class FstabCommentLine(dict):
         return str(self["line"])
 
     def __hash__(self):
-        return hash('%030x' % random.randrange(16**32))
+        return hash('%030x' % random.randrange(16**32))  # nosec: B311
 
 
 class FstabAutoPlaceholderLine(dict):

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -563,8 +563,7 @@ class JailGenerator(JailResource):
     ) -> None:
 
         if self.config["id"] is None:
-            import uuid
-            self.config["id"] = str(uuid.uuid4())
+            self.config["id"] = str(iocage.lib.helpers.get_random_uuid())
 
         self.require_jail_not_existing()
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -24,7 +24,6 @@
 import typing
 import os
 import subprocess  # nosec: B404
-import uuid
 import shlex
 
 import iocage.lib.Types
@@ -564,6 +563,7 @@ class JailGenerator(JailResource):
     ) -> None:
 
         if self.config["id"] is None:
+            import uuid
             self.config["id"] = str(uuid.uuid4())
 
         self.require_jail_not_existing()

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -23,9 +23,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import typing
 import json
+import random
 import re
 import subprocess  # nosec: B404
-import uuid
 
 import iocage.lib.errors
 import iocage.lib.Datasets
@@ -156,11 +156,16 @@ def _prettify_output(output: str) -> str:
 
 
 def to_humanreadable_name(name: str) -> str:
-    try:
-        uuid.UUID(name)
-        return str(name)[:8]
-    except (TypeError, ValueError):
-        return name
+    return name[:8] if (is_uuid(name) is True) else name
+
+
+_UUID_REGEX = re.compile(
+    "^[A-z0-9]{8}-[A-z0-9]{4}-[A-z0-9]{4}-[A-z0-9]{4}-[A-z0-9]{12}$"
+)
+
+
+def is_uuid(text: str) -> bool:
+    return _UUID_REGEX.match(text) is not None
 
 
 # helper function to validate names
@@ -456,6 +461,13 @@ def umount(
                 mountpoint=mountpoint,
                 logger=logger
             )
+
+
+def get_random_uuid() -> str:
+    return "-".join(map(
+        lambda x: ('%030x' % random.randrange(16**x))[-x:],
+        [8, 4, 4, 4, 12]
+    ))
 
 
 def get_basedir_list(distribution_name="FreeBSD"):

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -465,7 +465,7 @@ def umount(
 
 def get_random_uuid() -> str:
     return "-".join(map(
-        lambda x: ('%030x' % random.randrange(16**x))[-x:],
+        lambda x: ('%030x' % random.randrange(16**x))[-x:],  # nosec: B311
         [8, 4, 4, 4, 12]
     ))
 


### PR DESCRIPTION
Importing uuid turned out to be slow on larger systems. Since we didn't really depend on it we could replace the features in use with two helper functions that practically do the same.

On a test host with 12 cores and 24 threads the import time for the library dropped from 0.9s to 0.21s.