### PR TITLE
Add JID to IOCAGE_ env variables

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1439,6 +1439,7 @@ class JailGenerator(JailResource):
             jail_env[prop_name] = self.getstring(prop)
 
         jail_env["IOCAGE_JAIL_PATH"] = self.root_dataset.mountpoint
+        jail_env["IOCAGE_JID"] = str(self.jid)
 
         return jail_env
 


### PR DESCRIPTION
This fix adds JID to the list of ENV variables. It's set to None in case of **prestart** and to JID in case of **poststart**