### PR TITLE
Fix: use /iocage as default mountpoint

### DIFF
--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -140,6 +140,9 @@ class Datasets:
                 "Claiming /iocage as mountpoint of the activated zpool"
             )
             mountpoint = iocage.lib.Types.AbsolutePath('/iocage')
+        
+        if self.root.mountpoint != mountpoint:
+            self.root.properties["mountpoint"] = libzfs.ZFSUserProperty(mountpoint)
 
     def _is_pool_active(self, pool: libzfs.ZFSPool) -> bool:
         return iocage.lib.helpers.parse_user_input(self._get_pool_property(

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -140,9 +140,10 @@ class Datasets:
                 "Claiming /iocage as mountpoint of the activated zpool"
             )
             mountpoint = iocage.lib.Types.AbsolutePath('/iocage')
-        
+
         if self.root.mountpoint != mountpoint:
-            self.root.properties["mountpoint"] = libzfs.ZFSUserProperty(mountpoint)
+            zfs_property = libzfs.ZFSUserProperty(mountpoint)
+            self.root.properties["mountpoint"] = zfs_property
 
     def _is_pool_active(self, pool: libzfs.ZFSPool) -> bool:
         return iocage.lib.helpers.parse_user_input(self._get_pool_property(


### PR DESCRIPTION
When activating a pool the preferred mountpoint for the iocage root dataset is `/iocage`.