### PR TITLE
Explicitly return JailGenerator

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -85,8 +85,9 @@ class JailResource(iocage.lib.LaunchableResource.LaunchableResource):
             pass
 
         # is instance of Jail itself
-        if isinstance(self, iocage.lib.Jail.JailGenerator):
-            return self
+        if isinstance(self, JailGenerator):
+            jail = self  # type: JailGenerator
+            return jail
 
         raise Exception("This resource is not a jail or not linked to one")
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014-2017, iocage
 # All rights reserved.
 #


### PR DESCRIPTION
Suddenly MyPy started to complain about this in multiple branches. This PR addresses the issue in a single place.