### PR TITLE
do not print header when -NH flag is set

### DIFF
--- a/iocage/cli/shared/output.py
+++ b/iocage/cli/shared/output.py
@@ -52,6 +52,6 @@ def print_table(
     if show_header is True:
         table.add_rows([table_head] + table_data)
     else:
-        table.add_rows(table_data)
+        table.add_rows(table_data, header=False)
 
     print(table.draw())


### PR DESCRIPTION
fixes #220

The first line of the list output without header was indented as regular header. With this change textable is explicitly advised to omit the header.