### PR TITLE
Add jail config option allow_mount_fdescfs

### DIFF
--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -96,6 +96,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "allow_mount_devfs": 0,
         "allow_mount_nullfs": 0,
         "allow_mount_procfs": 0,
+        "allow_mount_fdescfs": 0,
         "allow_mount_zfs": 0,
         "allow_mount_tmpfs": 0,
         "allow_quotas": 0,

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1115,6 +1115,7 @@ class JailGenerator(JailResource):
             f"allow.mount.devfs={self._get_value('allow_mount_devfs')}",
             f"allow.mount.nullfs={self._get_value('allow_mount_nullfs')}",
             f"allow.mount.procfs={self._get_value('allow_mount_procfs')}",
+            f"allow.mount.fdescfs={self._get_value('allow_mount_fdescfs')}",
             f"allow.mount.zfs={self._allow_mount_zfs}",
             f"allow.quotas={self._get_value('allow_quotas')}",
             f"allow.socket_af={self._get_value('allow_socket_af')}",


### PR DESCRIPTION
Adds the boolean jail configuration property `allow_mount_fdescfs`.