### PR TITLE
Fix HardenedBSD release annotations

### DIFF
--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -176,6 +176,7 @@ class DistributionGenerator:
                 "Accept-Charset": "utf-8"
             }
         )
+        self.logger.verbose(f"Downloading EOL info from {self.eol_url}")
         with urllib.request.urlopen(request) as response:  # nosec: B310
 
             if response.getcode() != 200:  # noqa: T484

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -309,7 +309,7 @@ class ReleaseGenerator(ReleaseResource):
             else:
                 return False
 
-        return (host_release_name < release_name)
+        return (host_release_name[0:4] < release_name[0:4])
 
     def _pad_release_name(self, release_name: str, digits: int=4) -> str:
         """

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -309,7 +309,8 @@ class ReleaseGenerator(ReleaseResource):
             else:
                 return False
 
-        return (host_release_name[0:4] < release_name[0:4])
+        cropped_release_name = release_name[:len(host_release_name)]
+        return (host_release_name < cropped_release_name)
 
     def _pad_release_name(self, release_name: str, digits: int=4) -> str:
         """

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -250,7 +250,7 @@ class ReleaseGenerator(ReleaseResource):
             annotations.add("Newer than Host")
 
         if len(annotations) > 0:
-            return f"{self.name} ({', ('.join(annotations)})"
+            return f"{self.name} ({', '.join(annotations)})"
 
         return f"{self.name}"
 


### PR DESCRIPTION
fixes #242

- Release annotations (`Newer than host` or `EOL`) now work for specialized HardenedBSD branches like `11-STABLE-libressl`
- STABLE releases are no longer listed as EOL until they are explicitly unsupported