### PR TITLE
fix release updates on hosts with custom kernel

### DIFF
--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -623,6 +623,7 @@ class ReleaseGenerator(ReleaseResource):
                         yield event
                     else:
                         changed = event
+            jail.stop()
             yield runReleaseUpdateEvent.end()
         except Exception as e:
             # kill the helper jail and roll back if anything went wrong

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -591,6 +591,7 @@ class ReleaseGenerator(ReleaseResource):
 
         jail = iocage.lib.Jail.JailGenerator(
             {
+                "name": self.name.replace(".", "-"),
                 "basejail": False,
                 "allow_mount_nullfs": "1",
                 "release": self.name,

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -25,6 +25,7 @@ import typing
 import datetime
 import hashlib
 import os
+import re
 import shutil
 import tarfile
 import urllib.request
@@ -531,10 +532,11 @@ class ReleaseGenerator(ReleaseResource):
                 if self.host.distribution.name == "FreeBSD":
                     with open(local_path, "r+") as f:
                         content = f.read()
+                        pattern = re.compile("^Components .+$", re.MULTILINE)
                         f.seek(0)
-                        f.write(content.replace(
-                            "Components src",
-                            "Components"
+                        f.write(pattern.sub(
+                            "Components world",
+                            content
                         ))
                         f.truncate()
 


### PR DESCRIPTION
When a custom kernel was compiled on a host that attempts to fetch and install release updates in a jail, it mistakenly assumes kernel debug modules. Since we are running jails only, there is no need to patch the kernel separately.

@igalic thanks for pairing on this!