### PR TITLE
iocage_legacy UCL config (develop branch) support

### DIFF
--- a/iocage/cli/get.py
+++ b/iocage/cli/get.py
@@ -72,6 +72,7 @@ def cli(ctx, prop, _all, _pool, jail, log_level):
 
     if jail == "defaults":
         source_resource = host.defaults
+        source_resource.read_config()
         lookup_method = _lookup_config_value
     else:
         lookup_method = _lookup_jail_value

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -38,17 +38,19 @@ import iocage.lib.Releases
 supported_output_formats = ['table', 'csv', 'list', 'json']
 
 
-@click.command(name="list", help="List a specified dataset type, by default"
-                                 " lists all jails.")
+@click.command(
+    name="list",
+    help="List a specified dataset type, by default lists all jails."
+)
 @click.pass_context
 @click.option("--release", "--base", "-r", "-b", "dataset_type",
               flag_value="base", help="List all bases.")
-@click.option("--template", "-t", "dataset_type", flag_value="template",
-              help="List all templates.")
+@click.option("--template", "-t", "dataset_type",
+              flag_value="template", help="List all templates.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
               help="Show the full uuid and ip4 address.")
-@click.option("--remote", "-R", is_flag=True, help="Show remote's available "
-                                                   "RELEASEs.")
+@click.option("--remote", "-R",
+              is_flag=True, help="Show remote's available RELEASEs.")
 @click.option("--plugins", "-P", is_flag=True, help="Show available plugins.")
 @click.option("--sort", "-s", "_sort", default=None, nargs=1,
               help="Sorts the list by the given type")

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -105,7 +105,7 @@ def cli(ctx, dataset_type, header, _long, remote, plugins,
         if dataset_type == "template":
             filters += ("template=yes",)
         else:
-            filters += ("template=no",)
+            filters += ("template=no,-",)
 
         resources_class = iocage.lib.Jails.JailsGenerator
         columns = _list_output_comumns(output, _long)

--- a/iocage/cli/set.py
+++ b/iocage/cli/set.py
@@ -112,7 +112,7 @@ def set_properties(
             try:
                 del target.config[key]
                 updated_properties.add(key)
-            except iocage.lib.errors.IocageException:
+            except (iocage.lib.errors.IocageException, KeyError):
                 pass
 
     if len(updated_properties) > 0:

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -349,12 +349,14 @@ class BaseConfig(dict):
 
     def _set_jail_zfs_dataset(
         self,
-        value: typing.Union[typing.List[str], str],
+        value: typing.Optional[typing.Union[typing.List[str], str]],
         **kwargs
     ) -> None:
-
         value = [value] if isinstance(value, str) else value
-        self.data["jail_zfs_dataset"] = " ".join(value)
+        if value is None:
+            self.data["jail_zfs_dataset"] = ""
+        else:
+            self.data["jail_zfs_dataset"] = " ".join(value)
 
     def _get_jail_zfs(self):
         return iocage.lib.helpers.parse_user_input(

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -94,6 +94,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "allow_mount_tmpfs": 0,
         "allow_quotas": 0,
         "allow_socket_af": 0,
+        "rlimits": None,
         "sysvmsg": "new",
         "sysvsem": "new",
         "sysvshm": "new",

--- a/iocage/lib/Config/Jail/Properties/Addresses.py
+++ b/iocage/lib/Config/Jail/Properties/Addresses.py
@@ -67,7 +67,7 @@ _AddressSetInputType = typing.Union[str, typing.Dict[str, AddressSet]]
 
 class AddressesProp(dict):
 
-    logger: iocage.lib.Logger.Logger
+    logger: 'iocage.lib.Logger.Logger'
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str = "ip4_address"
     skip_on_error: bool

--- a/iocage/lib/Config/Type/UCL.py
+++ b/iocage/lib/Config/Type/UCL.py
@@ -36,12 +36,11 @@ class ConfigUCL(iocage.lib.Config.Prototype.Prototype):
     config_type = "ucl"
 
     def map_input(self, data: typing.TextIO) -> typing.Dict[str, typing.Any]:
-        result = ucl.load(data)  # type: typing.Dict[str, typing.Any]
+        result = ucl.load(data.read())  # type: typing.Dict[str, typing.Any]
         return result
 
     def map_output(self, data: dict) -> str:
-        # ToDo: Re-Implement UCL output
-        raise iocage.lib.errors.MissingFeature("Writing ConfigUCL")
+        return str(iocage.lib.helpers.to_ucl(data))
 
 
 class ResourceConfigUCL(

--- a/iocage/lib/Config/Type/UCL.py
+++ b/iocage/lib/Config/Type/UCL.py
@@ -37,6 +37,7 @@ class ConfigUCL(iocage.lib.Config.Prototype.Prototype):
 
     def map_input(self, data: typing.TextIO) -> typing.Dict[str, typing.Any]:
         result = ucl.load(data.read())  # type: typing.Dict[str, typing.Any]
+        result["legacy"] = True
         return result
 
     def map_output(self, data: dict) -> str:

--- a/iocage/lib/Config/Type/ZFS.py
+++ b/iocage/lib/Config/Type/ZFS.py
@@ -52,9 +52,13 @@ class BaseConfigZFS(iocage.lib.Config.Dataset.DatasetConfig):
 
     def read(self) -> dict:
         try:
-            return self.map_input(self._read_properties())
+            data = self.map_input(self._read_properties())
+            data["legacy"] = True
+            return data
         except AttributeError:
-            return {}
+            return {
+                "legacy": True
+            }
 
     def write(self, data: dict) -> None:
         """
@@ -133,7 +137,7 @@ class ConfigZFS(BaseConfigZFS):
         return self._dataset
 
 
-class ResourceConfigZFS(BaseConfigZFS):
+class ResourceConfigZFS(ConfigZFS):
 
     def __init__(
         self,
@@ -142,9 +146,13 @@ class ResourceConfigZFS(BaseConfigZFS):
     ) -> None:
 
         self.resource = resource
-        iocage.lib.Config.Dataset.DatasetConfig.__init__(self, **kwargs)
+        ConfigZFS.__init__(self, **kwargs)
 
     @property
     def dataset(self) -> libzfs.ZFSDataset:
-        dataset: libzfs.ZFSDataset = self.resource.dataset
+        dataset: libzfs.ZFSDataset
+        if self._dataset is not None:
+            dataset = self._dataset
+        else:
+            dataset = self.resource.dataset
         return dataset

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -106,10 +106,6 @@ class Datasets:
     def jails(self) -> libzfs.ZFSDataset:
         return self._get_or_create_dataset("jails")
 
-    @property
-    def logs(self) -> libzfs.ZFSDataset:
-        return self._get_or_create_dataset("log")
-
     def activate(
         self,
         mountpoint: typing.Optional[iocage.lib.Types.AbsolutePath]=None

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -89,13 +89,25 @@ class HostGenerator:
             logger=self.logger,
             zfs=self.zfs
         )
+
+        self._init_defaults(defaults)
+
+    def _init_defaults(
+        self,
+        defaults: typing.Optional[iocage.lib.Resource.DefaultResource]=None
+    ) -> None:
+
         if defaults is not None:
             self._defaults = defaults
+        else:
+            self._defaults = iocage.lib.Resource.DefaultResource(
+                dataset=self.datasets.root,
+                logger=self.logger,
+                zfs=self.zfs
+            )
 
     @property
     def defaults(self) -> 'iocage.lib.Resource.DefaultResource':
-        if "_defaults" not in dir(self):
-            self._defaults = self._load_defaults()
         return self._defaults
 
     @property
@@ -103,15 +115,6 @@ class HostGenerator:
         self
     ) -> 'iocage.lib.Config.Jail.BaseConfig.BaseConfig':
         return self.defaults.config
-
-    def _load_defaults(self) -> iocage.lib.Resource.DefaultResource:
-        defaults_resource = iocage.lib.Resource.DefaultResource(
-            dataset=self.datasets.root,
-            logger=self.logger,
-            zfs=self.zfs
-        )
-        defaults_resource.config.read(data=defaults_resource.read_config())
-        return defaults_resource
 
     @property
     def devfs(self) -> 'iocage.lib.DevfsRules.DevfsRules':

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -49,6 +49,7 @@ class HostGenerator:
 
     _devfs: iocage.lib.DevfsRules.DevfsRules
     _defaults: iocage.lib.Resource.DefaultResource
+    _defaults_initialized = False
     releases_dataset: libzfs.ZFSDataset
     datasets: iocage.lib.Datasets.Datasets
     distribution: _distribution_types
@@ -108,6 +109,9 @@ class HostGenerator:
 
     @property
     def defaults(self) -> 'iocage.lib.Resource.DefaultResource':
+        if self._defaults_initialized is False:
+            self._defaults.read_config()
+            self._defaults_initialized = True
         return self._defaults
 
     @property

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -55,10 +55,12 @@ class HostGenerator:
 
     branch_pattern = re.compile(
         r"""\(hardened/
-            (?P<release>[A-z0-9]+(?:[A-z0-9\-]+[A-z0-9]))
-            /
-            (?P<branch>[A-z0-9]+)
-            \):""", re.X)
+        (?P<release>[A-z0-9]+(?:[A-z0-9\-]+[A-z0-9]))
+        /
+        (?P<branch>[A-z0-9]+)
+        \):""",
+        re.X
+    )
 
     release_name_pattern = re.compile(
         r"^(?P<major>\d+)(?:\.(?P<minor>\d+))-(?P<type>[A-Z]+)-HBSD$",

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -934,6 +934,10 @@ class JailGenerator(JailResource):
 
     def _limit_resources(self) -> None:
 
+        if self.config['rlimits'] is False:
+            self.logger.verbose("Resource limits disabled")
+            return
+
         for key, limit, action in map(
             lambda name: (name, ) + self._get_resource_limit(name),
             self._resource_limit_config_keys

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1133,7 +1133,7 @@ class JailGenerator(JailResource):
                     "/root/etcupdate",
                     "/root/usr/ports",
                     "/root/usr/src",
-                    "/tmp"
+                    "/tmp"  # nosec: B108
                 ]
             )
         ))

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -850,7 +850,6 @@ class JailGenerator(JailResource):
 
         command += [
             "allow.dying",
-            f"exec.consolelog={self.logfile_path}",
             "persist"
         ]
 
@@ -1260,13 +1259,6 @@ class JailGenerator(JailResource):
             host=self.host,
             zfs=self.zfs
         )
-
-    @property
-    def logfile_path(self):
-        """
-        Absolute path of the jail log file
-        """
-        return f"{self.host.datasets.logs.mountpoint}-console.log"
 
     def __getattribute__(self, key: str):
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1129,7 +1129,11 @@ class JailGenerator(JailResource):
                     "/dev/fd",
                     "/dev",
                     "/proc",
-                    "/root/compat/linux/proc"
+                    "/root/compat/linux/proc",
+                    "/root/etcupdate",
+                    "/root/usr/ports",
+                    "/root/usr/src",
+                    "/tmp"
                 ]
             )
         ))

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1157,11 +1157,10 @@ class JailGenerator(JailResource):
                 "/bin/sh",
                 "-c",
                 " | ".join([
-                    "mount",
-                    f"grep 'on {self.root_dataset.mountpoint}'",
-                    "grep nullfs",
-                    "cut -f1 -d ' '",
-                    "xargs -n1 umount"
+                    "mount -t nullfs",
+                    "sed -r 's/(.+) on (.+) \\(nullfs, .+\\)$/\\2/'",
+                    f"grep '^{self.root_dataset.mountpoint}/'",
+                    "xargs umount"
                 ])
             ]
             iocage.lib.helpers.exec(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1152,6 +1152,23 @@ class JailGenerator(JailResource):
             ignore_error=True
         )
 
+        if self.config.legacy is True:
+            command = [
+                "/bin/sh",
+                "-c",
+                " | ".join([
+                    "mount",
+                    f"grep 'on {self.root_dataset.mountpoint}'",
+                    "grep nullfs",
+                    "cut -f1 -d ' '",
+                    "xargs -n1 umount"
+                ])
+            ]
+            iocage.lib.helpers.exec(
+                command,
+                logger=self.logger
+            )
+
     def _get_absolute_path_from_jail_asset(
         self,
         value: str

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -91,7 +91,13 @@ class Network:
         epair_a = epair_a.decode("utf-8").strip()
         epair_b = f"{epair_a[:-1]}b"
 
-        mac_a, mac_b = self.__generate_mac_address_pair()
+        try:
+            mac_config = self.jail.config[f"{self.nic}_mac"]
+            if mac_config is None or mac_config == "":
+                raise Exception("no manual mac address")
+            mac_a, mac_b = mac_config.split(',')
+        except Exception:
+            mac_a, mac_b = self.__generate_mac_address_pair()
 
         host_if = iocage.lib.NetworkInterface.NetworkInterface(
             name=epair_a,

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -177,11 +177,15 @@ def validate_name(name: str) -> bool:
     return _validate_name.fullmatch(name) is not None
 
 
-def parse_none(data: typing.Any) -> None:
+def parse_none(
+    data: typing.Any,
+    none_matches: typing.List[str]=["none", "-", ""]
+) -> None:
+
     if data is None:
         return None
 
-    if data in ["none", "-", ""]:
+    if data in none_matches:
         return None
 
     raise TypeError("Value is not None")

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -26,6 +26,7 @@ import json
 import random
 import re
 import subprocess  # nosec: B404
+import ucl
 
 import iocage.lib.errors
 import iocage.lib.Datasets
@@ -264,6 +265,18 @@ def to_json(data: typing.Dict[str, typing.Any]) -> str:
             none="none"
         )
     return str(json.dumps(output_data, sort_keys=True, indent=4))
+
+
+def to_ucl(data: typing.Dict[str, typing.Any]) -> str:
+    output_data = {}
+    for key, value in data.items():
+        output_data[key] = to_string(
+            value,
+            true="on",
+            false="off",
+            none="none"
+        )
+    return str(ucl.dump(output_data))
 
 
 def to_string(


### PR DESCRIPTION
- [x] can list properties of a UCL jail created with iocage_legacy@1.7.6
- [x] can set properties of a UCL jail created with iocage_legacy@1.7.6
- [x] can start nullfs basejails created with iocage_legacy@1.7.6
- [x] can start standalone jails created with iocage_legacy@1.7.6
- [x] can create new standalone jails using a release fetched with iocage_legacy#develop
- [x] can create new zfs basejail using a release fetched with iocage_legacy#develop
- [x] iocage_legacy@1.7.6 can create jails from releases fetched with libiocage
- [x] jail config rlimits=no disables rlimits
- [x] can read defaults from UCL file automatically
- ~can read defaults from UCL config file as `ioc get all defaults@ucl`~
- ~can write defaults to UCL config file as `ioc set key=value defaults@ucl`~