### PR TITLE
remove unneccessary -h flag on jls command of JailState

### DIFF
--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -67,7 +67,6 @@ class JailState(dict):
                 "-j",
                 self.name,
                 "-v",
-                "-h",
                 "--libxo=json"
             ], shell=False, stderr=subprocess.DEVNULL)  # nosec TODO use helper
             output = stdout.decode().strip()
@@ -119,7 +118,6 @@ class JailStates(dict):
             stdout = subprocess.check_output([
                 "/usr/sbin/jls",
                 "-v",
-                "-h",
                 "--libxo=json"
             ], shell=False, stderr=subprocess.DEVNULL)  # nosec TODO use helper
             output = stdout.decode().strip()


### PR DESCRIPTION
The `-h` flag on the jls command that JailState executes is currently unused. This got my attention after a report on HBSD that the flag was removed:

```
$ sudo jls -v --libxo=json -h
jls: unknown parameter: hardening.log.log
{"__version": "1", "jail-information": {"jail": []}
}
```