### PR TITLE
fix invalid click flag in cli/fstab

### DIFF
--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -96,7 +96,7 @@ def _get_jail(
     required=False
 )
 @click.argument("jail", nargs=1, required=True)
-@click.option("--write", "-rw", is_flag=True, default=False)
+@click.option("--read-write", "-rw", is_flag=True, default=False)
 def cli_add(
     ctx: ClickContext,
     source: str,


### PR DESCRIPTION
The click argument `write` was renamed to `read_write` without updating the flag string.