### PR TITLE
Feature: Secure VNET

### DIFF
--- a/iocage/lib/BridgeInterface.py
+++ b/iocage/lib/BridgeInterface.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import typing
+
+
+class BridgeInterface:
+
+    name: str
+    secure: bool
+
+    def __init__(
+        self,
+        name: str,
+        secure: typing.Optional[bool]=None
+    ) -> None:
+
+        if name.startswith("!"):
+            self.secure = True
+            self.name = name[1:]
+        else:
+            self.name = name
+            self.secure = False
+
+        # may override name set secure mode
+        if secure is not None:
+            self.secure = secure
+
+    def __str__(self):
+        secure_prefix = "!" if (self.secure is True) else ""
+        return f"{secure_prefix}{self.name}"
+

--- a/iocage/lib/BridgeInterface.py
+++ b/iocage/lib/BridgeInterface.py
@@ -29,13 +29,15 @@ class BridgeInterface:
     name: str
     secure: bool
 
+    SECURE_BRIDGE_PREFIX = ":"
+
     def __init__(
         self,
         name: str,
         secure: typing.Optional[bool]=None
     ) -> None:
 
-        if name.startswith("!"):
+        if name.startswith(self.SECURE_BRIDGE_PREFIX):
             self.secure = True
             self.name = name[1:]
         else:
@@ -47,6 +49,8 @@ class BridgeInterface:
             self.secure = secure
 
     def __str__(self):
-        secure_prefix = "!" if (self.secure is True) else ""
-        return f"{secure_prefix}{self.name}"
+        if self.secure is True:
+            return f"{self.SECURE_BRIDGE_PREFIX}{self.name}"
+        else:
+            return self.name
 

--- a/iocage/lib/Config/Jail/File/SysctlConf.py
+++ b/iocage/lib/Config/Jail/File/SysctlConf.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import os.path
+import typing
+
+import ucl
+
+import iocage.lib.helpers
+import iocage.lib.Config.Jail.File.Prototype
+
+# MyPy
+import iocage.lib.Logger
+
+
+class SysctlConf(
+    dict,
+    iocage.lib.Config.Jail.File.Prototype.ResourceConfigFile
+):
+
+    # the file is always relative to the resource
+    _file: str = "/etc/sysctl.conf"
+
+    def __init__(
+        self,
+        resource: 'iocage.lib.LaunchableResource.LaunchableResource',
+        file: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
+    ) -> None:
+
+        dict.__init__(self, {})
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+
+        # No file was loaded yet, so we can't know the delta yet
+        self._file_content_changed = True
+
+        if file is not None:
+            self._file = file
+
+        self.resource = resource
+        self._read_file()
+
+    @property
+    def path(self):
+        path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
+        self._require_path_relative_to_resource(
+            filepath=path,
+            resource=self.resource
+        )
+        return os.path.abspath(path)
+
+    @property
+    def file(self):
+        return self._file
+
+    @file.setter
+    def file(self, value):
+        if self._file != value:
+            self._file = value
+            self._read_file()
+
+    @property
+    def changed(self) -> bool:
+        return (self._file_content_changed is True)
+
+    def _read_file(
+        self,
+        silent: bool=False,
+        delete: bool=False,
+        merge: bool=False
+    ) -> None:
+        """
+        Read the sysctl.conf file
+
+        Args:
+
+            silent:
+                Do not use the logger
+
+            delete:
+                Delete entries that do not exist in the file
+
+            merge:
+                Do not change already existing properties
+        """
+        try:
+            if (self.path is not None) and os.path.isfile(self.path):
+                data = self._read(silent=silent)
+            else:
+                data = {}
+        except (FileNotFoundError, ValueError):
+            data = {}
+
+        existing_keys = set(self.keys())
+        new_keys = set(data.keys())
+        delete_keys = existing_keys - new_keys
+
+        if delete is True:
+            for key in delete_keys:
+                del self[key]
+
+        for key in new_keys:
+            if key in existing_keys:
+                if (merge is True) and (self[key] != data[key]):
+                    self[key] = data[key]
+                    self._file_content_changed = True
+            else:
+                self[key] = data[key]
+                self._file_content_changed = True
+
+        if silent is False:
+            self.logger.verbose(f"Updated sysctl.conf data from {self.path}")
+
+        if delete is False and len(delete_keys) > 0:
+            # There are properties that are not in the file
+            self._file_content_changed = True
+        else:
+            # Current data matches with file contents
+            self._file_content_changed = False
+
+    def _read(self, silent=False) -> dict:
+        data = dict(ucl.load(open(self.path).read()))
+        self.logger.spam(f"sysctl.conf was read from {self.path}")
+        return data
+
+    def save(self) -> bool:
+
+        if self.changed is False:
+            self.logger.debug("sysctl.conf was not modified - skipping write")
+            return False
+
+        with open(self.path, "w") as rcconf:
+
+            output = ucl.dump(self, ucl.UCL_EMIT_CONFIG)
+            output = output.replace(" = \"", "=\"")
+            output = output.replace("\";\n", "\"\n")
+
+            self.logger.verbose(f"Writing sysctl.conf to {self.path}")
+
+            rcconf.write(output)
+            rcconf.truncate()
+            rcconf.close()
+
+            self._file_content_changed = False
+            self.logger.spam(output[:-1], indent=1)
+            return True
+
+    def __setitem__(self, key, value):
+        val = iocage.lib.helpers.to_string(
+            iocage.lib.helpers.parse_user_input(value),
+            true="YES",
+            false="NO"
+        )
+
+        try:
+            if self[key] == value:
+                return
+        except KeyError:
+            pass
+
+        dict.__setitem__(self, key, val)
+        self._file_content_changed = True
+
+    def __getitem__(self, key):
+        val = dict.__getitem__(self, key)
+        return iocage.lib.helpers.parse_user_input(val)

--- a/iocage/lib/Config/Jail/File/SysrcConf.py
+++ b/iocage/lib/Config/Jail/File/SysrcConf.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import os.path
+import typing
+
+import ucl
+
+import iocage.lib.helpers
+import iocage.lib.Config.Jail.File.Prototype
+
+# MyPy
+import iocage.lib.Logger
+
+
+class SysctlConf(
+    dict,
+    iocage.lib.Config.Jail.File.Prototype.ResourceConfigFile
+):
+
+    # the file is always relative to the resource
+    _file: str = "/etc/sysrc.conf"
+
+    def __init__(
+        self,
+        resource: 'iocage.lib.LaunchableResource.LaunchableResource',
+        file: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
+    ) -> None:
+
+        dict.__init__(self, {})
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+
+        # No file was loaded yet, so we can't know the delta yet
+        self._file_content_changed = True
+
+        if file is not None:
+            self._file = file
+
+        self.resource = resource
+        self._read_file()
+
+    @property
+    def path(self):
+        path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
+        self._require_path_relative_to_resource(
+            filepath=path,
+            resource=self.resource
+        )
+        return os.path.abspath(path)
+
+    @property
+    def file(self):
+        return self._file
+
+    @file.setter
+    def file(self, value):
+        if self._file != value:
+            self._file = value
+            self._read_file()
+
+    @property
+    def changed(self) -> bool:
+        return (self._file_content_changed is True)
+
+    def _read_file(
+        self,
+        silent: bool=False,
+        delete: bool=False,
+        merge: bool=False
+    ) -> None:
+        """
+        Read the sysrc.conf file
+
+        Args:
+
+            silent:
+                Do not use the logger
+
+            delete:
+                Delete entries that do not exist in the file
+
+            merge:
+                Do not change already existing properties
+        """
+        try:
+            if (self.path is not None) and os.path.isfile(self.path):
+                data = self._read(silent=silent)
+            else:
+                data = {}
+        except (FileNotFoundError, ValueError):
+            data = {}
+
+        existing_keys = set(self.keys())
+        new_keys = set(data.keys())
+        delete_keys = existing_keys - new_keys
+
+        if delete is True:
+            for key in delete_keys:
+                del self[key]
+
+        for key in new_keys:
+            if key in existing_keys:
+                if (merge is True) and (self[key] != data[key]):
+                    self[key] = data[key]
+                    self._file_content_changed = True
+            else:
+                self[key] = data[key]
+                self._file_content_changed = True
+
+        if silent is False:
+            self.logger.verbose(f"Updated sysrc.conf data from {self.path}")
+
+        if delete is False and len(delete_keys) > 0:
+            # There are properties that are not in the file
+            self._file_content_changed = True
+        else:
+            # Current data matches with file contents
+            self._file_content_changed = False
+
+    def _read(self, silent=False) -> dict:
+        data = dict(ucl.load(open(self.path).read()))
+        self.logger.spam(f"sysrc.conf was read from {self.path}")
+        return data
+
+    def save(self) -> bool:
+
+        if self.changed is False:
+            self.logger.debug("sysrc.conf was not modified - skipping write")
+            return False
+
+        with open(self.path, "w") as rcconf:
+
+            output = ucl.dump(self, ucl.UCL_EMIT_CONFIG)
+            output = output.replace(" = \"", "=\"")
+            output = output.replace("\";\n", "\"\n")
+
+            self.logger.verbose(f"Writing sysrc.conf to {self.path}")
+
+            rcconf.write(output)
+            rcconf.truncate()
+            rcconf.close()
+
+            self._file_content_changed = False
+            self.logger.spam(output[:-1], indent=1)
+            return True
+
+    def __setitem__(self, key, value):
+        val = iocage.lib.helpers.to_string(
+            iocage.lib.helpers.parse_user_input(value),
+            true="YES",
+            false="NO"
+        )
+
+        try:
+            if self[key] == value:
+                return
+        except KeyError:
+            pass
+
+        dict.__setitem__(self, key, val)
+        self._file_content_changed = True
+
+    def __getitem__(self, key):
+        val = dict.__getitem__(self, key)
+        return iocage.lib.helpers.parse_user_input(val)

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -96,7 +96,7 @@ class InterfaceProp(dict):
         """
         try:
             bridge = iocage.lib.helpers.parse_none(bridge_if)
-        except:
+        except TypeError:
             bridge = iocage.lib.BridgeInterface.BridgeInterface(bridge_if)
 
         dict.__setitem__(self, jail_if, bridge)
@@ -118,9 +118,8 @@ class InterfaceProp(dict):
     def __notify(self) -> None:
         self.config.update_special_property(self.property_name)
 
-    def __empty_prop(self, key: str) -> str:
+    def __empty_prop(self, key: str) -> None:
         dict.__setitem__(self, key, None)
-        return None
 
     def to_string(self, value: dict) -> str:
         out = []

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -24,6 +24,7 @@
 import typing
 
 import iocage.lib.helpers
+import iocage.lib.BridgeInterface
 
 
 class InterfaceProp(dict):
@@ -72,7 +73,6 @@ class InterfaceProp(dict):
         self,
         jail_if: str,
         bridge_if: typing.Optional[str]=None,
-        secure: typing.Optional[bool]=False,
         notify: typing.Optional[bool]=True
     ) -> None:
         """
@@ -86,23 +86,20 @@ class InterfaceProp(dict):
             bridge_if (string): (optional)
                 Interface name of the host bridge device (VNET only)
 
-            secure (bool): (default=False)
-                Enabling this option adds an epair device between the bridge
-                and the jail, so that source IP and mac address cannot be
-                manipulated from inside the jail
+                A name beginning with ! (exclamation mark) enables the secure
+                mode, that adds a second bridge between the jail and the
+                target bridge, so that source IP and mac address cannot be
+                spoofed from within the jail
 
             notify (bool): (default=True)
                 Sends an update notification to the jail config instance
         """
-
         try:
-            bridge_if = iocage.lib.helpers.parse_none(bridge_if)
+            bridge = iocage.lib.helpers.parse_none(bridge_if)
         except:
-            pass
+            bridge = iocage.lib.BridgeInterface.BridgeInterface(bridge_if)
 
-        # ToDo: Implement secur option
-
-        dict.__setitem__(self, jail_if, bridge_if)
+        dict.__setitem__(self, jail_if, bridge)
 
         if notify is True:
             self.__notify()

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -86,10 +86,12 @@ class InterfaceProp(dict):
             bridge_if (string): (optional)
                 Interface name of the host bridge device (VNET only)
 
-                A name beginning with ! (exclamation mark) enables the secure
+                A name beginning with : (colon) enables the secure
                 mode, that adds a second bridge between the jail and the
                 target bridge, so that source IP and mac address cannot be
-                spoofed from within the jail
+                spoofed from within the jail.
+
+                  ioc set interfaces="vnet0::bridge0" my-jail
 
             notify (bool): (default=True)
                 Sends an update notification to the jail config instance

--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -150,7 +150,10 @@ class DistributionGenerator:
                 logger=self.logger,
                 eol=self._check_eol(x, eol_list)
             ),
-            available_releases
+            filter(
+                lambda y: len(y) > 0,
+                available_releases
+            )
         ))
 
     def _map_available_release(self, release_name: str) -> str:
@@ -256,7 +259,6 @@ class DistributionGenerator:
                 )
             )
         )
-
         return list(matches)
 
 

--- a/iocage/lib/Firewall.py
+++ b/iocage/lib/Firewall.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2014-2017, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import typing
+
+import sysctl
+
+import iocage.lib.helpers
+
+
+class Firewall:
+
+    IPFW_RULE_OFFSET: int = 10000
+    IPFW_COMMAND: str = "/sbin/ipfw"
+
+    def __init__(
+        self,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
+    ) -> None:
+
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+
+    @property
+    def _required_sysctl_properties(self):
+        return {
+            "net.inet.ip.fw.enable": 1,
+            "net.link.ether.ipfw": 1
+        }
+
+    @property
+    def ipfw_enabled(self):
+        requirements = self._required_sysctl_properties
+        requirement_keys = list(requirements.keys())
+        for item in sysctl.filter("net"):
+            if item.name in requirement_keys:
+                if item.value != requirements[item.name]:
+                    return False
+        return True
+
+    def delete_rule(self, rule_number: int) -> None:
+        iocage.lib.helpers.exec(
+            [
+                self.IPFW_COMMAND,
+                "-q", "delete",
+                str(rule_number + self.IPFW_RULE_OFFSET)
+            ],
+            ignore_error=True
+        )
+
+    def add_rule(
+        self,
+        rule_number: int,
+        rule_arguments: typing.List[str]
+    ) -> None:
+        iocage.lib.helpers.exec([
+            self.IPFW_COMMAND,
+            "-q", "add",
+            str(rule_number + self.IPFW_RULE_OFFSET)
+        ] + rule_arguments)

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -892,7 +892,7 @@ class JailGenerator(JailResource):
 
         for nic in nics:
 
-            bridges = list(self.config["interfaces"][nic])
+            bridge = self.config["interfaces"][nic]
 
             try:
                 ipv4_addresses = self.config["ip4_addr"][nic]
@@ -909,7 +909,7 @@ class JailGenerator(JailResource):
                 nic=nic,
                 ipv4_addresses=ipv4_addresses,
                 ipv6_addresses=ipv6_addresses,
-                bridges=bridges,
+                bridge=bridge,
                 logger=self.logger
             )
             networks.append(net)

--- a/iocage/lib/LaunchableResource.py
+++ b/iocage/lib/LaunchableResource.py
@@ -26,6 +26,7 @@ import libzfs
 import typing
 
 import iocage.lib.Config.Jail.File.RCConf
+import iocage.lib.Config.Jail.File.SysctlConf
 import iocage.lib.Resource
 
 # MyPy
@@ -36,6 +37,9 @@ import iocage.lib.Config.Jail.File
 class LaunchableResource(iocage.lib.Resource.Resource):
 
     _rc_conf: typing.Optional[iocage.lib.Config.Jail.File.RCConf.RCConf] = None
+    _sysctl_conf: typing.Optional[
+        iocage.lib.Config.Jail.File.SysctlConf.SysctlConf
+    ] = None
     config: iocage.lib.Config.Jail.JailConfig.JailConfig
 
     def __init__(self, *args, **kwargs) -> None:
@@ -90,3 +94,15 @@ class LaunchableResource(iocage.lib.Resource.Resource):
                 logger=self.logger
             )
         return self._rc_conf
+
+    @property
+    def sysctl_conf(
+        self
+    ) -> 'iocage.lib.Config.Jail.File.SysctlConf.SysctlConf':
+        if self._sysctl_conf is None:
+            sysctl_conf = iocage.lib.Config.Jail.File.SysctlConf.SysctlConf(
+                resource=self,
+                logger=self.logger
+            )
+            self._sysctl_conf = sysctl_conf
+        return self._sysctl_conf

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -32,6 +32,13 @@ import iocage.lib.helpers
 
 
 class Network:
+    """
+    VNET Jails may have access to different networks. Each is identified by a
+    network interface name that is unique to the jail.
+
+    A Network is configured with IPv4 and IPv6 addresses, a bridge interface
+    and an optional MTU.
+    """
 
     def __init__(
         self,
@@ -57,11 +64,20 @@ class Network:
         self.ipv6_addresses = ipv6_addresses or []
 
     def setup(self) -> None:
+        """
+        Jails call this method to create the network after being started
+        and configure the interfaces on jail and host side according to the
+        class attributes.
+        """
         if (self.vnet is True) and (self.bridge is None):
             raise iocage.lib.errors.VnetBridgeMissing(logger=self.logger)
         self.__create_vnet_iface()
 
     def teardown(self) -> None:
+        """
+        After Jails are stopped the devices that were used by it remain on the
+        host. This method is called by jails after they terminated.
+        """
         if self.vnet is True:
             self.__down_host_interface()
             if self.bridge.secure is True:
@@ -91,7 +107,13 @@ class Network:
 
     @property
     def nic_local_name(self) -> str:
+        """
+        The Network NIC is unique per jail. Iocage appends the running jails
+        JID to the device name, so that the epair device exposed to the jail
+        host can be easily identified by the user.
 
+        Example for JID 1: `vnet0:1`
+        """
         self.jail.require_jail_running(silent=True)
         return f"{self.nic}:{self.jail.jid}"
 

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -91,13 +91,9 @@ class Network:
 
     @property
     def nic_local_name(self) -> str:
+
         self.jail.require_jail_running(silent=True)
         return f"{self.nic}:{self.jail.jid}"
-
-    @property
-    def nic_group_name(self) -> str:
-        self.jail.require_jail_running(silent=True)
-        return f"ioc-{self.jail.jid}"
 
     @property
     def nic_local_description(self) -> str:
@@ -107,7 +103,6 @@ class Network:
         epair_a = iocage.lib.NetworkInterface.NetworkInterface(
             name="epair",
             create=True,
-            group=self.nic_group_name,
             logger=self.logger
         )
         epair_a_name = epair_a.name
@@ -136,7 +131,6 @@ class Network:
             mtu=self.mtu,
             description=self.nic_local_description,
             rename=self.nic_local_name,
-            group=self.nic_group_name,
             logger=self.logger
         )
 
@@ -164,7 +158,6 @@ class Network:
                 name="bridge",
                 create=True,
                 rename=f"{self.nic_local_name}:net",
-                group=self.nic_group_name,
             )
             bridge_name = bridge.name
             iocage.lib.NetworkInterface.NetworkInterface(

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -21,6 +21,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import typing
 import subprocess  # nosec: B404
 from hashlib import sha224
 
@@ -30,66 +31,68 @@ import iocage.lib.helpers
 
 
 class Network:
-    def __init__(self, jail,
-                 nic="vnet0",
-                 ipv4_addresses=None,
-                 ipv6_addresses=None,
-                 mtu=1500,
-                 bridges=None,
-                 logger=None):
+
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        nic: typing.Optional[str]="vnet0",
+        ipv4_addresses: typing.Optional[typing.List[str]]=None,
+        ipv6_addresses: typing.Optional[typing.List[str]]=None,
+        mtu: typing.Optional[int]=1500,
+        bridge: typing.Optional[str]=None,
+        logger: 'iocage.lib.Logger.Logger'=None
+    ) -> None:
 
         self.logger = iocage.lib.helpers.init_logger(self, logger)
 
-        if bridges is not None:
-            if not isinstance(bridges, list):
-                raise iocage.lib.errors.InvalidNetworkBridge(
-                    reason="Expected None or list of strings",
-                    logger=self.logger
-                )
-
         self.vnet = True
-        self.bridges = bridges
+        self.bridge = bridge
         self.jail = jail
         self.nic = nic
         self.mtu = mtu
         self.ipv4_addresses = ipv4_addresses or []
         self.ipv6_addresses = ipv6_addresses or []
 
-    def setup(self):
-        if self.vnet:
-            if not self.bridges or len(self.bridges) == 0:
-                raise iocage.lib.errors.VnetBridgeMissing(
-                    logger=self.logger
-                )
+    def setup(self) -> None:
+        if (self.vnet is True) and (self.bridge is None):
+            raise iocage.lib.errors.VnetBridgeMissing(logger=self.logger)
+        self.__create_vnet_iface()
 
-            jail_if, host_if = self.__create_vnet_iface()
+    def teardown(self) -> None:
+        if self.vnet is True:
+            self.__down_host_interface()
 
-    def teardown(self):
-        if self.vnet:
-            # down host_if
-            iocage.lib.NetworkInterface.NetworkInterface(
+    def __down_host_interface(self) -> None:
+        iocage.lib.NetworkInterface.NetworkInterface(
                 name=self.nic_local_name,
                 extra_settings=["destroy"],
                 logger=self.logger
             )
 
     @property
-    def nic_local_name(self):
+    def nic_local_name(self) -> str:
         self.jail.require_jail_running(silent=True)
         return f"{self.nic}:{self.jail.jid}"
 
     @property
-    def nic_local_description(self):
+    def nic_local_description(self) -> str:
         return f"associated with jail: {self.jail.humanreadable_name}"
 
-    def __create_vnet_iface(self):
-
-        # create new epair interface
+    def __create_new_epair_interface(self) -> typing.Tuple[str, str]:
         epair_a_cmd = ["/sbin/ifconfig", "epair", "create"]
         epair_a = subprocess.Popen(  # nosec: TODO: use exec helper?
             epair_a_cmd, stdout=subprocess.PIPE, shell=False).communicate()[0]
         epair_a = epair_a.decode("utf-8").strip()
         epair_b = f"{epair_a[:-1]}b"
+        return epair_a, epair_b
+
+    def __create_vnet_iface(
+        self
+    ) -> typing.Tuple[
+        iocage.lib.NetworkInterface.NetworkInterface,
+        iocage.lib.NetworkInterface.NetworkInterface
+    ]:
+        epair_a, epair_b = self.__create_new_epair_interface()
 
         try:
             mac_config = self.jail.config[f"{self.nic}_mac"]
@@ -108,25 +111,12 @@ class Network:
             logger=self.logger
         )
 
-        # add host_if to bridges
-        for bridge in self.bridges:
-            iocage.lib.NetworkInterface.NetworkInterface(
-                name=bridge,
-                addm=self.nic_local_name,
-                extra_settings=["up"],
-                logger=self.logger
-            )
-
-        # up host_if
-        iocage.lib.NetworkInterface.NetworkInterface(
-            name=self.nic_local_name,
-            extra_settings=["up"],
-            logger=self.logger
-        )
+        self.__add_host_id_to_bridge()
+        self.__up_host_if()
 
         # assign epair_b to jail
         self.__assign_vnet_iface_to_jail(epair_b, self.jail.identifier)
-
+        
         jail_if = iocage.lib.NetworkInterface.NetworkInterface(
             name=epair_b,
             mac=mac_b,
@@ -140,6 +130,21 @@ class Network:
         )
 
         return jail_if, host_if
+
+    def __add_host_id_to_bridge(self) -> None:
+        iocage.lib.NetworkInterface.NetworkInterface(
+            name=self.bridge,
+            addm=self.nic_local_name,
+            extra_settings=["up"],
+            logger=self.logger
+        )
+
+    def __up_host_if(self) -> None:
+        iocage.lib.NetworkInterface.NetworkInterface(
+            name=self.nic_local_name,
+            extra_settings=["up"],
+            logger=self.logger
+        )
 
     def __assign_vnet_iface_to_jail(self, nic, jail_name):
         iocage.lib.NetworkInterface.NetworkInterface(

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -153,6 +153,9 @@ class Network:
         if self.bridge is None:
             raise iocage.lib.errors.VnetBridgeMissing(logger=self.logger)
 
+        if self._is_secure_bridge is True:
+            self.firewall.ensure_firewall_enabled()
+
         epair_a, epair_b = self.__create_new_epair_interface()
 
         try:
@@ -192,11 +195,8 @@ class Network:
                 logger=self.logger
             )
 
-            # Firewall
-            if self.firewall.ipfw_enabled is False:
-                raise iocage.lib.errors.FirewallDisabled(logger=self.logger)
-
             self.logger.verbose("Configuring Secure VNET Firewall")
+
             for ipv4_address in self.ipv4_addresses:
                 address = ipv4_address.split("/", maxsplit=1)[0]
                 self.firewall.add_rule(self.jail.jid, [
@@ -234,6 +234,7 @@ class Network:
                 "via", host_if.name,
                 "out"
             ])
+            self.logger.debug("Firewall rules added")
 
             # bridge_name is the secondary bridge name in secure mode
             bridge = iocage.lib.NetworkInterface.NetworkInterface(

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -26,6 +26,10 @@ import iocage.lib.helpers
 
 
 class NetworkInterface:
+    """
+    NetworkInterface abstracts interface configurations and commands executed
+    on the host or within jails. This class is internally used by Network.
+    """
 
     ifconfig_command = "/sbin/ifconfig"
     dhclient_command = "/sbin/dhclient"
@@ -90,10 +94,16 @@ class NetworkInterface:
             self.apply()
 
     def apply(self) -> None:
+        """
+        Applies the interface settings and configures IP address
+        """
         self.apply_settings()
         self.apply_addresses()
 
     def apply_settings(self) -> str:
+        """
+        Only applies the interface settings
+        """
         command = [self.ifconfig_command, self.name]
 
         if self.create is True:
@@ -121,6 +131,9 @@ class NetworkInterface:
             self.rename = False
 
     def apply_addresses(self) -> None:
+        """
+        Applies the configured IP addresses
+        """
         self.__apply_addresses(self.ipv4_addresses, ipv6=False)
         self.__apply_addresses(self.ipv6_addresses, ipv6=True)
 

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -105,11 +105,14 @@ class NetworkInterface:
 
     def __apply_addresses(self, addresses, ipv6=False):
         family = "inet6" if ipv6 else "inet"
-        for address in addresses:
+        for i, address in enumerate(addresses):
             if (ipv6 is False) and (address.lower() == "dhcp"):
                 command = [self.dhclient_command, self.name]
             else:
                 command = [self.ifconfig_command, self.name, family, address]
+
+            if i > 0:
+                command.append("alias")
 
             self.exec(command)
 

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -76,8 +76,8 @@ class NetworkInterface:
         if addm:
             self.settings["addm"] = addm
 
-        # if group:
-        #     self.settings["group"] = group
+        if group:
+            self.settings["group"] = group
 
         # rename interface when applying settings next time
         if isinstance(rename, str):

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -122,7 +122,7 @@ class NetworkInterface:
         if self.extra_settings:
             command += self.extra_settings
 
-        self.exec(command)
+        self.__exec(command)
 
         # update name when the interface was renamed
         if self.rename:
@@ -148,12 +148,12 @@ class NetworkInterface:
             if i > 0:
                 command.append("alias")
 
-            self.exec(command)
+            self.__exec(command)
 
             if (ipv6 is True) and (address.lower() == "accept_rtadv"):
                 self.exec([self.rtsold_command, self.name])
 
-    def exec(
+    def __exec(
         self,
         command: typing.List[str],
         force_local: typing.Optional[bool]=False

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -32,7 +32,6 @@ class NetworkInterface:
     """
 
     ifconfig_command = "/sbin/ifconfig"
-    ipfw_command = "/sbin/ipfw"
     dhclient_command = "/sbin/dhclient"
     rtsold_command = "/usr/sbin/rtsold"
 

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -32,6 +32,7 @@ class NetworkInterface:
     """
 
     ifconfig_command = "/sbin/ifconfig"
+    ipfw_command = "/sbin/ipfw"
     dhclient_command = "/sbin/dhclient"
     rtsold_command = "/usr/sbin/rtsold"
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -430,6 +430,13 @@ class ZFSPoolUnavailable(IocageException):
 # Network
 
 
+class InvalidInterfaceName(IocageException):
+
+    def __init__(self, *args, **kwargs) -> None:
+        msg = "Invalid NIC name"
+        super().__init__(msg, *args, **kwargs)
+
+
 class VnetBridgeMissing(IocageException):
 
     def __init__(self, *args, **kwargs) -> None:

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -461,8 +461,22 @@ class InvalidNetworkBridge(IocageException, ValueError):
 
 class FirewallDisabled(IocageException):
 
+    def __init__(
+        self,
+        hint: typing.Optional[str]=None,
+        *args,
+        **kwargs
+    ) -> None:
+        msg = "IPFW is disabled"
+        if hint is not None:
+            msg += f": {hint}"
+        super().__init__(msg, *args, **kwargs)
+
+
+class FirewallCommandFailure(IocageException):
+
     def __init__(self, *args, **kwargs) -> None:
-        msg = "IPFW is disabled on the host system"
+        msg = "Firewall Command failed. Is IPFW enabled?"
         super().__init__(msg, *args, **kwargs)
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -459,6 +459,13 @@ class InvalidNetworkBridge(IocageException, ValueError):
         super().__init__(msg, *args, **kwargs)
 
 
+class FirewallDisabled(IocageException):
+
+    def __init__(self, *args, **kwargs) -> None:
+        msg = "IPFW is disabled on the host system"
+        super().__init__(msg, *args, **kwargs)
+
+
 # Release
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click==6.7
 texttable==0.9.0
 tqdm==4.17.1
 ucl
+sysctl


### PR DESCRIPTION
When multiple jails share a bridge device, a malicious jail may spoof its IP or MAC address. In a common network scenario, where the host bridges multiple IP addresses from the same uplink interface on a shared bridge device, the VNET jails may pretend to own any of the available addresses.

This feature uses a second epair device pair and an additional bridge to enforce a jails MAC and IP address and to apply additional filters with pf.

### Current VNET

1. HOST_UPLINK vtnet0
2. PUBLIC_BRIDGE (bridge1)
3. EPAIR_A (Host, vnet0:23)
4. EPAIR_B (Jail, vnet0)

### Secured VNET

1. HOST_UPLINK vtnet0
2. PUBLIC_BRIDGE (bridge1)
3. EPAIR_C (Host, **vnet0:23:a**)
5. EPAIR_D (Host, **vnet0:23:b**)
5. JAIL_BRIDGE (Host, **vnet0:23:net**)
6. EPAIR_A (Host, vnet0:23)
7. EPAIR_B (Jail, vnet0)

---

Introduces configuration syntax for pointopoint gateway routes as required to bridge in some network situations. For example:

```sh
ADDITIONAL_IP=10.23.42.2
GATEWAY=`netstat -4 -rn | grep ^default | awk '{ print $2 }'`
MAC_HETZNER_IP="00:53:00:10:C4:63"
MAC_RANDOM="00:53:0B:AD:C0:DE"

ioc set vnet0=on \
  interfaces="vnet0::bridge0" \
  vnet0_mac="$MAC_HETZNER_IP,$MAC_RANDOM" \
  ip4_add="vnet0|$ADDITIONAL_IP/32" \
  defaultrouter="$GATEWAY@vnet0" \
  my-jail
```

---

Currently there is no firewall support included. This means the jails are still able to spoof source addresses, but we have an anchor point to hook in layer-2 filtering.