### PR TITLE
Fix hbsd release list

### DIFF
--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -162,7 +162,8 @@ class DistributionGenerator:
     def _filter_available_releases(self, release_name: str) -> bool:
         if self.name != "HardenedBSD":
             return True
-        return (self.host.processor in release_name)
+        arch = release_name.split("-")[-2:][0]
+        return (self.host.processor == arch) is True
 
     def _get_eol_list(self) -> typing.List[str]:
         """Scrapes the FreeBSD website and returns a list of EOL RELEASES"""


### PR DESCRIPTION
This reverts commit c3d87ea to fix a regression in lists of available HardenedBSD releases.