### PR TITLE
Fix make install on FreeBSD and HardenedBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SERVER=""
 MYPYPATH = $(shell pwd)/.travis/mypy-stubs
 
 deps:
-	which pkg && pkg install -q -y libucl cython3 rsync python36 py36-libzfs py36-sysctl || true
+	which pkg && pkg install -q -y libucl py36-cython rsync python36 py36-libzfs py36-sysctl || true
 	python3.6 -m ensurepip
 	python3.6 -m pip install -Ur requirements.txt
 install: deps

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SERVER=""
 MYPYPATH = $(shell pwd)/.travis/mypy-stubs
 
 deps:
-	which pkg && pkg install -q -y libucl cython3 rsync python36 py36-libzfs || true
+	which pkg && pkg install -q -y libucl cython3 rsync python36 py36-libzfs py36-sysctl || true
 	python3.6 -m ensurepip
 	python3.6 -m pip install -Ur requirements.txt
 install: deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ click==6.7
 texttable==0.9.0
 tqdm==4.17.1
 ucl
-sysctl


### PR DESCRIPTION
- the `cython3` package was renamed to `py36-cython` (fixes HardenedBSD install)
- Python dependency `sysctl` is installed from package source since the pip install failed