### PR TITLE
Ignore A001 flake8 warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ uninstall:
 	python3.6 -m pip uninstall -y iocage
 check:
 	flake8 --version
-	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107,A002
+	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107,A001,A002
 	bandit --skip B404 --exclude iocage/tests/ -r .
 test:
 	pytest iocage/tests --zpool $(ZPOOL)


### PR DESCRIPTION
In a recent version of flake8 support for `A001` warnings about re-usage of builtin functions was introduced. Currently libiocage does not comply with this yet. Rather than blocking further Pull-Requests we will re-enable this check at a later time together with `A002`.