### PR TITLE
Fix/iocage legacy filter template mismatch

### DIFF
--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -112,7 +112,7 @@ def _normal(
     ]
 ) -> bool:
 
-    filters += ("template=no",)
+    filters += ("template=no,-",)
 
     jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -95,13 +95,12 @@ def _normal(
         filters=filters
     )
 
-    if len(jails) == 0:
-        logger.error("No jail selector provided")
-        return False
+    found_jails = False
 
     changed_jails = []
     failed_jails = []
     for jail in jails:
+        found_jails = True
         try:
             print_function(jail.stop(force=force))
         except iocage.lib.errors.IocageException:
@@ -110,6 +109,10 @@ def _normal(
 
         logger.log(f"{jail.name} stopped")
         changed_jails.append(jail)
+
+    if found_jails is False:
+        logger.error("No jail selector provided")
+        return False
 
     if len(failed_jails) > 0:
         exit(1)

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -436,15 +436,16 @@ class ListableResource(list, Resource):
         for child_dataset in self.dataset.children:
 
             name = self._get_asset_name_from_dataset(child_dataset)
-            if self._filters is not None and \
-               self._filters.match_key("name", name) is not True:
-                # Skip all jails that do not even match the name
-                continue
+            if self._filters is not None:
+                if self._filters.match_key("name", name) is not True:
+                    # Skip all jails that do not even match the name
+                    continue
 
             # ToDo: Do not load jail if filters do not require to
             resource = self._get_resource_from_dataset(child_dataset)
             if self._filters is not None:
                 if self._filters.match_resource(resource):
+                    print("YIELD", child_dataset.name)
                     yield resource
 
     def __len__(self) -> int:


### PR DESCRIPTION
fixes #69

iocage_legacy sets the template configuration property explicitly to "None" when creating a jail. This causes the injected filter `template=no` not to match because even though both values are not `True`.