### PR TITLE
comma delimiter for IPs and interface names

### DIFF
--- a/iocage/lib/Config/Jail/Properties/Addresses.py
+++ b/iocage/lib/Config/Jail/Properties/Addresses.py
@@ -71,6 +71,7 @@ class AddressesProp(dict):
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str = "ip4_address"
     skip_on_error: bool
+    delimiter: str = ","
 
     def __init__(
         self,
@@ -190,4 +191,4 @@ class AddressesProp(dict):
         for nic in self:
             for address in self[nic]:
                 out.append(f"{nic}|{address}")
-        return str(" ".join(out))
+        return str(self.delimiter.join(out))

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -31,6 +31,7 @@ class InterfaceProp(dict):
 
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str = "interfaces"
+    delimiter: str = ","
 
     def __init__(
         self,
@@ -128,7 +129,7 @@ class InterfaceProp(dict):
         for jail_if in value:
             bridge_if = self[jail_if]
             out.append(f"{jail_if}:{bridge_if}")
-        return " ".join(out)
+        return self.delimiter.join(out)
 
     def __str__(self) -> str:
         return self.to_string(value=self)


### PR DESCRIPTION
#251 adapted comma separated IP address input. The internal processing was not updated, so that saving configurations resulted in the old pattern (whitespace separated addresses or interface names).