### PR TITLE
use duplicate equal sign to pin python dependency ucl==0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
 texttable==0.9.0
 tqdm==4.17.1
-ucl=0.8.0
+ucl==0.8.0


### PR DESCRIPTION
A general rule of thumb: Even simple looking stuff must be teste. No excuse!

Fixes a regression introduced in #278 (specificly https://github.com/iocage/libiocage/pull/278/commits/7ad9066988a38a44e97c35f2b2a260e7b54ddcf8)