### PR TITLE
Print configured ip4_addr and ip6_addr in ioc list

### DIFF
--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -213,14 +213,14 @@ def _list_output_comumns(
             columns += [
                 "running",
                 "release",
-                "ip4.addr",
-                "ip6.addr"
+                "ip4_addr",
+                "ip6_addr"
             ]
         else:
             columns += [
                 "running",
                 "release",
-                "ip4.addr"
+                "ip4_addr"
             ]
 
         return columns


### PR DESCRIPTION
Prints the raw value of configured ip4_addr and ip5_addr (with `--long` option).

Can later on be enhanced to read real IP aliases from running jails.