### PR TITLE
Improve error handling when creating resources

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -153,15 +153,12 @@ class BaseConfig(dict):
 
     def _set_id(self, name: str, **kwargs) -> None:
 
-        try:
+        if ("id" in self.data.keys()) and (self.data["id"] == name):
             # We do not want to set the same name twice.
             # This can occur when the Jail is initialized
             # with it's name and the same name is read from
             # the configuration
-            if self["id"] == name:
-                return
-        except KeyError:
-            pass
+            return
 
         if name is None:
             self.data["id"] = None

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -170,9 +170,12 @@ class Resource(metaclass=abc.ABCMeta):
     @property
     def exists(self) -> bool:
         try:
-            return os.path.isdir(self.dataset.mountpoint)
+            mountpoint = self.dataset.mountpoint
+            if isinstance(mountpoint, str):
+                return os.path.isdir(mountpoint)
         except (AttributeError, libzfs.ZFSException):
-            return False
+            pass
+        return False
 
     @property
     def _assigned_dataset_name(self) -> str:


### PR DESCRIPTION
- Improved error output when the iocage root dataset is unmounted
- refactored duplicate name detection when setting the jail config `id` property.