### PR TITLE
Rollback snapshots recursively

### DIFF
--- a/iocage/lib/VersionedResource.py
+++ b/iocage/lib/VersionedResource.py
@@ -67,7 +67,8 @@ class ResourceSnapshots:
 
         snapshot = self._get_snapshot(snapshot_name)
         try:
-            snapshot.rollback(force=force)
+            for snap in reversed(list(snapshot.parent.snapshots_recursive)):
+                snap.rollback(force=force)
         except libzfs.ZFSException as e:
             raise iocage.lib.errors.SnapshotRollback(
                 reason=str(e),


### PR DESCRIPTION
libzfs (and py-libzfs) does not recursively rollback to snapshots, so that libiocage needs to iterate over the list of snapshots