### PR TITLE
MacAddress data type

### DIFF
--- a/iocage/lib/MacAddress.py
+++ b/iocage/lib/MacAddress.py
@@ -57,7 +57,7 @@ class MacAddress:
 
     def __str__(self) -> str:
         address = self.address
-        mac_bytes = [address[i:i+2] for i in range(0, len(address), 2)]
+        mac_bytes = [address[i:(i + 2)] for i in range(0, len(address), 2)]
         return ":".join(mac_bytes)
 
 
@@ -77,6 +77,8 @@ class MacAddressPair:
     ) -> None:
 
         self.logger = iocage.lib.helpers.init_logger(self, logger)
+        a: MacAddress
+        b: MacAddress
 
         if isinstance(mac_pair, str):
             a, b = [MacAddress(
@@ -87,7 +89,7 @@ class MacAddressPair:
             a = MacAddress(mac_pair[0], logger=self.logger)
             b = MacAddress(mac_pair[1], logger=self.logger)
         else:
-            a, b = mac_pair
+            a, b = mac_pair  # type: ignore
 
         self.a = a
         self.b = b

--- a/iocage/lib/MacAddress.py
+++ b/iocage/lib/MacAddress.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import typing
+
+import iocage.lib.helpers
+import iocage.lib.errors
+
+
+class MacAddress:
+
+    _address: str
+
+    def __init__(
+        self,
+        mac_address: str,
+        logger: 'iocage.lib.Logger.Logger'
+    ) -> None:
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+        self.address = mac_address
+
+    @property
+    def address(self):
+        return self._address
+
+    @address.setter
+    def address(self, mac_address: str) -> None:
+        address = mac_address.replace(":", "").replace("-", "").lower()
+
+        if len(address) != 12:
+            raise iocage.lib.errors.InvalidMacAddress(
+                mac_address=mac_address,
+                logger=self.logger
+            )
+
+        self._address = address
+
+    def __str__(self) -> str:
+        address = self.address
+        mac_bytes = [address[i:i+2] for i in range(0, len(address), 2)]
+        return ":".join(mac_bytes)
+
+
+class MacAddressPair:
+
+    a: str
+    b: str
+
+    def __init__(
+        self,
+        mac_pair: typing.Union[
+            str,
+            typing.Tuple[MacAddress, MacAddress],
+            typing.Tuple[str, str]
+        ],
+        logger: 'iocage.lib.Logger.Logger'
+    ) -> None:
+
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+
+        if isinstance(mac_pair, str):
+            a, b = [MacAddress(
+                mac_address=x,
+                logger=self.logger
+            ) for x in mac_pair.split(",")]
+        elif isinstance(mac_pair[0], str):
+            a = MacAddress(mac_pair[0], logger=self.logger)
+            b = MacAddress(mac_pair[1], logger=self.logger)
+        else:
+            a, b = mac_pair
+
+        self.a = a
+        self.b = b
+
+    def __str__(self) -> str:
+        return f"{self.a},{self.b}"

--- a/iocage/lib/MacAddress.py
+++ b/iocage/lib/MacAddress.py
@@ -63,8 +63,8 @@ class MacAddress:
 
 class MacAddressPair:
 
-    a: str
-    b: str
+    a: MacAddress
+    b: MacAddress
 
     def __init__(
         self,

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -170,7 +170,6 @@ class Network:
                 mac_config,
                 logger=self.logger
             )
-            
 
         host_if = iocage.lib.NetworkInterface.NetworkInterface(
             name=epair_a,

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -159,7 +159,10 @@ class Network:
 
         epair_a, epair_b = self.__create_new_epair_interface()
 
-        mac_config = self.jail.config[f"{self.nic}_mac"]
+        try:
+            mac_config = self.jail.config[f"{self.nic}_mac"]
+        except KeyError:
+            mac_config = None
         if mac_config is None or mac_config == "":
             mac_address_pair = iocage.lib.MacAddress.MacAddressPair(
                 mac_config,
@@ -304,7 +307,9 @@ class Network:
         prefix = self.jail.config["mac_prefix"]
         return f"{prefix}{m.hexdigest()[0:12-len(prefix)]}"
 
-    def __generate_mac_address_pair(self) -> typing.Tuple[str, str]:
+    def __generate_mac_address_pair(
+        self
+    ) -> iocage.lib.MacAddress.MacAddressPair:
         mac_a = self.__generate_mac_bytes()
         mac_b = hex(int(mac_a, 16) + 1)[2:].zfill(12)
         return iocage.lib.MacAddress.MacAddressPair(

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -164,12 +164,13 @@ class Network:
         except KeyError:
             mac_config = None
         if mac_config is None or mac_config == "":
+            mac_address_pair = self.__generate_mac_address_pair()
+        else:
             mac_address_pair = iocage.lib.MacAddress.MacAddressPair(
                 mac_config,
                 logger=self.logger
             )
-        else:
-            mac_address_pair = self.__generate_mac_address_pair()
+            
 
         host_if = iocage.lib.NetworkInterface.NetworkInterface(
             name=epair_a,

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -44,7 +44,9 @@ class NetworkInterface:
         create: typing.Optional[bool]=False,
         ipv4_addresses: typing.Optional[typing.List[str]]=[],
         ipv6_addresses: typing.Optional[typing.List[str]]=[],
-        mac: typing.Optional[str]=None,
+        mac: typing.Optional[
+            typing.Union[str, 'iocage.lib.MacAddress.MacAddress']
+        ]=None,
         mtu: typing.Optional[int]=None,
         description: typing.Optional[str]=None,
         rename: typing.Optional[str]=None,
@@ -117,13 +119,13 @@ class NetworkInterface:
 
         for key in self.settings:
             value = self.settings[key]
-            if isinstance(value, str):
+            if not isinstance(value, list):
                 values = [value]
             else:
                 values = value
             for value in values:
                 command.append(key)
-                command.append(value)
+                command.append(str(value))
 
         if self.extra_settings:
             command += self.extra_settings

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -257,12 +257,13 @@ class InvalidJailConfigAddress(InvalidJailConfigValue):
         )
 
 
-class InvalidMacAddress(ValueError, IocageException):
+class InvalidMacAddress(IocageException, ValueError):
 
     def __init__(self, mac_address: str, **kwargs) -> None:
         reason = f"invalid mac address: \"{mac_address}\""
-        super().__init__(
-            reason=reason,
+        IocageException.__init__(
+            self,
+            message=reason,
             **kwargs
         )
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -257,6 +257,16 @@ class InvalidJailConfigAddress(InvalidJailConfigValue):
         )
 
 
+class InvalidMacAddress(IocageException, ValueError):
+
+    def __init__(self, mac_address: str, **kwargs) -> None:
+        reason = f"invalid mac address: \"{mac_address}\""
+        super().__init__(
+            reason=reason,
+            **kwargs
+        )
+
+
 class JailConfigNotFound(IocageException):
 
     def __init__(self, config_type: str, *args, **kwargs) -> None:

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -257,7 +257,7 @@ class InvalidJailConfigAddress(InvalidJailConfigValue):
         )
 
 
-class InvalidMacAddress(IocageException, ValueError):
+class InvalidMacAddress(ValueError, IocageException):
 
     def __init__(self, mac_address: str, **kwargs) -> None:
         reason = f"invalid mac address: \"{mac_address}\""


### PR DESCRIPTION
The MacAddress and MacAddressPair types replace MAC address handling as string and format addresses consistently.

This fixes an issue on HardenedBSD where the MAC address format without separating colons was not accepted by ipfw.