### PR TITLE
Fix dependency issues with py36-ucl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SERVER=""
 MYPYPATH = $(shell pwd)/.travis/mypy-stubs
 
 deps:
-	which pkg && pkg install -q -y libucl py36-ucl py36-cython rsync python36 py36-libzfs py36-sysctl || true
+	which pkg && pkg install -q -y libucl py36-cython rsync python36 py36-libzfs py36-sysctl || true
 	python3.6 -m ensurepip
 	python3.6 -m pip install -Ur requirements.txt
 install: deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==6.7
 texttable==0.9.0
 tqdm==4.17.1
+ucl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 texttable==0.9.0
 tqdm==4.17.1
-ucl
+ucl=0.8.0


### PR DESCRIPTION
fixes #277

The Python package `ucl` with the recently released version `0.8.1` fails installing. Pinning the dependency to `0.8.0` solves this issue temporary.