### PR TITLE
do not print input filters in cli/destroy

### DIFF
--- a/iocage/cli/destroy.py
+++ b/iocage/cli/destroy.py
@@ -84,7 +84,6 @@ def cli(ctx,
     )
 
     if len(list(resources)) == 0:
-        print(filters)
         logger.error("No target matched your input")
         exit(1)
 


### PR DESCRIPTION
fixes #257

Removes a debug print from the `ioc destroy` CLI command.