### PR TITLE
normalize error handling and message printing in console cli command

### DIFF
--- a/iocage/cli/console.py
+++ b/iocage/cli/console.py
@@ -26,6 +26,7 @@ import click
 
 import iocage.lib.Jail
 import iocage.lib.Logger
+import iocage.lib.errors
 
 __rootcmd__ = True
 
@@ -47,10 +48,8 @@ def cli(ctx, jail, start):
     if not ioc_jail.running:
         if start is True:
             ctx.parent.print_events(ioc_jail.start())
-        else:
-            logger.error(
-                f"The jail {ioc_jail.humanreadable_name} is not running"
-            )
-            exit(1)
 
-    jail.exec_console()
+    try:
+        ioc_jail.exec_console()
+    except iocage.lib.errors.IocageException:
+        exit(1)

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1050,6 +1050,7 @@ class JailGenerator(JailResource):
 
     def exec_console(self) -> typing.Tuple[str, str]:
         """Shortcut to drop into a shell of a started jail."""
+        self.require_jail_running()
         return self.passthru(
             ["/usr/bin/login"] + self.config["login_flags"]
         )


### PR DESCRIPTION
When a logger is attached IocageEvent instances already notify the logger about the issue. There is no need for manual error handling when `Jail.exec_console()` already raises when a jail is not running. 