### PR TITLE
Add confirmation dialog before deleting data

### DIFF
--- a/iocage/cli/destroy.py
+++ b/iocage/cli/destroy.py
@@ -88,6 +88,13 @@ def cli(ctx,
         logger.error("No target matched your input")
         exit(1)
 
+    if not force:
+        message = "These {} will be deleted:\n  - {}\nAre you sure?".format(
+            "releases" if release else "jails",
+            "\n  - ".join([r.getstring('name') for r in resources])
+        )
+        click.confirm(message, default=False, abort=True)
+
     failed_items = []
 
     for item in resources:


### PR DESCRIPTION
Fixes #146. Adds a dialog asking the user for confirmation when calling `destroy`, except when the force flag `-f` is supplied.
For example:
```
# ioc create -n foo
foo successfully created from 11.1-RELEASE!
# ioc destroy name=foo
These jails will be deleted:
  - foo
Are you sure? [y/N]:
Aborted!
# ioc create -n bar
bar successfully created from 11.1-RELEASE!
# ioc destroy name=foo,bar
These jails will be deleted:
  - bar
  - foo
Are you sure? [y/N]: y
/iocage/jails/bar destroyed
/iocage/jails/foo destroyed

# ioc destroy -r 10.4-RELEASE
These releases will be deleted:
  - 10.4-RELEASE
Are you sure? [y/N]:
Aborted!
# ioc destroy -fr 10.4-RELEASE
/iocage/releases/10.4-RELEASE destroyed
```

