### PR TITLE
Feature: Multi-Pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ uninstall:
 	python3.6 -m pip uninstall -y iocage
 check:
 	flake8 --version
-	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107
+	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107,A002
 	bandit --skip B404 --exclude iocage/tests/ -r .
 test:
 	pytest iocage/tests --zpool $(ZPOOL)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ make install
 
 Please note: this will build `py-libzfs` from source, which will require `/usr/src` to be populated.
 
+## Configuration
+
+### Active ZFS pool
+
+libiocage iterates over existing ZFS pools and stops at the first one with ZFS property `org.freebsd.ioc:active` set to `yes`. This behavior is the default used by other iocage variants and is restricted to one pool managed by iocage
+
+### Root Datasets configured in /etc/rc.conf
+
+When iocage datasets are specified in the jail hosts `/etc/rc.conf`, libiocage prefers them over activated pool lookups. Every ZFS filesystem that iocage should use as root dataset has a distinct name and is configured as `ioc_dataset_<NAME>="zroot/some-dataset/iocage"`, for example:
+
+```
+$ cat /etc/rc.conf | grep ^ioc_dataset
+ioc_dataset_mysource="zroot/mysource/iocage"
+ioc_dataset_othersource="zroot/iocage"
+```
+
+iocage commands default to the first root data source specified in the file.
+Operations can be pointed to an alternative root by prefixing the subject with the source name followed by a slash.
+
+```sh
+ioc create -b -n othersource/myjail
+ioc rename othersource/myjail myjail2
+```
+
+When `othersource` is the only datasource with a jail named `myjail` the above operation would have worked without explicitly stating the dataset name.
+
 ## Usage
 
 ### Library
@@ -34,7 +60,8 @@ jail.create("11.1-RELEASE")
 
 ### CLI
 
-Libiocage comes bundles with a CLI tool called `ioc`. It is inspired by the command line interface of [iocage](https://github.com/iocage/iocage) but meant to be developed along with the library and to spike on new features.
+Libiocage comes bundles with a CLI tool called `ioc`.
+It is inspired by the command line interface of [iocage](https://github.com/iocage/iocage) but meant to be developed along with the library and to spike on new features.
 
 ### Custom Release (e.g. running -CURRENT)
 

--- a/iocage/cli/activate.py
+++ b/iocage/cli/activate.py
@@ -53,7 +53,7 @@ def cli(ctx, zpool, mountpoint):
 
     try:
         datasets = iocage.lib.Datasets.Datasets(
-            pool=iocage_pool,
+            root_dataset=f"{iocage_pool.name}/iocage",
             zfs=zfs,
             logger=logger
         )

--- a/iocage/cli/activate.py
+++ b/iocage/cli/activate.py
@@ -53,10 +53,10 @@ def cli(ctx, zpool, mountpoint):
 
     try:
         datasets = iocage.lib.Datasets.Datasets(
-            root_dataset=f"{iocage_pool.name}/iocage",
             zfs=zfs,
             logger=logger
         )
+        datasets.attach_source("iocage", f"{iocage_pool.name}/iocage")
         datasets.activate(mountpoint=mountpoint)
         logger.log(f"ZFS pool '{zpool}' activated")
     except iocage.lib.errors.IocageException:

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -84,11 +84,6 @@ def validate_count(
                    " jails.")
 @click.option("--no-fetch", is_flag=True, default=False,
               help="Do not automatically fetch releases")
-@click.option(
-    "--dataset", "-d",
-    multiple=True,
-    help="Limit the command to certain root datasets specified in rc.conf."
-)
 @click.argument("props", nargs=-1)
 def cli(
     ctx: IocageClickContext,
@@ -100,8 +95,7 @@ def cli(
     basejail_type: str,
     empty: bool,
     name: str,
-    no_fetch: bool,
-    dataset: typing.Tuple[str, ...]
+    no_fetch: bool
 ) -> None:
     """Create iocage jails."""
     logger = ctx.parent.logger
@@ -117,10 +111,9 @@ def cli(
         )
         release = host.release_version
 
-    if name:
-        jail_data["name"] = name
-
-    root_datasets_name = dataset[0] if len(dataset) > 0 else None
+    resource_selector = iocage.lib.ResourceSelector.ResourceSelector(name)
+    jail_data["name"] = resource_selector.name
+    root_datasets_name = resource_selector.source_name
 
     if release is not None:
         resource = iocage.lib.Release.ReleaseGenerator(

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -188,7 +188,9 @@ def cli(
             jail.create(resource)
             msg = (
                 f"{jail.humanreadable_name} successfully created"
-                f" from {resource.name}!{suffix}"
+                f" from {resource.name}"
+                f" on {jail.source}" if len(host.datasets) > 1 else ""
+                f"!{suffix}"
             )
             logger.log(msg)
         except iocage.lib.errors.IocageException:

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -84,6 +84,11 @@ def validate_count(
                    " jails.")
 @click.option("--no-fetch", is_flag=True, default=False,
               help="Do not automatically fetch releases")
+@click.option(
+    "--dataset", "-d",
+    multiple=True,
+    help="Limit the command to certain root datasets specified in rc.conf."
+)
 @click.argument("props", nargs=-1)
 def cli(
     ctx: IocageClickContext,
@@ -95,7 +100,8 @@ def cli(
     basejail_type: str,
     empty: bool,
     name: str,
-    no_fetch: bool
+    no_fetch: bool,
+    dataset: typing.Tuple[str, ...]
 ) -> None:
     """Create iocage jails."""
     logger = ctx.parent.logger
@@ -114,9 +120,12 @@ def cli(
     if name:
         jail_data["name"] = name
 
+    root_datasets_name = dataset[0] if len(dataset) > 0 else None
+
     if release is not None:
         resource = iocage.lib.Release.ReleaseGenerator(
             name=release,
+            root_datasets_name=root_datasets_name,
             logger=logger,
             host=host,
             zfs=zfs
@@ -137,11 +146,12 @@ def cli(
                 exit(1)
             else:
                 logger.spam(msg)
-                logger.log("Automatically fetching release '{resource.name}'")
+                logger.log(f"Automatically fetching release '{resource.name}'")
                 resource.fetch()
     elif template is not None:
         resource = iocage.lib.Jail.JailGenerator(
             template,
+            root_datasets_name=root_datasets_name,
             logger=logger,
             host=host,
             zfs=zfs
@@ -174,6 +184,7 @@ def cli(
 
         jail = iocage.lib.Jail.JailGenerator(
             jail_data,
+            root_datasets_name=root_datasets_name,
             logger=logger,
             host=host,
             zfs=zfs,

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -116,13 +116,16 @@ def cli(
     root_datasets_name = resource_selector.source_name
 
     if release is not None:
-        resource = iocage.lib.Release.ReleaseGenerator(
-            name=release,
-            root_datasets_name=root_datasets_name,
-            logger=logger,
-            host=host,
-            zfs=zfs
-        )
+        try:
+            resource = iocage.lib.Release.ReleaseGenerator(
+                name=release,
+                root_datasets_name=root_datasets_name,
+                logger=logger,
+                host=host,
+                zfs=zfs
+            )
+        except iocage.lib.errors.IocageException:
+            exit(1)
         if not resource.fetched:
             if not resource.available:
                 logger.error(

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -186,11 +186,11 @@ def cli(
         suffix = f" ({i}/{count})" if count > 1 else ""
         try:
             jail.create(resource)
+            msg_source = f" on {jail.source}" if len(host.datasets) > 1 else ""
             msg = (
                 f"{jail.humanreadable_name} successfully created"
                 f" from {resource.name}"
-                f" on {jail.source}" if len(host.datasets) > 1 else ""
-                f"!{suffix}"
+                f"{msg_source}!{suffix}"
             )
             logger.log(msg)
         except iocage.lib.errors.IocageException:

--- a/iocage/cli/deactivate.py
+++ b/iocage/cli/deactivate.py
@@ -52,10 +52,10 @@ def cli(ctx, zpool):
 
     try:
         datasets = iocage.lib.Datasets.Datasets(
-            pool=iocage_pool,
             zfs=zfs,
             logger=logger
         )
+        datasets.attach_source("iocage", f"{iocage_pool.name}/iocage")
         if datasets.is_pool_active():
             datasets.deactivate()
             logger.log(f"ZFS pool '{zpool}' deactivated")

--- a/iocage/cli/destroy.py
+++ b/iocage/cli/destroy.py
@@ -96,7 +96,7 @@ def cli(
     if not force:
         message = "These {} will be deleted:\n  - {}\nAre you sure?".format(
             "releases" if release else "jails",
-            "\n  - ".join([r.getstring('name') for r in resources])
+            "\n  - ".join([r.getstring('full_name') for r in resources])
         )
         click.confirm(message, default=False, abort=True)
 

--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -85,6 +85,11 @@ __rootcmd__ = True
         "(Deprecared: renamed to --file)"
     )
 )
+@click.option(
+    "--dataset", "-d",
+    multiple=True,
+    help="Limit the command to certain root datasets specified in rc.conf."
+)
 def cli(  # noqa: T484
     ctx: IocageClickContext,
     **kwargs

--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -85,11 +85,6 @@ __rootcmd__ = True
         "(Deprecared: renamed to --file)"
     )
 )
-@click.option(
-    "--dataset", "-d",
-    multiple=True,
-    help="Limit the command to certain root datasets specified in rc.conf."
-)
 def cli(  # noqa: T484
     ctx: IocageClickContext,
     **kwargs

--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -46,7 +46,7 @@ __rootcmd__ = True
     help="Remote URL with path to the release/snapshot directory"
 )
 @click.option(  # noqa: T484
-    "--file", "-F",
+    "--file", "-F",  # noqa: T484
     multiple=True,
     help="Specify the files to fetch from the mirror."
 )

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -60,11 +60,6 @@ supported_output_formats = ['table', 'csv', 'list', 'json']
               type=click.Choice(supported_output_formats))
 @click.option("--header/--no-header", "-H/-NH", is_flag=True, default=True,
               help="Show or hide column name heading.")
-@click.option(
-    "--dataset", "-d",
-    multiple=True,
-    help="Limit the command to certain root datasets specified in rc.conf."
-)
 @click.argument("filters", nargs=-1)
 def cli(
     ctx: IocageClickContext,
@@ -75,7 +70,6 @@ def cli(
     _sort: typing.Optional[str],
     output: typing.Optional[str],
     output_format: str,
-    dataset: typing.Tuple[str, ...],
     filters: typing.Tuple[str, ...]
 ) -> None:
     """List jails in various formats."""
@@ -111,7 +105,7 @@ def cli(
 
             if (dataset_type == "base"):
                 resources_class = iocage.lib.Releases.ReleasesGenerator
-                columns = ["name"]
+                columns = ["full_name"]
             else:
                 resources_class = iocage.lib.Jails.JailsGenerator
                 columns = _list_output_comumns(output, _long)
@@ -120,13 +114,11 @@ def cli(
                 else:
                     filters += ("template=no,-",)
 
-            sources = dataset if len(dataset) > 0 else None
             resources = resources_class(
                 logger=logger,
                 host=host,
                 # ToDo: allow quoted whitespaces from user inputs
-                filters=filters,
-                sources=sources
+                filters=filters
             )
 
     except iocage.lib.errors.IocageException:

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -98,7 +98,7 @@ def cli(
     try:
 
         if (dataset_type == "base") and (remote is True):
-            columns = ["name"]
+            columns = ["name", "eol"]
             resources = host.distribution.releases
 
         else:

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -134,7 +134,7 @@ def _autostop(
     force: bool=True
 ) -> None:
     """Stop a bunch of autostarted jails."""
-    filters = ("boot=yes", "running=yes", "template=no",)
+    filters = ("running=yes", "template=no",)
 
     ioc_jails = iocage.lib.Jails.Jails(
         logger=logger,

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -117,7 +117,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "stop_timeout": "30",
         "mount_procfs": "0",
         "mount_devfs": "1",
-        "mount_fdescfs": "1",
+        "mount_fdescfs": "0",
         "securelevel": "2",
         "tags": [],
         "template": False,

--- a/iocage/lib/Config/Jail/File/Prototype.py
+++ b/iocage/lib/Config/Jail/File/Prototype.py
@@ -59,7 +59,7 @@ class ResourceConfig:
         return os.path.realpath(os.path.abspath(filepath))
 
 
-class ResourceConfigFile(ResourceConfig, dict):
+class ConfigFile(dict):
     """Abstraction of UCL file based config files in Resources."""
 
     _file: str
@@ -67,7 +67,6 @@ class ResourceConfigFile(ResourceConfig, dict):
 
     def __init__(
         self,
-        resource: 'iocage.lib.LaunchableResource.LaunchableResource',
         file: typing.Optional[str]=None,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None
     ) -> None:
@@ -81,18 +80,12 @@ class ResourceConfigFile(ResourceConfig, dict):
         if file is not None:
             self._file = file
 
-        self.resource = resource
         self._read_file()
 
     @property
     def path(self) -> str:
         """Absolute path to the file."""
-        path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
-        self._require_path_relative_to_resource(
-            filepath=path,
-            resource=self.resource
-        )
-        return os.path.abspath(path)
+        return self.file
 
     @property
     def file(self) -> str:
@@ -223,3 +216,27 @@ class ResourceConfigFile(ResourceConfig, dict):
         if isinstance(output, str) or isinstance(output, bool):
             return output
         return None
+
+
+class ResourceConfigFile(ConfigFile, ResourceConfig):
+    """Abstraction of UCL file based config files in Resources."""
+
+    def __init__(
+        self,
+        resource: 'iocage.lib.LaunchableResource.LaunchableResource',
+        file: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
+    ) -> None:
+
+        self.resource = resource
+        ConfigFile.__init__(self, file=file, logger=logger)
+
+    @property
+    def path(self) -> str:
+        """Absolute path to the file."""
+        path = f"{self.resource.root_dataset.mountpoint}/{self.file}"
+        self._require_path_relative_to_resource(
+            filepath=path,
+            resource=self.resource
+        )
+        return os.path.abspath(path)

--- a/iocage/lib/Config/Jail/File/Prototype.py
+++ b/iocage/lib/Config/Jail/File/Prototype.py
@@ -131,9 +131,9 @@ class ConfigFile(dict):
         except (FileNotFoundError, ValueError):
             data = {}
 
-        existing_keys = set(self.keys())
-        new_keys = set(data.keys())
-        delete_keys = existing_keys - new_keys
+        existing_keys = list(self.keys())
+        new_keys = list(data.keys())
+        delete_keys = [x for x in existing_keys if x not in new_keys]
 
         if delete is True:
             for key in delete_keys:

--- a/iocage/lib/Config/Jail/File/RCConf.py
+++ b/iocage/lib/Config/Jail/File/RCConf.py
@@ -29,7 +29,13 @@ import iocage.lib.Config.Jail.File.Prototype
 import iocage.lib.Logger
 
 
-class RCConf(iocage.lib.Config.Jail.File.Prototype.ResourceConfigFile):
+class RCConf(iocage.lib.Config.Jail.File.Prototype.ConfigFile):
     """Model a rc.conf file."""
+
+    _file: str = "/etc/rc.conf"
+
+
+class ResourceRCConf(iocage.lib.Config.Jail.File.Prototype.ResourceConfigFile):
+    """Model a rc.conf file relative to a resource."""
 
     _file: str = "/etc/rc.conf"

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -146,12 +146,18 @@ class Datasets(dict):
         self.attach_sources(_e)
 
     def _configure_from_pool_property(self) -> None:
+        active_pool = self._active_pool_or_none
+        if active_pool is None:
+            # raise internally without logging
+            raise iocage.lib.errors.IocageNotActivated()
         self.attach_sources(dict(iocage=f"{self.active_pool.name}/iocage"))
         self.logger.spam(f"Found active ZFS pool {self.active_pool.name}")
 
     @property
     def main(self) -> 'iocage.lib.Datasets.Datasets':
         """Return the source that was attached first."""
+        if self.main_datasets_name is None:
+            raise iocage.lib.errors.IocageNotActivated(logger=self.logger)
         return self[self.main_datasets_name]
 
     def find_root_datasets_name(self, dataset_name: str) -> str:

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -150,7 +150,7 @@ class Datasets(dict):
         if active_pool is None:
             # raise internally without logging
             raise iocage.lib.errors.IocageNotActivated()
-        self.attach_sources(dict(iocage=f"{self.active_pool.name}/iocage"))
+        self.attach_sources(dict(ioc=f"{self.active_pool.name}/iocage"))
         self.logger.spam(f"Found active ZFS pool {self.active_pool.name}")
 
     @property

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -208,7 +208,7 @@ class Datasets(dict):
         rc_conf = iocage.lib.Config.Jail.File.RCConf.RCConf(
             logger=self.logger
         )
-        rc_conf_keys = filter(lambda x: x.startswith(prefix), rc_conf)
+        rc_conf_keys = list(filter(lambda x: x.startswith(prefix), rc_conf))
 
         output = dict()
         for rc_conf_key in rc_conf_keys:

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -122,8 +122,17 @@ class Datasets(dict):
 
         try:
             self._configure_from_rc_conf()
+            return
         except RCConfEmptyException:
+            pass
+
+        try:
             self._configure_from_pool_property()
+            return
+        except iocage.lib.errors.IocageNotActivated:
+            pass
+
+        self.logger.spam("No iocage root dataset configuration found")
 
     def _configure_from_rc_conf(self) -> None:
         enabled_datasets = self._read_root_datasets_from_rc_conf()
@@ -132,7 +141,8 @@ class Datasets(dict):
         self.attach_sources(enabled_datasets)
 
     def _configure_from_pool_property(self) -> None:
-        self.attach_sources(dict(iocage=self.active_pool))
+        self.attach_sources(dict(iocage=f"{self.active_pool.name}/iocage"))
+        self.logger.spam(f"Found active ZFS pool {self.active_pool.name}")
 
     @property
     def main(self) -> 'iocage.lib.Datasets.Datasets':

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -95,8 +95,9 @@ class RootDatasets:
         asset = self.zfs.get_or_create_dataset(
             f"{self.root.name}/{asset_name}"
         )
-        self._datasets[asset_name] = asset
-        return asset
+        _asset: libzfs.ZFSDataset = asset
+        self._datasets[asset_name] = _asset
+        return _asset
 
 
 class Datasets(dict):
@@ -138,7 +139,11 @@ class Datasets(dict):
         enabled_datasets = self._read_root_datasets_from_rc_conf()
         if len(enabled_datasets) == 0:
             raise RCConfEmptyException()
-        self.attach_sources(enabled_datasets)
+
+        _e: typing.Dict[str, typing.Union[str, libzfs.ZFSDataset]] = {}
+        for key, value in enabled_datasets.items():
+            _e[key] = value
+        self.attach_sources(_e)
 
     def _configure_from_pool_property(self) -> None:
         self.attach_sources(dict(iocage=f"{self.active_pool.name}/iocage"))
@@ -220,7 +225,7 @@ class Datasets(dict):
         )
         rc_conf_keys = list(filter(lambda x: x.startswith(prefix), rc_conf))
 
-        output = dict()
+        output: typing.Dict[str, str] = {}
         for rc_conf_key in rc_conf_keys:
             datasets_name = rc_conf_key[len(prefix):]
             output[datasets_name] = rc_conf[rc_conf_key]

--- a/iocage/lib/Filter.py
+++ b/iocage/lib/Filter.py
@@ -266,7 +266,10 @@ class Terms(list):
             prop, value = user_input.split("=", maxsplit=1)
         except ValueError:
             prop = "name"
-            value = iocage.lib.ResourceSelector.ResourceSelector(user_input)
+            value = user_input
+
+        if prop == "name":
+            value = iocage.lib.ResourceSelector.ResourceSelector(value)
 
         terms.append(Term(prop, value))
 

--- a/iocage/lib/Filter.py
+++ b/iocage/lib/Filter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2017, iocage
+# Copyright (c) 2014-2018, iocage
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,11 @@ import iocage.lib.Resource
 import iocage.lib.ResourceSelector
 
 _ResourceSelector = iocage.lib.ResourceSelector.ResourceSelector
-_TermValuesType = typing.Union[str, typing.List[str], _ResourceSelector]
+_TermValuesType = typing.Union[
+    str,
+    typing.List[str],
+    iocage.lib.ResourceSelector.ResourceSelector
+]
 
 
 def match_filter(value: str, filter_string: str) -> bool:
@@ -135,9 +139,7 @@ class Term(list):
         has_humanreadble_length = (len(filter_string) == 8)
         has_no_globs = not self._filter_string_has_globs(filter_string)
         if (has_humanreadble_length and has_no_globs) is True:
-            shortname = iocage.lib.helpers.to_humanreadable_name(
-                input_value
-            )
+            shortname = iocage.lib.helpers.to_humanreadable_name(value)
             if shortname == filter_string:
                 return True
 
@@ -251,7 +253,7 @@ class Terms(list):
             resource_selector = term[0]
             if resource_selector.source_name is None:
                 return True
-            return resource_selector.source_name == source_name
+            return (resource_selector.source_name == source_name) is True
 
         # no name term or none at all
         return True

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -50,10 +50,12 @@ class HostGenerator:
     _class_distribution = iocage.lib.Distribution.DistributionGenerator
 
     _devfs: iocage.lib.DevfsRules.DevfsRules
+    _rc_conf: 'iocage.lib.Config.Jail.File.RCConf'
     _defaults: iocage.lib.Resource.DefaultResource
     _defaults_initialized = False
     releases_dataset: libzfs.ZFSDataset
-    datasets: iocage.lib.Datasets.Datasets
+    datasets: typing.Dict[str, iocage.lib.Datasets.Datasets]
+    main_datasets_name: str
     distribution: _distribution_types
 
     branch_pattern = re.compile(
@@ -72,9 +74,6 @@ class HostGenerator:
 
     def __init__(
         self,
-        root_dataset: typing.Optional[
-            typing.Union[str, libzfs.ZFSDataset]
-        ]=None,
         defaults: typing.Optional[iocage.lib.Resource.DefaultResource]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None
@@ -83,11 +82,25 @@ class HostGenerator:
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
 
-        self.datasets = iocage.lib.Datasets.Datasets(
-            logger=self.logger,
-            zfs=self.zfs,
-            root_dataset=root_dataset
-        )
+        self.datasets = {}
+        root_datasets = self._read_root_datasets_from_rc_conf()
+        if len(root_datasets) == 0:
+            # legacy support (before ioc_dataset_<name> in rc.conf)
+            main_datasets_name = "iocage"
+            self.main_datasets_name = main_datasets_name
+            self.datasets[main_datasets_name] = iocage.lib.Datasets.Datasets(
+                logger=self.logger,
+                zfs=self.zfs
+            )
+        else:
+            for key, value in root_datasets.items():
+                if len(self.datasets) == 0:
+                    self.main_datasets_name = key
+                self.datasets[key] = (iocage.lib.Datasets.Datasets(
+                    logger=self.logger,
+                    zfs=self.zfs,
+                    root_dataset=value
+                ))
 
         self.distribution = self._class_distribution(
             host=self,
@@ -106,10 +119,22 @@ class HostGenerator:
             self._defaults = defaults
         else:
             self._defaults = iocage.lib.Resource.DefaultResource(
-                dataset=self.datasets.root,
+                dataset=self.main_datasets.root,
                 logger=self.logger,
                 zfs=self.zfs
             )
+
+    @property
+    def main_datasets(self) -> 'iocage.lib.Datasets.Datasets':
+        return self.datasets[self.main_datasets_name]
+
+    def get_root_datasets(
+        self,
+        dataset_name: typing.Optional[str]=None
+    ) -> 'iocage.lib.Datasets.Datasets':
+        if dataset_name is None:
+            return self.main_datasets
+        return self.datasets[dataset_name]
 
     @property
     def defaults(self) -> 'iocage.lib.Resource.DefaultResource':
@@ -166,6 +191,27 @@ class HostGenerator:
     def processor(self) -> str:
         """Return the hosts processor architecture."""
         return platform.processor()
+
+    @property
+    def rc_conf(self) -> 'iocage.lib.Config.Jail.File.RCConf.RCConf':
+        if "_rc_conf" not in self.__dir__():
+            import iocage.lib.Config.Jail.File.RCConf
+            self._rc_conf = iocage.lib.Config.Jail.File.RCConf.RCConf(
+                logger=self.logger
+            )
+        return self._rc_conf
+
+    def _read_root_datasets_from_rc_conf(self) -> typing.Dict[str, str]:
+        prefix = "ioc_dataset_"
+
+        rc_conf = self.rc_conf
+        rc_conf_keys = filter(lambda x: x.startswith(prefix), rc_conf)
+
+        output = dict()
+        for rc_conf_key in rc_conf_keys:
+            datasets_name = rc_conf_key[len(prefix):]
+            output[datasets_name] = rc_conf[rc_conf_key]
+        return output
 
 
 class Host(HostGenerator):

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -72,7 +72,9 @@ class HostGenerator:
 
     def __init__(
         self,
-        root_dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        root_dataset: typing.Optional[
+            typing.Union[str, libzfs.ZFSDataset]
+        ]=None,
         defaults: typing.Optional[iocage.lib.Resource.DefaultResource]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None
@@ -84,7 +86,7 @@ class HostGenerator:
         self.datasets = iocage.lib.Datasets.Datasets(
             logger=self.logger,
             zfs=self.zfs,
-            root=root_dataset
+            root_dataset=root_dataset
         )
 
         self.distribution = self._class_distribution(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -546,7 +546,7 @@ class JailGenerator(JailResource):
                 [value],
                 logger=self.logger,
                 env=self.env,
-                shell=True
+                shell=True  # nosec: B604
             )
             return (child, stdout, stderr, )
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1608,7 +1608,7 @@ class JailGenerator(JailResource):
     def identifier(self) -> str:
         """Return the jail id used in snapshots, jls, etc."""
         config = object.__getattribute__(self, 'config')
-        return f"ioc-{self.source}-{config['id']}"
+        return f"{self.source}-{config['id']}"
 
     @property
     def release(self) -> 'iocage.lib.Release.ReleaseGenerator':

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -573,10 +573,16 @@ class JailGenerator(JailResource):
         events: typing.Any = iocage.lib.events
         jailDestroyEvent = events.JailDestroy(self)
         jailNetworkTeardownEvent = events.JailNetworkTeardown(self)
+        jailServicesStopEvent = events.JailServicesStop(self)
         jailMountTeardownEvent = events.JailMountTeardown(self)
         JailZfsShareUmount = events.JailZfsShareUmount(jail=self)
 
         self._run_hook("prestop")
+
+        if self.config["exec_stop"] is not None:
+            yield jailServicesStopEvent.begin()
+            self._run_hook("stop")
+            yield jailServicesStopEvent.end()
 
         yield jailDestroyEvent.begin()
         self._destroy_jail()
@@ -1174,7 +1180,6 @@ class JailGenerator(JailResource):
             f"allow.mount.zfs={self._allow_mount_zfs}",
             f"allow.quotas={self._get_value('allow_quotas')}",
             f"allow.socket_af={self._get_value('allow_socket_af')}",
-            f"exec.stop={self._get_value('exec_stop')}",
             f"exec.clean={self._get_value('exec_clean')}",
             f"exec.timeout={self._get_value('exec_timeout')}",
             f"stop.timeout={self._get_value('stop_timeout')}",

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -62,8 +62,8 @@ class JailResource(
     def __init__(  # noqa: T484
         self,
         host: 'iocage.lib.Host.HostGenerator',
-        root_datasets_name: typing.Optional[str]=None,
         jail: typing.Optional['JailGenerator']=None,
+        root_datasets_name: typing.Optional[str]=None,
         **kwargs
     ) -> None:
 
@@ -280,8 +280,11 @@ class JailGenerator(JailResource):
 
         if isinstance(data, str):
             data = {
-                "id": self._resolve_name(data)
+                "id": data
             }
+
+        if "id" in data.keys():
+            data["id"] = self._resolve_name(data["id"])
 
         JailResource.__init__(
             self,
@@ -1488,9 +1491,9 @@ class JailGenerator(JailResource):
             name=text
         )
 
-        root_datasets = resource_selector.filter_datasets(self.datasets)
+        root_datasets = resource_selector.filter_datasets(self.host.datasets)
 
-        for datasets_key, datasets in root_datasets:
+        for datasets_key, datasets in root_datasets.items():
             for dataset in list(datasets.jails.children):
                 dataset_name = str(
                     dataset.name[(len(datasets.jails.name) + 1):]
@@ -1498,7 +1501,8 @@ class JailGenerator(JailResource):
                 humanreadable_name = iocage.lib.helpers.to_humanreadable_name(
                     dataset_name
                 )
-                if text in [dataset_name, humanreadable_name]:
+                possible_names = [dataset_name, humanreadable_name]
+                if resource_selector.name in possible_names:
                     return dataset_name
 
         raise iocage.lib.errors.JailNotFound(text, logger=self.logger)

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -575,7 +575,6 @@ class JailGenerator(JailResource):
         jailNetworkTeardownEvent = events.JailNetworkTeardown(self)
         jailServicesStopEvent = events.JailServicesStop(self)
         jailMountTeardownEvent = events.JailMountTeardown(self)
-        JailZfsShareUmount = events.JailZfsShareUmount(jail=self)
 
         self._run_hook("prestop")
 
@@ -596,15 +595,6 @@ class JailGenerator(JailResource):
         yield jailMountTeardownEvent.begin()
         self._teardown_mounts()
         yield jailMountTeardownEvent.end()
-
-        if self.config["jail_zfs"] is True:
-            yield JailZfsShareUmount.begin()
-            share_storage = iocage.lib.ZFSShareStorage.ZFSShareStorage(
-                jail=self,
-                logger=self.logger
-            )
-            share_storage.umount_zfs_shares()
-            yield JailZfsShareUmount.end()
 
         self.state.query()
 
@@ -790,7 +780,6 @@ class JailGenerator(JailResource):
         jailDestroyEvent = events.JailDestroy(self)
         jailNetworkTeardownEvent = events.JailNetworkTeardown(self)
         jailMountTeardownEvent = events.JailMountTeardown(self)
-        JailZfsShareUmount = events.JailZfsShareUmount(jail=self)
 
         try:
             self._run_hook("prestop")
@@ -821,18 +810,6 @@ class JailGenerator(JailResource):
             yield jailMountTeardownEvent.end()
         except Exception as e:
             yield jailMountTeardownEvent.skip()
-
-        if self.config["jail_zfs"] is True:
-            yield JailZfsShareUmount.begin()
-            try:
-                share_storage = iocage.lib.ZFSShareStorage.ZFSShareStorage(
-                    jail=self,
-                    logger=self.logger
-                )
-                share_storage.umount_zfs_shares()
-                yield JailZfsShareUmount.end()
-            except Exception as e:
-                yield JailZfsShareUmount.skip()
 
         try:
             self.state.query()

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -536,9 +536,10 @@ class JailGenerator(JailResource):
             )
         else:
             child, stdout, stderr = iocage.lib.helpers.exec(
-                command,
+                [value],
                 logger=self.logger,
-                env=self.env
+                env=self.env,
+                shell=True
             )
             return (child, stdout, stderr, )
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -184,8 +184,11 @@ class JailResource(
         return f"{base_name}/{jail_id}"
 
     @property
-    def source(self):
-        return self.host.datasets.find_root_datasets_name(self.dataset_name)
+    def source(self) -> str:
+        """Return the name of the jails source root datasets."""
+        return str(
+            self.host.datasets.find_root_datasets_name(self.dataset_name)
+        )
 
     def get(self, key: str) -> typing.Any:
         """Get a config value from the jail or defer to its resource."""
@@ -1486,7 +1489,6 @@ class JailGenerator(JailResource):
             name=text
         )
 
-        jail_name = resource_selector.name
         root_datasets = resource_selector.filter_datasets(self.datasets)
 
         for datasets_key, datasets in root_datasets:
@@ -1497,7 +1499,6 @@ class JailGenerator(JailResource):
                 humanreadable_name = iocage.lib.helpers.to_humanreadable_name(
                     dataset_name
                 )
-
                 if text in [dataset_name, humanreadable_name]:
                     return dataset_name
 
@@ -1509,7 +1510,15 @@ class JailGenerator(JailResource):
         return str(self.config["id"])
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
+        """
+        Return the full identifier of a jail.
+
+        When more than one root dataset is managed by iocage, the full source
+        and name are returned. Otherwise just the name.
+
+        For example `mydataset/jailname` or just `jailname`.
+        """
         if len(self.host.datasets) > 1:
             return f"{self.source}/{self.name}"
         else:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -694,6 +694,9 @@ class JailGenerator(JailResource):
         self.require_jail_stopped()
         self.require_storage_backend()
 
+        if iocage.lib.helpers.validate_name(new_name) is False:
+            raise iocage.lib.errors.InvalidJailName(logger=self.logger)
+
         current_id = self.config["id"]
         current_mountpoint = self.dataset.mountpoint
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -44,6 +44,7 @@ import iocage.lib.ZFSBasejailStorage
 import iocage.lib.ZFSShareStorage
 import iocage.lib.LaunchableResource
 import iocage.lib.VersionedResource
+import iocage.lib.ResourceSelector
 import iocage.lib.Config.Jail.File.Fstab
 
 
@@ -1477,11 +1478,18 @@ class JailGenerator(JailResource):
 
     def _resolve_name(self, text: str) -> str:
 
+        print(text)
         if (text is None) or (len(text) == 0):
             raise iocage.lib.errors.JailNotSupplied(logger=self.logger)
 
-        for datasets_key, datasets in self.host.datasets.items():
-            print(datasets_key)
+        resource_selector = iocage.lib.ResourceSelector.ResourceSelector(
+            name=text
+        )
+
+        jail_name = resource_selector.name
+        root_datasets = resource_selector.filter_datasets(self.datasets)
+
+        for datasets_key, datasets in root_datasets:
             for dataset in list(datasets.jails.children):
                 dataset_name = str(
                     dataset.name[(len(datasets.jails.name) + 1):]

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1481,7 +1481,6 @@ class JailGenerator(JailResource):
 
     def _resolve_name(self, text: str) -> str:
 
-        print(text)
         if (text is None) or (len(text) == 0):
             raise iocage.lib.errors.JailNotSupplied(logger=self.logger)
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -574,6 +574,7 @@ class JailGenerator(JailResource):
         jailDestroyEvent = events.JailDestroy(self)
         jailNetworkTeardownEvent = events.JailNetworkTeardown(self)
         jailMountTeardownEvent = events.JailMountTeardown(self)
+        JailZfsShareUmount = events.JailZfsShareUmount(jail=self)
 
         self._run_hook("prestop")
 
@@ -589,6 +590,15 @@ class JailGenerator(JailResource):
         yield jailMountTeardownEvent.begin()
         self._teardown_mounts()
         yield jailMountTeardownEvent.end()
+
+        if self.config["jail_zfs"] is True:
+            yield JailZfsShareUmount.begin()
+            share_storage = iocage.lib.ZFSShareStorage.ZFSShareStorage(
+                jail=self,
+                logger=self.logger
+            )
+            share_storage.umount_zfs_shares()
+            yield JailZfsShareUmount.end()
 
         self.state.query()
 
@@ -774,6 +784,7 @@ class JailGenerator(JailResource):
         jailDestroyEvent = events.JailDestroy(self)
         jailNetworkTeardownEvent = events.JailNetworkTeardown(self)
         jailMountTeardownEvent = events.JailMountTeardown(self)
+        JailZfsShareUmount = events.JailZfsShareUmount(jail=self)
 
         try:
             self._run_hook("prestop")
@@ -804,6 +815,18 @@ class JailGenerator(JailResource):
             yield jailMountTeardownEvent.end()
         except Exception as e:
             yield jailMountTeardownEvent.skip()
+
+        if self.config["jail_zfs"] is True:
+            yield JailZfsShareUmount.begin()
+            try:
+                share_storage = iocage.lib.ZFSShareStorage.ZFSShareStorage(
+                    jail=self,
+                    logger=self.logger
+                )
+                share_storage.umount_zfs_shares()
+                yield JailZfsShareUmount.end()
+            except Exception as e:
+                yield JailZfsShareUmount.skip()
 
         try:
             self.state.query()

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -63,7 +63,6 @@ class JailResource(
         **kwargs
     ) -> None:
 
-        self.__jails_dataset_name = host.datasets.jails.name
         self.host = iocage.lib.helpers.init_host(self, host)
 
         if jail is not None:
@@ -165,7 +164,7 @@ class JailResource(
         if jail_id is None:
             raise iocage.lib.errors.JailUnknownIdentifier()
 
-        return f"{self.__jails_dataset_name}/{jail_id}"
+        return f"{self.host.main_datasets.jails.name}/{jail_id}"
 
     def get(self, key: str) -> typing.Any:
         """Get a config value from the jail or defer to its resource."""
@@ -1458,17 +1457,17 @@ class JailGenerator(JailResource):
         if (text is None) or (len(text) == 0):
             raise iocage.lib.errors.JailNotSupplied(logger=self.logger)
 
-        jails_dataset = self.host.datasets.jails
+        for datasets_key, datasets in self.host.datasets.items():
+            for dataset in list(datasets.jails.children):
+                dataset_name = str(
+                    dataset.name[(len(datasets.jails.name) + 1):]
+                )
+                humanreadable_name = iocage.lib.helpers.to_humanreadable_name(
+                    dataset_name
+                )
 
-        for dataset in list(jails_dataset.children):
-
-            dataset_name = str(dataset.name[(len(jails_dataset.name) + 1):])
-            humanreadable_name = iocage.lib.helpers.to_humanreadable_name(
-                dataset_name
-            )
-
-            if text in [dataset_name, humanreadable_name]:
-                return dataset_name
+                if text in [dataset_name, humanreadable_name]:
+                    return dataset_name
 
         raise iocage.lib.errors.JailNotFound(text, logger=self.logger)
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -989,7 +989,7 @@ class JailGenerator(JailResource):
 
             Example: ["/usr/bin/whoami"]
         """
-        command = ["/usr/sbin/jexec", self.identifier] + command
+        command = ["/usr/sbin/jexec", str(self.jid)] + command
 
         child, stdout, stderr = iocage.lib.helpers.exec(
             command,
@@ -1015,7 +1015,7 @@ class JailGenerator(JailResource):
         stdout, stdin = iocage.lib.helpers.exec_passthru(
             [
                 "/usr/sbin/jexec",
-                self.identifier
+                str(self.jid)
             ] + command,
             logger=self.logger
         )

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1582,7 +1582,7 @@ class JailGenerator(JailResource):
     def identifier(self) -> str:
         """Return the jail id used in snapshots, jls, etc."""
         config = object.__getattribute__(self, 'config')
-        return f"ioc-{config['id']}"
+        return f"ioc-{self.source}-{config['id']}"
 
     @property
     def release(self) -> 'iocage.lib.Release.ReleaseGenerator':

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -71,7 +71,6 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
             logger=logger
         )
 
-
     def _create_resource_instance(  # noqa: T484
         self,
         dataset: libzfs.ZFSDataset,

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -49,7 +49,6 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
     def __init__(
         self,
         filters: typing.Optional[iocage.lib.Filter.Terms]=None,
-        sources: typing.Optional[typing.Tuple[str, ...]]=None,
         host: typing.Optional['iocage.lib.Host.HostGenerator']=None,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None,
         zfs: typing.Optional['iocage.lib.ZFS.ZFS']=None
@@ -61,10 +60,7 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
 
         iocage.lib.ListableResource.ListableResource.__init__(
             self,
-            sources=iocage.lib.Datasets.filter_datasets(
-                datasets=self.host.datasets,
-                sources=sources
-            ),
+            sources=self.host.datasets,
             namespace="jails",
             filters=filters,
             zfs=zfs,
@@ -78,10 +74,13 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
         **class_kwargs
     ) -> iocage.lib.Jail.JailGenerator:
 
+        sources = self.sources
         class_kwargs["data"] = {
             "id": dataset.name.split("/").pop()
         }
-        class_kwargs["dataset"] = dataset
+        class_kwargs["root_datasets_name"] = sources.find_root_datasets_name(
+            dataset.name
+        )
         class_kwargs["logger"] = self.logger
         class_kwargs["host"] = self.host
         class_kwargs["zfs"] = self.zfs

--- a/iocage/lib/LaunchableResource.py
+++ b/iocage/lib/LaunchableResource.py
@@ -38,7 +38,9 @@ import iocage.lib.Config.Jail.File
 class LaunchableResource(iocage.lib.Resource.Resource):
     """Representation of launchable resources like jails."""
 
-    _rc_conf: typing.Optional[iocage.lib.Config.Jail.File.RCConf.RCConf] = None
+    _rc_conf: typing.Optional[
+        iocage.lib.Config.Jail.File.RCConf.ResourceRCConf
+    ] = None
     _sysctl_conf: typing.Optional[
         iocage.lib.Config.Jail.File.SysctlConf.SysctlConf
     ] = None
@@ -118,10 +120,10 @@ class LaunchableResource(iocage.lib.Resource.Resource):
         )
 
     @property
-    def rc_conf(self) -> 'iocage.lib.Config.Jail.File.RCConf.RCConf':
+    def rc_conf(self) -> 'iocage.lib.Config.Jail.File.RCConf.ResourceRCConf':
         """Return a lazy-loaded instance of the resources RCConf."""
         if self._rc_conf is None:
-            self._rc_conf = iocage.lib.Config.Jail.File.RCConf.RCConf(
+            self._rc_conf = iocage.lib.Config.Jail.File.RCConf.ResourceRCConf(
                 resource=self,
                 logger=self.logger
             )

--- a/iocage/lib/ListableResource.py
+++ b/iocage/lib/ListableResource.py
@@ -66,13 +66,17 @@ class ListableResource(list):
         if self.namespace is None:
             raise ListableResourceNamespaceUndefined(logger=self.logger)
 
+        filters = self._filters
+        has_filters = (filters is not None)
+
         for root_name, root_datasets in self.sources.items():
+            if has_filters and (filters.match_source(root_name) is False):
+                # skip when the resources defined source does not match
+                continue
             children = root_datasets.__getattribute__(self.namespace).children
             for child_dataset in children:
-
                 name = self._get_asset_name_from_dataset(child_dataset)
-                if self._filters is not None:
-                    if self._filters.match_key("name", name) is not True:
+                if has_filters and (filters.match_key("name", name) is False):
                         # Skip all jails that do not even match the name
                         continue
 

--- a/iocage/lib/ListableResource.py
+++ b/iocage/lib/ListableResource.py
@@ -64,15 +64,18 @@ class ListableResource(list):
     ) -> typing.Generator['iocage.lib.Resource.Resource', None, None]:
         """Return an iterator over the child datasets."""
         if self.namespace is None:
-            raise ListableResourceNamespaceUndefined(logger=self.logger)
+            raise iocage.lib.errors.ListableResourceNamespaceUndefined(
+                logger=self.logger
+            )
 
         filters = self._filters
         has_filters = (filters is not None)
 
         for root_name, root_datasets in self.sources.items():
-            if has_filters and (filters.match_source(root_name) is False):
-                # skip when the resources defined source does not match
-                continue
+            if (filters is not None):
+                if (filters.match_source(root_name) is False):
+                    # skip when the resources defined source does not match
+                    continue
             children = root_datasets.__getattribute__(self.namespace).children
             for child_dataset in children:
                 name = self._get_asset_name_from_dataset(child_dataset)

--- a/iocage/lib/ListableResource.py
+++ b/iocage/lib/ListableResource.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""iocage Resource module."""
+import typing
+import libzfs
+import abc
+
+import iocage.lib.Filter
+import iocage.lib.Resource
+
+
+class ListableResource(list):
+    """Representation of Resources that can be listed."""
+
+    _filters: typing.Optional['iocage.lib.Filter.Terms'] = None
+    sources: 'iocage.lib.Datasets.Datasets'
+    namespace: typing.Optional[str]
+
+    def __init__(
+        self,
+        sources: 'iocage.lib.Datasets.Datasets',
+        namespace: typing.Optional[str]=None,
+        filters: typing.Optional['iocage.lib.Filter.Terms']=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None,
+        zfs: typing.Optional['iocage.lib.ZFS.ZFS']=None,
+    ) -> None:
+
+        list.__init__(self, [])
+
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+        self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
+
+        self.namespace = namespace
+        self.sources = sources
+        self.filters = filters
+
+    def destroy(self, force: bool=False) -> None:
+        """Listable resources by itself cannot be destroyed."""
+        raise NotImplementedError("destroy unimplemented for ListableResource")
+
+    def __iter__(
+        self
+    ) -> typing.Generator['iocage.lib.Resource.Resource', None, None]:
+        """Return an iterator over the child datasets."""
+        if self.namespace is None:
+            raise ListableResourceNamespaceUndefined(logger=self.logger)
+
+        for root_name, root_datasets in self.sources.items():
+            children = root_datasets.__getattribute__(self.namespace).children
+            for child_dataset in children:
+
+                name = self._get_asset_name_from_dataset(child_dataset)
+                if self._filters is not None:
+                    if self._filters.match_key("name", name) is not True:
+                        # Skip all jails that do not even match the name
+                        continue
+
+                # ToDo: Do not load jail if filters do not require to
+                resource = self._get_resource_from_dataset(child_dataset)
+                if self._filters is not None:
+                    if self._filters.match_resource(resource):
+                        yield resource
+
+    def __len__(self) -> int:
+        """Return the number of resources matching the filters."""
+        return len(list(self.__iter__()))
+
+    def _get_asset_name_from_dataset(
+        self,
+        dataset: libzfs.ZFSDataset
+    ) -> str:
+        """
+        Return the last fragment of a dataset's name.
+
+        Example:
+            /iocage/jails/foo -> foo
+        """
+        return str(dataset.name.split("/").pop())
+
+    def _get_resource_from_dataset(
+        self,
+        dataset: libzfs.ZFSDataset
+    ) -> 'iocage.lib.Resource.Resource':
+
+        return self._create_resource_instance(dataset)
+
+    @property
+    def filters(self) -> typing.Optional['iocage.lib.Filter.Terms']:
+        """Return the filters that are applied on the list items."""
+        return self._filters
+
+    @filters.setter
+    def filters(
+        self,
+        value: typing.Iterable[typing.Union['iocage.lib.Filter.Term', str]]
+    ) -> None:
+        """Set the filters that are applied on the list items."""
+        if isinstance(value, iocage.lib.Filter.Terms):
+            self._filters = value
+        else:
+            self._filters = iocage.lib.Filter.Terms(value)
+
+    @abc.abstractmethod
+    def _create_resource_instance(  # noqa: T484
+        self,
+        dataset: libzfs.ZFSDataset,
+        *args,
+        **kwargs
+    ) -> 'iocage.lib.Resource.Resource':
+        pass

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -289,7 +289,7 @@ class ReleaseGenerator(ReleaseResource):
     @property
     def releases_folder(self) -> str:
         """Return the mountpoint of the iocage/releases dataset."""
-        return str(self.host.datasets.releases.mountpoint)
+        return str(self.source_dataset.releases.mountpoint)
 
     @property
     def download_directory(self) -> str:

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -131,16 +131,21 @@ class ReleaseResource(iocage.lib.LaunchableResource.LaunchableResource):
 
     @property
     def _dataset_name_from_release_name(self) -> str:
-        #return f"{self.root_dataset.releases.name}/{self.release.name}"
         return f"{self.source_dataset.releases.name}/{self.name}"
 
     @property
     def _dataset_name_from_base_name(self) -> str:
-        #return f"{self.root_dataset.bases.name}/{self.release.name}"
         return f"{self.source_dataset.base.name}/{self.name}"
 
     @property
     def source_dataset(self) -> 'iocage.lib.Datasets.RootDatasets':
+        """
+        Return the releases source root dataset.
+
+        iocage can manage multiple source datasets (on different ZFS pools
+        for instance). This property returns the RootDatasets instance that
+        belongs to the release.
+        """
         try:
             assigned_name = str(self._assigned_dataset_name)
             return self.host.datasets.find_root_datasets(assigned_name)

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -240,7 +240,8 @@ class ReleaseGenerator(ReleaseResource):
                 # ToDo: omit root_datasets_name at all ?
                 raise iocage.lib.errors.ConflictingResourceSelection(
                     source_a=resource_selector.source_name,
-                    source_b=root_datasets_name
+                    source_b=root_datasets_name,
+                    logger=self.logger
                 )
             else:
                 root_datasets_name = resource_selector.source_name

--- a/iocage/lib/Releases.py
+++ b/iocage/lib/Releases.py
@@ -68,7 +68,6 @@ class ReleasesGenerator(iocage.lib.ListableResource.ListableResource):
     @property
     def local(self) -> ReleaseListType:
         """Return the locally available releases."""
-
         datasets = iocage.lib.ListableResource.ListableResource.__iter__(self)
         return list(map(
             lambda x: self._class_release(

--- a/iocage/lib/ResourceSelector.py
+++ b/iocage/lib/ResourceSelector.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""iocage resource selector type."""
+import typing
+
+import iocage.lib.Datasets
+
+
+class ResourceSelector:
+    """Parse and wrap resource selectors."""
+
+    source_name: typing.Optional[str]
+    _name: str
+
+    def __init__(
+        self,
+        name: str
+    ) -> None:
+        self.name = name
+
+    @property
+    def name(self) -> str:
+        """Return the name (without source)."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        name_components = value.split("/", maxsplit=1)
+        if len(name_components) == 2:
+            self._name = name_components[1]
+            self.source_name = name_components[0]
+        else:
+            self._name = value
+            self.source_name = None
+
+    def __str__(self) -> str:
+        """Return the full resource selector string."""
+        if self.source_name is None:
+            return self._name
+        else:
+            return f"{self.source_name}/{self._name}"
+
+    def filter_datasets(
+        self,
+        datasets: iocage.lib.Datasets.Datasets
+    ) -> iocage.lib.Datasets.FilteredDatasets:
+        """Filter given Datasets according to the resource selector source."""
+        if self.source_name is None:
+            return datasets
+
+        return iocage.lib.Datasets.filter_datasets(
+            datasets=datasets,
+            sources=(self.source_name,)
+        )

--- a/iocage/lib/ResourceSelector.py
+++ b/iocage/lib/ResourceSelector.py
@@ -41,7 +41,7 @@ class ResourceSelector:
 
     @property
     def name(self) -> str:
-        """Return the name (without source)."""
+        """Return the given name without the source."""
         return self._name
 
     @name.setter

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -302,10 +302,8 @@ class Updater:
 
         def _rollback_snapshot() -> None:
             self.logger.spam(f"Rolling back to snapshot {snapshot_name}")
-            dataset.umount()
             snapshot = self.resource.zfs.get_snapshot(snapshot_name)
             snapshot.rollback(force=True)
-            dataset.mount()
             snapshot.delete()
 
         runReleaseUpdateEvent.add_rollback_step(_rollback_snapshot)

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -301,6 +301,7 @@ class Updater:
         dataset.snapshot(name=snapshot_name, recursive=True)
 
         def _rollback_snapshot() -> None:
+            self.logger.spam(f"Rolling back to snapshot {snapshot_name}")
             dataset.umount()
             snapshot = self.resource.zfs.get_snapshot(snapshot_name)
             snapshot.rollback(force=True)

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -91,7 +91,7 @@ class Storage:
 
         try:
             new_dataset_name = "/".join([
-                self.jail.host.datasets.jails.name,
+                self.jail.host.datasets[self.jail.source].jails.name,
                 new_name
             ])
             dataset = self.jail.dataset

--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -48,11 +48,6 @@ class ZFSShareStorage:
         self.logger.verbose("Mounting ZFS shares")
         self._mount_jail_datasets(auto_create=auto_create)
 
-    def umount_zfs_shares(self) -> None:
-        """Invoke mounting the ZFS shares."""
-        self.logger.verbose("Unmounting ZFS shares")
-        self._umount_jail_datasets()
-
     def get_zfs_datasets(
         self,
         auto_create: bool=False
@@ -108,15 +103,6 @@ class ZFSShareStorage:
             )
 
         self.jail.exec(["zfs", "mount", "-a"])
-
-    def _umount_jail_datasets(self) -> None:
-        if self.jail.jid is None:
-            return
-        for dataset in self.get_zfs_datasets():
-            iocage.lib.helpers.exec(
-                ["zfs", "unjail", str(self.jail.jid), dataset.name],
-                logger=self.logger
-            )
 
     def _get_pool_name_from_dataset_name(
         self,

--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -116,7 +116,6 @@ class ZFSShareStorage:
 
             if dataset.properties['mountpoint'] is not None:
                 for child in list(dataset.children):
-                    self.jail.storage._ensure_dataset_exists(child)
                     self._mount_jail_dataset(child.name)
 
     def _umount_jail_datasets(self) -> None:

--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -87,13 +87,6 @@ class ZFSShareStorage:
 
         return list(datasets)
 
-    def _mount_jail_dataset(
-        self,
-        dataset_name: str
-    ) -> None:
-
-        self.jail.exec(['zfs', 'mount', dataset_name])
-
     def _mount_jail_datasets(
         self,
         auto_create: bool=False
@@ -114,9 +107,7 @@ class ZFSShareStorage:
                 logger=self.logger
             )
 
-            if dataset.properties['mountpoint'] is not None:
-                for child in list(dataset.children):
-                    self._mount_jail_dataset(child.name)
+        self.jail.exec(["zfs", "mount", "-a"])
 
     def _umount_jail_datasets(self) -> None:
         for dataset in self.get_zfs_datasets():

--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -110,6 +110,8 @@ class ZFSShareStorage:
         self.jail.exec(["zfs", "mount", "-a"])
 
     def _umount_jail_datasets(self) -> None:
+        if self.jail.jid is None:
+            return
         for dataset in self.get_zfs_datasets():
             iocage.lib.helpers.exec(
                 ["zfs", "unjail", str(self.jail.jid), dataset.name],

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -568,6 +568,24 @@ class ResourceUnmanaged(IocageException):
         super().__init__(msg, *args, **kwargs)
 
 
+class ConflictingResourceSelection(IocageException):
+    """Raised when a resource was configured with conflicting sources."""
+
+    def __init__(  # noqa: T484
+        self,
+        source_a: str,
+        source_b: str,
+        *args,
+        **kwargs
+    ) -> None:
+
+        msg = (
+            "The resource was configured with conflicting root sources: "
+            f"{source_a} != {source_b}"
+        )
+        super().__init__(msg, *args, **kwargs)
+
+
 # Snapshots
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -554,6 +554,20 @@ class ZFSPoolUnavailable(IocageException):
         super().__init__(msg, *args, **kwargs)
 
 
+class ResourceUnmanaged(IocageException):
+    """Raised when locating a resources dataset on a root dataset fails."""
+
+    def __init__(  # noqa: T484
+        self,
+        dataset_name: str,
+        *args,
+        **kwargs
+    ) -> None:
+
+        msg = f"The resource dataset {dataset_name} is not managed by iocage"
+        super().__init__(msg, *args, **kwargs)
+
+
 # Snapshots
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -320,6 +320,21 @@ class DefaultConfigNotFound(IocageException, FileNotFoundError):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+# ListableResource
+
+
+class ListableResourceNamespaceUndefined(IocageException):
+    """Raised when a ListableResource was not defined with a namespace."""
+
+    def __init__(  # noqa: T484
+        self,
+        *args,
+        **kwargs
+    ) -> None:
+        msg = f"The ListableResource needs a namespace for this operation"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # General
 
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -324,6 +324,18 @@ class JailZfsShareMount(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
+class JailZfsShareUmount(JailEvent):
+    """Share ZFS datasets with the jail."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
 class JailServicesStart(JailEvent):
     """Start the jails services."""
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -265,7 +265,7 @@ class JailEvent(IocageEvent):
     ) -> None:
 
         try:
-            self.identifier = jail.humanreadable_name
+            self.identifier = jail.full_name
         except AttributeError:
             self.identifier = None
 
@@ -431,7 +431,7 @@ class ReleaseEvent(IocageEvent):
         **kwargs
     ) -> None:
 
-        self.identifier = release.name
+        self.identifier = release.full_name
         IocageEvent.__init__(self, release=release, **kwargs)
 
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -324,18 +324,6 @@ class JailZfsShareMount(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
-class JailZfsShareUmount(JailEvent):
-    """Share ZFS datasets with the jail."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
 class JailServicesStart(JailEvent):
     """Start the jails services."""
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -348,6 +348,18 @@ class JailServicesStart(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
+class JailServicesStop(JailEvent):
+    """Stops the jails services."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
 class JailDestroy(JailEvent):
     """Destroy the jail."""
 

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -152,10 +152,10 @@ def exec(  # noqa: T484
 
     subprocess_args["stdout"] = subprocess_args.get("stdout", subprocess.PIPE)
     subprocess_args["stderr"] = subprocess_args.get("stderr", subprocess.PIPE)
+    subprocess_args["shell"] = subprocess_args.get("shell", False)
 
     child = subprocess.Popen(  # nosec: TODO: #113
         command,
-        shell=False,
         **subprocess_args
     )
 


### PR DESCRIPTION
closes #285

This branch explores supporting multiple source datasets. Each source datasets contains the typical iocage dataset structure `releases`, `jails` and `base` (for legacy support of ZFS basejails).

Instead of searching for an activated ZFS pool, iocage reads `ioc_dataset_` properties from `/etc/rc.conf`:

```
ioc_dataset_main="zroot/some-dataset/iocage"
ioc_dataset_ssd="ssd/iocage"
```

Handling multiple pools comes with a bunch of problems. From a users perspective there should not be a notable difference in using the commandline tool or library APIs when interfacing with the **main** source dataset (the first one declared in rc.conf or the one detected via ZFS properties).

Approximately all CLI commands need to expose a flag for operation source/target datasets. In some cases multiple are desirable (for example when listing or other operations affecting multiple targets), in others we need the user to be specific. In any case the *main* source should be preferred or assumed to be the target when not explicitly specified by the user.

Some commands even require mixed specification of jail sources. When there are two jails with the same name, which is going to be destroyed when referencing it by name. Whenever a jail name can be selected via its name or name globbing there must be the option to specify a source name.

```
ioc create -n main/duplicate -r 11.1-RELEASE
ioc create -n ssd/duplicate -r 11.1-RELEASE
ioc destroy main/duplicate
ioc destroy ssd/duplicate
```

### Current Status
This branch is an early draft for what needs to be done to support multiple iocage sources. There are two different ways in which user selections of sources are passed through. Either FilteredDatasets can be passed to Releases or Jails instances or `root_datasets_name` can be passed to Jail or Release instances. I fear this two mechanisms could cause confusion and would like to consolidate the approaches.

### Update 1
The previous attempt to add another CLI flag `--datasets` or `-d` was discarded. Instead libiocage always expects the main dataset to be suspect of the operation whenever the jail or release name does not include a specific source, for example `ioc start mypool/myjail`.

https://asciinema.org/a/RpoMlvb2A5VzsXWKEnqTUPjLU