### PR TITLE
Fix defect parsing jls output without running jails

### DIFF
--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -34,6 +34,8 @@ JailStatesDict = typing.Dict[str, 'JailState']
 def _parse(text: str) -> JailStatesDict:
     output: JailStatesDict = {}
     for line in text.split("\n"):
+        if line == "":
+            continue
         data: typing.Dict[str, str] = {}
         for item in shlex.split(line):
             if "=" not in item:


### PR DESCRIPTION
When the output of `jls -vnq` was empty, parsing the output failed 

```
Traceback (most recent call last):
  File "./iocage/lib/JailState.py", line 132, in query
    output_data = _parse(output)
  File "./iocage/lib/JailState.py", line 47, in _parse
    output[data["name"]] = JailState(data["name"], data)
KeyError: 'name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "./__main__.py", line 48, in <module>
    main()
  File "./__main__.py", line 42, in main
    cli(prog_name="iocage")
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "./iocage/cli/list.py", line 145, in cli
    _print_table(resources, columns, header, _sort)
  File "./iocage/cli/list.py", line 160, in _print_table
    for resource in resources:
  File "./iocage/lib/Jails.py", line 101, in __iter__
    self.states.query()
  File "./iocage/lib/JailState.py", line 137, in query
    raise iocage.lib.errors.JailStateUpdateFailed()
iocage.lib.errors.JailStateUpdateFailed: Updating the jail state with jls failed
```