### PR TITLE
improve jail tag/tags combination handling

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -254,7 +254,18 @@ class BaseConfig(dict):
         return "tag" in self.data.keys()
 
     def _get_tags(self) -> typing.List[str]:
-        return list(iocage.lib.helpers.parse_list(self.data["tags"]))
+
+        data_keys = self.data.keys()
+
+        if "tags" in data_keys:
+            tags = set(list(iocage.lib.helpers.parse_list(self.data["tags"])))
+        else:
+            tags = set()
+
+        if (self._has_legacy_tag is True):
+            tags.add(self.data["tag"])
+
+        return list(tags)
 
     def _set_tags(
         self,


### PR DESCRIPTION
```
# ioc list -o name,tag,tags foo
+------+-----+-------------+
| NAME | TAG |    TAGS     |
+======+=====+=============+
| foo  | baz | baz,bar,foo |
+------+-----+-------------+
# ioc set tag=foo foo
Jail 'foo' updated: tag
# ioc list -o name,tag,tags foo
+------+-----+-------------+
| NAME | TAG |    TAGS     |
+======+=====+=============+
| foo  | foo | foo,baz,bar |
+------+-----+-------------+
# ioc list -o name,tag,tags tag=foo
+------+-----+-------------+
| NAME | TAG |    TAGS     |
+======+=====+=============+
| foo  | foo | foo,baz,bar |
+------+-----+-------------+
# ioc list -o name,tag,tags tag=baz
+------+-----+------+
| NAME | TAG | TAGS |
+======+=====+======+
+------+-----+------+
# ioc list -o name,tag,tags tags=baz
+------+-----+-------------+
| NAME | TAG |    TAGS     |
+======+=====+=============+
| foo  | foo | foo,baz,bar |
+------+-----+-------------+
#
```