### PR TITLE
Move installation of rc script to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,19 @@ deps:
 	python3.6 -m pip install -Ur requirements.txt
 install: deps
 	python3.6 -m pip install -U .
+	@if [ -f /usr/local/etc/init.d ]; then \
+		install -m 0755 rc.d/ioc /usr/local/etc/init.d; \
+	else \
+		install -m 0755 rc.d/ioc /usr/local/etc/rc.d; \
+	fi
 install-dev: deps
 	python3.6 -m pip install flake8-mutable flake8-builtins flake8-mypy bandit bandit-high-entropy-string
 	python3.6 -m pip install -e .
+	@if [ -f /usr/local/etc/init.d ]; then \
+		install -m 0755 -o root -g wheel rc.d/ioc /usr/local/etc/init.d; \
+	else \
+		install -m 0755 -o root -g wheel rc.d/ioc /usr/local/etc/rc.d; \
+	fi
 install-travis:
 	python3.6 -m pip install flake8-mutable flake8-builtins flake8-mypy bandit bandit-high-entropy-string
 uninstall:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import os.path
 import sys
 from setuptools import find_packages, setup
 from setuptools.command import easy_install
@@ -62,11 +61,6 @@ def get_args(cls, dist, header=None):
 easy_install.ScriptWriter.get_args = get_args
 
 
-if os.path.isdir("/usr/local/etc/init.d"):
-    _data = [('/usr/local/etc/init.d', ['rc.d/ioc'])]
-else:
-    _data = [('/usr/local/etc/rc.d', ['rc.d/ioc'])]
-
 if sys.version_info < (3, 6):
     exit("Only Python 3.6 and higher is supported.")
 
@@ -90,6 +84,5 @@ setup(
             'ioc=iocage.cli:cli'
         ]
     },
-    data_files=_data,
     tests_require=['pytest', 'pytest-cov', 'pytest-pep8']
 )


### PR DESCRIPTION
Hey there!

I'm trying to develop an application using libiocage, and I noticed that it currently doesn't install cleanly in a virtualenv, since `setup.py` tries to install an rcscript.

I'm suggesting a change where we install the rcscript as part of the `Makefile`, so that developers can develop programs inside virtualenvs without having to mess around with popping rcscripts in their dev boxes. I'm not wedded to this implementation, and am happy to make changes.

Thanks!!

- [x] Explain the feature
- [x] Read [CONTRIBUTING.md](https://github.com/iocage/iocage/blob/master/CONTRIBUTING.md)
