### PR TITLE
Fix HardenedBSD detection when using CURRENT release

### DIFF
--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -106,7 +106,7 @@ class DistributionGenerator:
             release_path = f"/ftp/releases/{processor}/{processor}"
             return f"https://download.freebsd.org{release_path}"
         elif distribution == "HardenedBSD":
-            return f"http://jenkins.hardenedbsd.org/builds"
+            return f"https://jenkins.hardenedbsd.org/builds"
         else:
             raise iocage.lib.errors.DistributionUnknown(distribution)
 

--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -162,8 +162,7 @@ class DistributionGenerator:
     def _filter_available_releases(self, release_name: str) -> bool:
         if self.name != "HardenedBSD":
             return True
-        arch = release_name.split("-")[-2:][0]
-        return (self.host.processor == arch) is True
+        return (self.host.processor in release_name)
 
     def _get_eol_list(self) -> typing.List[str]:
         """Scrapes the FreeBSD website and returns a list of EOL RELEASES"""

--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -91,7 +91,7 @@ class DistributionGenerator:
 
     @property
     def name(self) -> str:
-        if os.uname()[2].endswith("-HBSD"):
+        if os.path.exists("/usr/sbin/hbsd-update"):
             return "HardenedBSD"
         else:
             return platform.system()

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -133,11 +133,10 @@ class HostGenerator:
 
     @property
     def userland_version(self) -> float:
-        return float(self.release_version.partition("-")[0])
+        return float(iocage.lib.helpers.get_userland_version())
 
     @property
     def release_version(self) -> str:
-
         if self.distribution.name == "FreeBSD":
             release_version_string = os.uname()[2]
             release_version_fragments = release_version_string.split("-")

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -101,7 +101,7 @@ def init_logger(
 def get_userland_version() -> str:
     f = open("/bin/freebsd-version", "r", re.MULTILINE, encoding="utf-8")
     # ToDo: move out of the function
-    pattern = re.compile("USERLAND_VERSION=\"(\d{2}\.\d)\-([A-z\-]+)\"")
+    pattern = re.compile("USERLAND_VERSION=\"(\d{2}\.\d)\-([A-z0-9\-]+)\"")
     content = f.read()
     match = pattern.search(content)
     return match[1]

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -98,6 +98,15 @@ def init_logger(
             return new_logger
 
 
+def get_userland_version() -> str:
+    f = open("/bin/freebsd-version", "r", re.MULTILINE, encoding="utf-8")
+    # ToDo: move out of the function
+    pattern = re.compile("USERLAND_VERSION=\"(\d{2}\.\d)\-([A-z\-]+)\"")
+    content = f.read()
+    match = pattern.search(content)
+    return match[1]
+
+
 def exec(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,


### PR DESCRIPTION
- When using a [custom kernel with CURRENT release](https://github.com/iocage/libiocage#custom-release-eg-running--current) on HardenedBSD the release version detection failed.
- The HardenedBSD uses HTTPS (see https://twitter.com/HardenedBSD/status/937477148503404544) 💜 