### PR TITLE
ip addresses are comma separated

### DIFF
--- a/iocage/lib/Config/Jail/Properties/Addresses.py
+++ b/iocage/lib/Config/Jail/Properties/Addresses.py
@@ -103,7 +103,7 @@ class AddressesProp(dict):
             dict.__init__(self, data)
             return
 
-        ip_addresses = data.split(" ")
+        ip_addresses = data.split(",")
         for ip_address_string in ip_addresses:
 
             try:


### PR DESCRIPTION
The assumption that `ip4_addr` and `ip6_addr` are separated by a whitespace was wrong was replaced with comma separation.