### PR TITLE
Feature: ioc fstab CLI command

### DIFF
--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -96,7 +96,7 @@ def _get_jail(
     required=False
 )
 @click.argument("jail", nargs=1, required=True)
-@click.option("--read-write", "-rw", is_flag=True, default=False)
+@click.option("--write", "-rw", is_flag=True, default=False)
 def cli_add(
     ctx: ClickContext,
     source: str,

--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""set module for the cli."""
+import typing
+import click
+import os.path
+
+import iocage.lib.errors
+import iocage.lib.Logger
+import iocage.lib.Host
+import iocage.lib.helpers
+import iocage.lib.Jail
+import iocage.lib.Config.Jail.File.Fstab
+
+
+__rootcmd__ = True
+FstabLine = iocage.lib.Config.Jail.File.Fstab.FstabLine
+
+
+@click.command(
+    name="add"
+)
+@click.pass_context
+@click.argument(
+    "source",
+    nargs=1,
+    required=False
+)
+@click.argument(
+    "destination",
+    nargs=1,
+    required=False
+)
+@click.option("--read-write", "-rw", is_flag=True, default=False)
+def cli_add(
+    ctx: click.core.Context,
+    source: str,
+    destination: str,
+    read_write: bool
+) -> None:
+
+    if destination is None:
+        destination = source
+
+    if os.path.exists(source) is False:
+        ctx.parent.logger.error(
+            f"The mount source {source} is does not exist"
+        )
+        exit(1)
+
+    if os.path.isdir(source) is False:
+        ctx.parent.logger.error(
+            f"The mount source {source} is not a directory"
+        )
+        exit(1)
+
+    mount_options = "rw" if read_write is True else "ro"
+
+    try:
+        fstab = ctx.parent.jail.fstab
+        fstab.read_file()
+        fstab.new_line(
+            source=source,
+            destination=destination,
+            fs_type="nullfs",
+            options=mount_options,
+            dump="0",
+            passnum="0",
+            comment=None
+        )
+        fstab.save()
+        ctx.parent.logger.log(
+            f"fstab mount added: {source} -> {destination} ({mount_options})"
+        )
+        exit(0)
+    except iocage.lib.errors.IocageException:
+        exit(1)
+
+
+@click.command(
+    name="show"
+)
+@click.pass_context
+def cli_show(ctx):
+    parent: typing.Any = ctx.parent
+
+    if os.path.isfile(ctx.parent.jail.fstab.path):
+        with open(ctx.parent.jail.fstab.path, "r") as f:
+            print(f.read())
+
+
+@click.command(
+    name="rm"
+)
+@click.argument(
+    "source",
+    nargs=1,
+    required=False
+)
+@click.pass_context
+def cli_rm(ctx, source):
+
+    fstab = ctx.parent.jail.fstab
+
+    deleted_destination = None
+    i = 0
+
+    try:
+        fstab.read_file()
+        for existing_line in fstab:
+            i += 1
+            if isinstance(existing_line, FstabLine) is False:
+                continue
+            if existing_line["source"] == source:
+                deleted_destination = fstab[i-1]["destination"]
+                del fstab[i-1]
+                fstab.save()
+                break
+    except iocage.lib.errors.IocageException:
+        exit(1)
+
+    if deleted_destination is None:
+        ctx.parent.logger.error("no matching fstab line found")
+        exit(1)
+
+    ctx.parent.logger.log(
+        f"fstab mount removed: {source} -> {deleted_destination}"
+    )
+
+
+class FstabCli(click.MultiCommand):
+
+    def list_commands(self, ctx: click.core.Context) -> typing.List[str]:
+        return [
+            "show",
+            "add",
+            "rm"
+        ]
+
+    def get_command(
+        self,
+        ctx: click.core.Context,
+        action: str
+    ):
+
+        if action == "show":
+            return cli_show
+        elif action == "add":
+            return cli_add
+        elif action == "rm":
+            return cli_rm
+
+        raise NotImplementedException("action does not exist")
+
+
+@click.group(
+    name="fstab",
+    cls=FstabCli,
+    context_settings=dict(
+        ignore_unknown_options=True,
+    )
+)
+@click.pass_context
+@click.argument(
+    "jail",
+    nargs=1,
+    required=True
+)
+def cli(
+    ctx: click.core.Context,
+    jail: str
+) -> None:
+    """Manage a jails fstab file"""
+
+    ctx.logger: iocage.lib.Logger.Logger = ctx.parent.logger
+    ctx.host = iocage.lib.Host.HostGenerator(logger=ctx.logger)
+
+    filters = (f"name={jail}",)
+    try:
+        ctx.jail = iocage.lib.Jail.JailGenerator(
+            jail,
+            host=ctx.host,
+            logger=ctx.logger
+        )
+    except iocage.lib.errors.IocageException:
+        exit(1)

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -311,6 +311,13 @@ class Fstab(
         else:
             self.logger.debug(f"Adding line to fstab: {line}")
 
+        for existing_line in self.__iter__():
+            if hash(existing_line) == hash(line):
+                raise iocage.lib.errors.FstabDestinationExists(
+                    mountpoint=line["destination"],
+                    logger=self.logger
+                )
+
         self._lines.append(line)
 
     @property

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -171,6 +171,13 @@ class VirtualFstabLineHasNoRealIndex(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+class FstabDestinationExists(IocageException):
+
+    def __init__(self, mountpoint: str, *args, **kwargs) -> None:
+        msg = f"The mountpoint {mountpoint} already exists in the fstab file"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # Security
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -188,11 +188,18 @@ class SecurityViolation(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
-class SecurityViolationConfigJailEscape(IocageException):
+class InsecureJailPath(SecurityViolation):
+
+    def __init__(self, path, *args, **kwargs) -> None:
+        msg = f"Insecure path {path} jail escape attempt"
+        SecurityViolation.__init__(self, msg, *args, **kwargs)
+
+
+class SecurityViolationConfigJailEscape(SecurityViolation):
 
     def __init__(self, file, *args, **kwargs) -> None:
         msg = f"The file {file} references a file outsite of the jail resource"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        SecurityViolation.__init__(self, msg, *args, **kwargs)
 
 
 # JailConfig


### PR DESCRIPTION
- A CLI command to view and manage jails fstab files
- Sub-commands
  - add
  - rm
  - show

**Update**: The discussion around interface changes was moved to #202 

```
# ioc create -b -n example
example successfully created from 11-STABLE!
# ioc fstab show example
/iocage/releases/11-STABLE/root/bin	/iocage/jails/example/root/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/boot	/iocage/jails/example/root/boot	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/lib	/iocage/jails/example/root/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/libexec	/iocage/jails/example/root/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/rescue	/iocage/jails/example/root/rescue	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/sbin	/iocage/jails/example/root/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/bin	/iocage/jails/example/root/usr/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/include	/iocage/jails/example/root/usr/include	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/lib	/iocage/jails/example/root/usr/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libexec	/iocage/jails/example/root/usr/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/sbin	/iocage/jails/example/root/usr/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/share	/iocage/jails/example/root/usr/share	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libdata	/iocage/jails/example/root/usr/libdata	nullfs	ro	0	0 # iocage-auto
# ioc fstab add /tmp example
fstab mount added: /tmp -> /iocage/jails/example/root/tmp (ro)
# ioc fstab add /tmp example
The mountpoint /iocage/jails/example/root/tmp already exists in the fstab file
# ioc fstab show example
/iocage/releases/11-STABLE/root/bin	/iocage/jails/example/root/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/boot	/iocage/jails/example/root/boot	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/lib	/iocage/jails/example/root/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/libexec	/iocage/jails/example/root/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/rescue	/iocage/jails/example/root/rescue	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/sbin	/iocage/jails/example/root/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/bin	/iocage/jails/example/root/usr/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/include	/iocage/jails/example/root/usr/include	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/lib	/iocage/jails/example/root/usr/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libexec	/iocage/jails/example/root/usr/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/sbin	/iocage/jails/example/root/usr/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/share	/iocage/jails/example/root/usr/share	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libdata	/iocage/jails/example/root/usr/libdata	nullfs	ro	0	0 # iocage-auto
/tmp	/iocage/jails/example/root/tmp	nullfs	ro	0	0
# ioc fstab rm /tmp example
fstab mount removed: /tmp -> /iocage/jails/example/root/tmp
# ioc fstab show example
/iocage/releases/11-STABLE/root/bin	/iocage/jails/example/root/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/boot	/iocage/jails/example/root/boot	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/lib	/iocage/jails/example/root/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/libexec	/iocage/jails/example/root/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/rescue	/iocage/jails/example/root/rescue	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/sbin	/iocage/jails/example/root/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/bin	/iocage/jails/example/root/usr/bin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/include	/iocage/jails/example/root/usr/include	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/lib	/iocage/jails/example/root/usr/lib	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libexec	/iocage/jails/example/root/usr/libexec	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/sbin	/iocage/jails/example/root/usr/sbin	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/share	/iocage/jails/example/root/usr/share	nullfs	ro	0	0 # iocage-auto
/iocage/releases/11-STABLE/root/usr/libdata	/iocage/jails/example/root/usr/libdata	nullfs	ro	0	0 # iocage-auto
```