### PR TITLE
update fstab when renaming Jails

### DIFF
--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -345,27 +345,18 @@ class Fstab(
     def __len__(self):
         return list.__len__(list(self.__iter__()))
 
-    def __delitem__(self, index: int) -> None:
+    def __delitem__(self, index):
         real_index = self._get_real_index(index)
         self._lines.__delitem__(real_index)
 
-    def __getitem__(self, index: int) -> typing.Union[
-        FstabLine,
-        FstabCommentLine,
-        FstabAutoPlaceholderLine
-    ]:
+    def __getitem__(self, index):
         return list(self.__iter__())[index]
 
     def __setitem__(
         self,
-        index: int,
-        value: typing.Union[
-            FstabLine,
-            FstabCommentLine,
-            FstabAutoPlaceholderLine
-        ]
-    ) -> None:
-
+        index,
+        value
+    ):
         real_index = self._get_real_index(index)
         self._lines.__setitem__(real_index, value)
 

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -167,6 +167,10 @@ class Fstab(
         line: str
         comment: typing.Optional[str]
         auto_comment_found: bool = False
+        basejail_destinations = map(
+            lambda x: str(x['destination']),
+            self.basejail_lines
+        )
 
         for line in input_text.rstrip("\n").split("\n"):
 
@@ -206,9 +210,13 @@ class Fstab(
 
             destination = os.path.abspath(fragments[1])
 
+            # skip lines with destinations overlapping self.basejail_lines
+            if destination in basejail_destinations:
+                continue
+
             new_line = FstabLine({
                 "source": fragments[0],
-                "destination": fragments[1],
+                "destination": destination,
                 "type": fragments[2],
                 "options": fragments[3],
                 "dump": fragments[4],
@@ -216,7 +224,7 @@ class Fstab(
                 "comment": comment
             })
 
-            if new_line in self:
+            if new_line in self._lines:
                 self.logger.error(
                     "Duplicate mountpoint in fstab: "
                     f"{destination} already mounted"

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -92,7 +92,9 @@ class Storage:
                 self.jail.host.datasets.jails.name,
                 new_name
             ])
-            self.jail.dataset.rename(new_dataset_name)
+            dataset = self.jail.dataset
+            dataset.rename(new_dataset_name)
+            self.jail._dataset = self.zfs.get_dataset(new_dataset_name)
             self.jail.dataset_name = new_dataset_name
             self.logger.verbose(
                 f"Dataset {current_dataset_name} renamed to {new_dataset_name}"

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -161,6 +161,16 @@ class JailStateUpdateFailed(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+# Jail Fstab
+
+
+class VirtualFstabLineHasNoRealIndex(IocageException):
+
+    def __init__(self, *args, **kwargs) -> None:
+        msg = f"The virtual fstab line does not have a real list index"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # Security
 
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -318,6 +318,18 @@ class JailMountTeardown(JailEvent):
 
         JailEvent.__init__(self, jail, **kwargs)
 
+
+class JailFstabUpdate(JailEvent):
+
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
 # Release
 
 


### PR DESCRIPTION
Source and destination paths of user-created fstab entries are updated to match the jail dataset after the renaming operation.