### PR TITLE
ignore A003 and A004 errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ uninstall:
 	python3.6 -m pip uninstall -y iocage
 check:
 	flake8 --version
-	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107,A001,A002
+	flake8 --exclude=".travis,.eggs,__init__.py" --ignore=E203,W391,D107,A001,A002,A003,A004
 	bandit --skip B404 --exclude iocage/tests/ -r .
 test:
 	pytest iocage/tests --zpool $(ZPOOL)


### PR DESCRIPTION
flake8 started to complain about usage of Python built-ins in method names. We may follow that recommendation, but the work should not be done in a feature branch.

This PR is related to #297 