### PR TITLE
make ioc start/stop --rc idempotent

### DIFF
--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -71,9 +71,9 @@ def autostart(
     ]
 ) -> None:
 
-    filters = ("boot=yes", "running=no",)
+    filters = ("boot=yes", "running=no", "template=no",)
 
-    ioc_jails = iocage.lib.Jails.JailsGenerator(
+    ioc_jails = iocage.lib.Jails.Jails(
         logger=logger,
         filters=filters
     )
@@ -84,34 +84,37 @@ def autostart(
         key=lambda x: x.config["priority"]
     )
 
-    start_jails(jails, logger=logger, print_function=print_function)
+    failed_jails = []
+    for jail in jails:
+        try:
+            jail.start()
+        except iocage.lib.errors.IocageException:
+            failed_jails.append(jail)
+            continue
+
+        logger.log(f"{jail.humanreadable_name} running as JID {jail.jid}")
+
+    if len(failed_jails) > 0:
+        exit(1)
+
+    exit(0)
 
 
 def normal(
-    filters: typing.Set[str],
+    filters: typing.Tuple[str, ...],
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
         [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
         None
     ]
 ) -> bool:
+
+    filters += ("template=no",)
 
     jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,
         filters=filters
     )
-
-    return start_jails(jails, logger=logger, print_function=print_function)
-
-
-def start_jails(
-    jails: typing.List[iocage.lib.Jails.JailsGenerator],
-    logger: iocage.lib.Logger.Logger,
-    print_function: typing.Callable[
-        [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
-        None
-    ]
-) -> bool:
 
     changed_jails = []
     failed_jails = []

--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -22,6 +22,7 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """start module for the cli."""
+import typing
 import click
 
 import iocage.lib.errors
@@ -62,7 +63,13 @@ def cli(ctx, rc, jails):
             exit(1)
 
 
-def autostart(logger, print_function):
+def autostart(
+    logger: iocage.lib.Logger.Logger,
+    print_function: typing.Callable[
+        [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
+        None
+    ]
+) -> None:
 
     filters = ("boot=yes", "running=no",)
 
@@ -80,7 +87,14 @@ def autostart(logger, print_function):
     start_jails(jails, logger=logger, print_function=print_function)
 
 
-def normal(filters, logger, print_function) -> bool:
+def normal(
+    filters: typing.Set[str],
+    logger: iocage.lib.Logger.Logger,
+    print_function: typing.Callable[
+        [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
+        None
+    ]
+) -> bool:
 
     jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,
@@ -90,7 +104,14 @@ def normal(filters, logger, print_function) -> bool:
     return start_jails(jails, logger=logger, print_function=print_function)
 
 
-def start_jails(jails, logger, print_function) -> bool:
+def start_jails(
+    jails: typing.List[iocage.lib.Jails.JailsGenerator],
+    logger: iocage.lib.Logger.Logger,
+    print_function: typing.Callable[
+        [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
+        None
+    ]
+) -> bool:
 
     changed_jails = []
     failed_jails = []

--- a/rc.d/ioc
+++ b/rc.d/ioc
@@ -26,6 +26,8 @@ load_rc_config "$name"
 
 start_cmd="ioc_start"
 stop_cmd="ioc_stop"
+status_cmd="ioc_status"
+extra_commands="status"
 export LANG=$ioc_lang
 
 ioc_start()
@@ -41,6 +43,21 @@ ioc_stop()
     if checkyesno ${rcvar}; then
         echo "* [I|O|C] stopping jails... "
         /usr/local/bin/ioc stop --rc
+    fi
+}
+
+ioc_status()
+{
+    if checkyesno ${rcvar}; then
+        echo -n "* [I|O|C] checking jails status..."
+	test -z "$(/usr/local/bin/ioc list boot=yes running=no template=no --no-header --output=name --output-format=list)"
+	status=$?
+	if test ${status} -eq 0; then
+            echo " OK"
+	else
+            echo " Failed!"
+	fi
+	exit $status
     fi
 }
 

--- a/rc.d/ioc
+++ b/rc.d/ioc
@@ -33,7 +33,7 @@ export LANG=$ioc_lang
 ioc_start()
 {
     if checkyesno ${rcvar}; then
-        echo "* [I|O|C] starting jails... "
+        echo "* [iocage] starting jails... "
         /usr/local/bin/ioc start --rc
     fi
 }
@@ -41,7 +41,7 @@ ioc_start()
 ioc_stop()
 {
     if checkyesno ${rcvar}; then
-        echo "* [I|O|C] stopping jails... "
+        echo "* [iocage] stopping jails... "
         /usr/local/bin/ioc stop --rc
     fi
 }
@@ -49,7 +49,7 @@ ioc_stop()
 ioc_status()
 {
     if checkyesno ${rcvar}; then
-        echo -n "* [I|O|C] checking jails status..."
+        echo -n "* [iocage] checking jails status..."
 	test -z "$(/usr/local/bin/ioc list boot=yes running=no template=no --no-header --output=name --output-format=list)"
 	status=$?
 	if test ${status} -eq 0; then


### PR DESCRIPTION
only filter the jails that aren't running already,
and don't fail when there aren't any.

simple, huh?! This fixes #227!