### PR TITLE
fix creation of release root datasets when fetching

### DIFF
--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -418,6 +418,7 @@ class ReleaseGenerator(ReleaseResource):
 
             # ToDo: allow to reach this for forced re-fetch
             self.create_resource()
+            self.get_or_create_dataset("root")
             self._ensure_dataset_mounted()
 
             yield releasePrepareStorageEvent.end()

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -308,7 +308,10 @@ class ReleaseGenerator(ReleaseResource):
         if self.exists is False:
             return False
 
-        root_dir_index = os.listdir(self.root_dataset.mountpoint)
+        try:
+            root_dir_index = os.listdir(self.root_dataset.mountpoint)
+        except libzfs.ZFSException:
+            return False
 
         for expected_directory in ["dev", "var", "etc"]:
             if expected_directory not in root_dir_index:


### PR DESCRIPTION
A regression in https://github.com/iocage/libiocage/commit/c0b68e40d71aba87f59175f4d1d7cd69ba1413ef causes fetching releases to fail because the releases root dataset does not exist. This changes re-apply the missing function call.