### PR TITLE
Single Command Jails

### DIFF
--- a/iocage/cli/exec.py
+++ b/iocage/cli/exec.py
@@ -85,7 +85,6 @@ def cli(
             user_command
         ]
     else:
-        command = ["/bin/sh", "-c", user_command]
         command = user_command.split()
 
     ioc_jail = iocage.lib.Jail.JailGenerator(jail, logger=logger)
@@ -102,7 +101,7 @@ def cli(
     try:
         if fork is True:
             events = ioc_jail.fork_exec(
-                command,
+                " ".join(command),
                 passthru=True,
                 exec_timeout=0
             )

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -39,14 +39,12 @@ __rootcmd__ = True
 @click.option("--rc", default=False, is_flag=True,
               help="Will stop all jails with boot=on, in the specified"
                    " order with higher value for priority stopping first.")
-@click.option("--log-level", "-d", default=None)
 @click.option("--force", "-f", is_flag=True, default=False,
               help="Skip checks and enforce jail shutdown")
 @click.argument("jails", nargs=-1)
 def cli(
     ctx: IocageClickContext,
     rc: bool,
-    log_level: str,
     force: bool,
     jails: typing.Tuple[str, ...]
 ) -> None:

--- a/iocage/lib/CommandQueue.py
+++ b/iocage/lib/CommandQueue.py
@@ -1,29 +1,40 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Class extension to queue commands for bulk executions."""
 import typing
 
 
 class CommandQueue:
+    """Class extension that queues command for bulk execution."""
 
-    shell_variable_nic_name: str
     command_queue: typing.List[str]
-    env_variables: typing.List[str]
 
     def clear(self) -> None:
         """Clear the command queue."""
         self.command_queue: typing.List[str] = []
-        self.env_variables: typing.List[str]
 
-    def merge_env(
-        self,
-        env_variables: typing.Dict[str, str]
-    ) -> typing.Dict[str, str]:
-        """Merge existing env variables with the newly set ones."""
-        output: typing.Dict[str, str] = {}
-        for key, value in env_variables.items():
-            output[key] = value
-        for key, value in self.env_variables.items():
-            output[key] = value
-
-    def read_commands(self) -> None:
+    def read_commands(self) -> typing.List[str]:
         """Return the collected jail commands and clear the queue."""
         queue = self.command_queue
         self.command_queue = []

--- a/iocage/lib/CommandQueue.py
+++ b/iocage/lib/CommandQueue.py
@@ -1,0 +1,30 @@
+import typing
+
+
+class CommandQueue:
+
+    shell_variable_nic_name: str
+    command_queue: typing.List[str]
+    env_variables: typing.List[str]
+
+    def clear(self) -> None:
+        """Clear the command queue."""
+        self.command_queue: typing.List[str] = []
+        self.env_variables: typing.List[str]
+
+    def merge_env(
+        self,
+        env_variables: typing.Dict[str, str]
+    ) -> typing.Dict[str, str]:
+        """Merge existing env variables with the newly set ones."""
+        output: typing.Dict[str, str] = {}
+        for key, value in env_variables.items():
+            output[key] = value
+        for key, value in self.env_variables.items():
+            output[key] = value
+
+    def read_commands(self) -> None:
+        """Return the collected jail commands and clear the queue."""
+        queue = self.command_queue
+        self.command_queue = []
+        return queue

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -308,6 +308,33 @@ class BaseConfig(dict):
         if self._has_legacy_tag is True:
             del self.data["tag"]
 
+    def _get_vnet_interfaces(self) -> typing.List[str]:
+
+        data_keys = self.data.keys()
+
+        if "vnet_interfaces" in data_keys:
+            vnet_interfaces = set(list(
+                iocage.lib.helpers.parse_list(self.data["vnet_interfaces"])
+            ))
+        else:
+            vnet_interfaces = set()
+
+        return list(vnet_interfaces)
+
+    def _set_vnet_interfaces(  # noqa: T484
+        self,
+        value: typing.Union[
+            str,
+            bool,
+            int,
+            typing.List[typing.Union[str, bool, int]]
+        ],
+        **kwargs
+    ) -> None:
+
+        data = iocage.lib.helpers.to_string(value)
+        self.data["vnet_interfaces"] = data
+
     def _get_basejail(self) -> bool:
         return iocage.lib.helpers.parse_bool(self.data["basejail"]) is True
 

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -113,6 +113,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "exec_prestop": "/usr/bin/true",
         "exec_stop": "/bin/sh /etc/rc.shutdown",
         "exec_poststop": "/usr/bin/true",
+        "exec_jail_user": "root",
         "exec_timeout": "60",
         "stop_timeout": "30",
         "mount_procfs": "0",

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -200,7 +200,7 @@ class Fstab(
             self.basejail_lines
         )
 
-        for line in input_text.rstrip("\n").split("\n"):
+        for line in input_text.rstrip("\n").splitlines():
 
             if _is_comment_line(line) or _is_empty_line(line):
                 self.add_line(FstabCommentLine({
@@ -232,7 +232,7 @@ class Fstab(
             line = re.sub("([^\\\\])\s", "\g<1>\n", line)
             line = line.replace("\\ ", " ")
 
-            fragments = line.split("\n")
+            fragments = line.splitlines()
             if len(fragments) != 6:
                 self.logger.log(
                     f"Invalid line in fstab file {self.path}"

--- a/iocage/lib/Config/Jail/File/Prototype.py
+++ b/iocage/lib/Config/Jail/File/Prototype.py
@@ -165,7 +165,9 @@ class ConfigFile(dict):
     def save(self) -> bool:
         """Save the changes to the file."""
         if self.changed is False:
-            self.logger.debug("{self._file} was not modified - skipping write")
+            self.logger.debug(
+                f"{self._file} was not modified - skipping write"
+            )
             return False
 
         with open(self.path, "w") as rcconf:

--- a/iocage/lib/Firewall.py
+++ b/iocage/lib/Firewall.py
@@ -89,9 +89,10 @@ class Firewall:
 
     def _offset_rule_number(self, rule_number: typing.Union[int, str]) -> str:
         _rule_number = int(rule_number)
-        return _rule_number + self.IPFW_RULE_OFFSET
+        return str(_rule_number + self.IPFW_RULE_OFFSET)
 
     def _exec(
+        self,
         command: typing.List[str],
         ignore_error: bool=False
     ) -> None:
@@ -104,6 +105,7 @@ class Firewall:
 
 
 class QueuingFirewall(Firewall, iocage.lib.CommandQueue.CommandQueue):
+    """Command queuing Firewall for bulk execution."""
 
     def __init__(  # noqa: T484
         self,
@@ -114,7 +116,7 @@ class QueuingFirewall(Firewall, iocage.lib.CommandQueue.CommandQueue):
 
     def _offset_rule_number(self, rule_number: typing.Union[int, str]) -> str:
         if isinstance(rule_number, int):
-            return _rule_number + self.IPFW_RULE_OFFSET
+            return str(rule_number + self.IPFW_RULE_OFFSET)
         return f"$(expr {rule_number} + {self.IPFW_RULE_OFFSET})"
 
     def _exec(

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -26,6 +26,7 @@ import typing
 import os
 import platform
 import re
+import sysctl
 
 import libzfs
 
@@ -162,6 +163,11 @@ class HostGenerator:
     def processor(self) -> str:
         """Return the hosts processor architecture."""
         return platform.processor()
+
+    @property
+    def ipfw_enabled(self):
+        _sysctl = sysctl.filter("net.inet.ip.fw.enable")
+        return ((len(_sysctl) == 1) and (_sysctl[0].value == 1))
 
 
 class Host(HostGenerator):

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -165,7 +165,8 @@ class HostGenerator:
         return platform.processor()
 
     @property
-    def ipfw_enabled(self):
+    def ipfw_enabled(self) -> bool:
+        """Return True if ipfw is enabled on the host system."""
         _sysctl = sysctl.filter("net.inet.ip.fw.enable")
         return ((len(_sysctl) == 1) and (_sysctl[0].value == 1))
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -637,13 +637,9 @@ class JailGenerator(JailResource):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL
             )
-        else:
-            return iocage.lib.helpers.exec(
-                [value],
-                logger=self.logger,
-                env=self.env,
-                shell=True  # nosec: B604
-            )
+
+        # ToDo: Deprecate and remove this method
+        raise NotImplemented("_run_hook only supports start/stop")
 
     def _ensure_script_dir(self) -> None:
         if os.path.isdir(self.launch_script_dir) is False:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -24,7 +24,6 @@
 """iocage Jail module."""
 import typing
 import os
-import random
 import subprocess  # nosec: B404
 import shlex
 import shutil

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1393,8 +1393,6 @@ class JailGenerator(JailResource):
             f"exec.poststart=\"{self.get_hook_script_path('poststart')}\""
         ]
 
-        humanreadable_name = self.humanreadable_name
-
         stdout, stderr, returncode = self._exec_launch_command(
             command=command,
             passthru=passthru
@@ -1450,7 +1448,6 @@ class JailGenerator(JailResource):
             f"{self._relative_hook_script_dir}/command.sh"
         ]
 
-        EOF_IDENTIFIER = f"EOF{random.getrandbits(64)}"
         self._write_hook_script("command", "\n".join(
             (["service ipfw onestop"] if self.host.ipfw_enabled else []) +
             [

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -380,7 +380,7 @@ class JailGenerator(JailResource):
 
                 Execute commands in an interactive shell.
 
-            single_command (bool):
+            single_command (str):
 
                 When set the jail is launched non-persistent. The startup cycle
                 reduces to the `prestart`, `command` and `poststop` hooks with

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -588,8 +588,21 @@ class JailGenerator(JailResource):
             logger=self.logger
         )
 
-        list(JailGenerator.start(self, single_command=command, passthru=True))
-        yield jailForkExecEvent.end()
+        try:
+            fork_exec_events = JailGenerator.start(
+                self,
+                single_command=command,
+                passthru=True
+            )
+            for event in fork_exec_events:
+                continue
+        except iocage.lib.errors.IocageException as e:
+            jailForkExecEvent.fail(e)
+            raise e
+        else:
+            yield jailForkExecEvent.end()
+        finally:
+            self.config = original_config
 
     @property
     def basejail_backend(self) -> typing.Optional[typing.Union[

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -719,10 +719,10 @@ class JailGenerator(JailResource):
                 )
                 try:
                     for hook_name in ["prestop", "poststop"]:
-                        iocage.lib.helpers.exec([
-                            "/bin/sh",
-                            self.get_hook_script_path(hook_name)
-                        ], logger=self.logger)
+                        iocage.lib.helpers.exec(
+                            [self.get_hook_script_path(hook_name)],
+                            logger=self.logger
+                        )
                 except Exception as e:
                     self.logger.warn(str(e))
             else:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -471,7 +471,7 @@ class JailGenerator(JailResource):
             else:
                 self._prepare_stop()
                 stdout, stderr, returncode = self._launch_single_command_jail(
-                    " ".join(single_command),
+                    single_command,
                     passthru=passthru
                 )
         except Exception as e:
@@ -558,7 +558,7 @@ class JailGenerator(JailResource):
 
     def fork_exec(  # noqa: T484
         self,
-        command: typing.List[str],
+        command: str,
         error_handler: typing.Optional[typing.Callable[
             [subprocess.Popen, str, str],
             typing.Tuple[bool, str],

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -772,9 +772,10 @@ class JailGenerator(JailResource):
             ), (
                 "exec.poststop = "
                 f"\"/bin/sh {self.get_hook_script_path('poststop')}\";"
-            ),
-            (
+            ), (
                 f"exec.stop = \"{stop_command}\";"
+            ), (
+                f"exec.jail_user = {self._get_value('exec_jail_user')};"
             ),
             "}"
         ])
@@ -1324,7 +1325,8 @@ class JailGenerator(JailResource):
             f"allow.sysvipc={self._get_value('allow_sysvipc')}",
             f"exec.prestart=\"{self.get_hook_script_path('prestart')}\"",
             f"exec.prestop=\"{self.get_hook_script_path('prestop')}\"",
-            f"exec.poststop=\"{self.get_hook_script_path('poststop')}\""
+            f"exec.poststop=\"{self.get_hook_script_path('poststop')}\"",
+            f"exec.jail_user={self._get_value('exec_jail_user')}"
         ]
 
         if self.host.userland_version > 10.3:

--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -33,7 +33,7 @@ JailStatesDict = typing.Dict[str, 'JailState']
 
 def _parse(text: str) -> JailStatesDict:
     output: JailStatesDict = {}
-    for line in text.split("\n"):
+    for line in text.splitlines():
         if line == "":
             continue
         data: typing.Dict[str, str] = {}

--- a/iocage/lib/Logger.py
+++ b/iocage/lib/Logger.py
@@ -69,7 +69,7 @@ class LogEntry:
 
     def __len__(self) -> int:
         """Return the number of lines of the log entry."""
-        return len(self.message.split("\n"))
+        return len(self.message.splitlines())
 
 
 class Logger:
@@ -301,7 +301,7 @@ class Logger:
 
     def _indent(self, message: str, level: int) -> str:
         indent = Logger.INDENT_PREFIX * level
-        return "\n".join(map(lambda x: f"{indent}{x}", message.split("\n")))
+        return "\n".join(map(lambda x: f"{indent}{x}", message.splitlines()))
 
     def _get_log_file_path(
         self,

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -159,7 +159,7 @@ class Network:
         return f"ioc:{self.epair_id}"
 
     @property
-    def _unic(self):
+    def _unic(self) -> str:
         """Return the uppercase nic name."""
         return self.nic.upper()
 

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -427,7 +427,7 @@ class Network:
         return commands
 
     @property
-    def env(self) -> typing.Dict[str, str]:
+    def env(self) -> typing.Dict[str, typing.Union[str, int]]:
         """
         Return a dict of env variables used by the started jail.
 
@@ -440,8 +440,8 @@ class Network:
             return self._env_temporary
 
     @property
-    def _env_running(self):
-        script_env: typing.Dict[str, str] = {
+    def _env_running(self) -> typing.Dict[str, typing.Union[str, int]]:
+        script_env: typing.Dict[str, typing.Union[str, int]] = {
             f"IOCAGE_NIC_EPAIR_A_{self._unic}": f"{self.nic}:$IOCAGE_JID",
             f"IOCAGE_NIC_EPAIR_B_{self._unic}": self.nic,
             f"IOCAGE_NIC_EPAIR_C_{self._unic}": f"{self.nic}:$IOCAGE_JID:a",
@@ -452,9 +452,9 @@ class Network:
         return script_env
 
     @property
-    def _env_temporary(self):
+    def _env_temporary(self) -> typing.Dict[str, typing.Union[str, int]]:
         identifier = self.temporary_nic_prefix
-        script_env: typing.Dict[str, str] = {
+        script_env: typing.Dict[str, typing.Union[str, int]] = {
             f"IOCAGE_NIC_EPAIR_A_{self._unic}": identifier,
             f"IOCAGE_NIC_EPAIR_B_{self._unic}": f"{identifier}:j",
             f"IOCAGE_NIC_EPAIR_C_{self._unic}": f"{identifier}:a",

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -135,7 +135,7 @@ class NetworkInterface:
         if self.extra_settings:
             command += self.extra_settings
 
-        self._exec(" ".join(command))
+        self._exec(command)
 
         # update name when the interface was renamed
         if self.rename:
@@ -171,13 +171,13 @@ class NetworkInterface:
             if i > 0:
                 command.append("alias")
 
-            self._exec(" ".join(command))
+            self._exec(command)
 
             if (ipv6 is True) and (address.lower() == "accept_rtadv"):
-                self._exec(" ".join([
+                self._exec([
                     self.rtsold_command,
                     self.current_nic_name
-                ]))
+                ])
 
     def _exec(
         self,
@@ -239,8 +239,9 @@ class QueuingNetworkInterface(
         else:
             return f"${self.shell_variable_nic_name}"
 
-    def _exec(self, command: str) -> str:
+    def _exec(self, command: typing.List[str]) -> str:
 
+        _command = " ".join(command)
         _has_variable_name = (self.shell_variable_nic_name is not None)
 
         if self.rename is True:
@@ -248,12 +249,11 @@ class QueuingNetworkInterface(
 
         if (_has_variable_name and self.create) is True:
             self.command_queue.append(
-                f"export {self.shell_variable_nic_name}=\"$({command})\""
+                f"export {self.shell_variable_nic_name}=\"$({_command})\""
             )
         else:
-            self.command_queue.append(command)
+            self.command_queue.append(_command)
             if (_has_variable_name and self.rename) is True:
                 self.command_queue.append(
                     f"export {self.shell_variable_nic_name}=\"{self.name}\""
                 )
-

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -23,7 +23,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Model if an iocage jails network interface."""
 import typing
+
 import iocage.lib.helpers
+import iocage.lib.CommandQueue
 
 
 class NetworkInterface:
@@ -40,6 +42,8 @@ class NetworkInterface:
 
     name: str
     settings: typing.Dict[str, typing.Union[str, typing.List[str]]]
+    rename: bool
+    create: bool
 
     def __init__(
         self,
@@ -65,8 +69,8 @@ class NetworkInterface:
         self.jail = jail
         self.logger = iocage.lib.helpers.init_logger(self, logger)
 
-        if name is None:
-            raise iocage.lib.errors.InvalidInterfaceName(logger=self.logger)
+        # if name is None:
+        #     raise iocage.lib.errors.InvalidInterfaceName(logger=self.logger)
 
         self.name = name
         self.create = create
@@ -111,7 +115,9 @@ class NetworkInterface:
 
     def apply_settings(self) -> None:
         """Apply the interface settings only."""
-        command: typing.List[str] = [self.ifconfig_command, self.name]
+        command: typing.List[str] = [
+            self.ifconfig_command, self.current_nic_name
+        ]
 
         if self.create is True:
             command.append("create")
@@ -129,7 +135,7 @@ class NetworkInterface:
         if self.extra_settings:
             command += self.extra_settings
 
-        self.__exec(command)
+        self._exec(" ".join(command))
 
         # update name when the interface was renamed
         if self.rename:
@@ -144,6 +150,10 @@ class NetworkInterface:
         if self.ipv6_addresses is not None:
             self.__apply_addresses(self.ipv6_addresses, ipv6=True)
 
+    @property
+    def current_nic_name(self):
+        return self.name
+
     def __apply_addresses(
         self,
         addresses: typing.List[str],
@@ -152,20 +162,24 @@ class NetworkInterface:
 
         family = "inet6" if ipv6 else "inet"
         for i, address in enumerate(addresses):
+            name = self.current_nic_name
             if (ipv6 is False) and (address.lower() == "dhcp"):
-                command = [self.dhclient_command, self.name]
+                command = [self.dhclient_command, name]
             else:
-                command = [self.ifconfig_command, self.name, family, address]
+                command = [self.ifconfig_command, name, family, address]
 
             if i > 0:
                 command.append("alias")
 
-            self.__exec(command)
+            self._exec(" ".join(command))
 
             if (ipv6 is True) and (address.lower() == "accept_rtadv"):
-                self.__exec([self.rtsold_command, self.name])
+                self._exec(" ".join([
+                    self.rtsold_command,
+                    self.current_nic_name
+                ]))
 
-    def __exec(
+    def _exec(
         self,
         command: typing.List[str],
         force_local: typing.Optional[bool]=False
@@ -176,5 +190,70 @@ class NetworkInterface:
         else:
             _, stdout, _ = iocage.lib.helpers.exec(command, logger=self.logger)
 
+        self._handle_exec_stdout(stdout)
+
+    def _handle_exec_stdout(stdout: str) -> None:
         if (self.create or self.rename) is True:
             self.name = stdout.strip()
+
+
+class QueuingNetworkInterface(
+    NetworkInterface,
+    iocage.lib.CommandQueue.CommandQueue
+):
+    """Delay command execution for bulk execution."""
+
+    shell_variable_nic_name: typing.Optional[str]
+
+    def __init__(  # noqa: T484
+        self,
+        name: typing.Optional[str]="vnet0",
+        shell_variable_nic_name: typing.Optional[str]=None,
+        **network_interface_options
+    ) -> None:
+
+        self.shell_variable_nic_name = shell_variable_nic_name
+
+        self.clear()
+        NetworkInterface.__init__(self, name=name, **network_interface_options)
+
+        if (self.create or self.rename) is False:
+            self.set_shell_variable_nic_name()
+
+    def set_shell_variable_nic_name(
+        self,
+        name: typing.Optional[str]=None
+    ) -> None:
+        _name = self.name if name is None else name
+        if (_name is None) or (self.shell_variable_nic_name is None):
+            return
+        setter_command = f"export {self.shell_variable_nic_name}=\"{_name}\""
+        self.command_queue.append(setter_command)
+
+    @property
+    def current_nic_name(self):
+        if self.shell_variable_nic_name is None:
+            return self.name
+        elif (self.create is True) and (self.name is not None):
+            return self.name
+        else:
+            return f"${self.shell_variable_nic_name}"
+
+    def _exec(self, command: str) -> str:
+
+        _has_variable_name = (self.shell_variable_nic_name is not None)
+
+        if self.rename is True:
+            self.name = self.settings["name"]
+
+        if (_has_variable_name and self.create) is True:
+            self.command_queue.append(
+                f"export {self.shell_variable_nic_name}=\"$({command})\""
+            )
+        else:
+            self.command_queue.append(command)
+            if (_has_variable_name and self.rename) is True:
+                self.command_queue.append(
+                    f"export {self.shell_variable_nic_name}=\"{self.name}\""
+                )
+

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -273,7 +273,7 @@ class QueuingNetworkInterface(
             if isinstance(new_name, str) is True:
                 self.name = str(new_name)
             else:
-                raise TypeError("Cannot rename multiple interfaces")
+                raise ValueError("Cannot rename multiple interfaces")
 
         if (_has_variable_name and (self.create or self.rename)) is True:
             self.command_queue.append(

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -664,7 +664,7 @@ class ReleaseGenerator(ReleaseResource):
         path = self.__get_hashfile_location()
         hashes = {}
         with open(path, "r") as f:
-            for line in f.read().split("\n"):
+            for line in f.read().splitlines():
                 s = set(line.replace("\t", " ").split(" "))
                 fingerprint = None
                 asset = None

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -174,6 +174,35 @@ class JailStateUpdateFailed(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
+class JailLaunchFailed(IocageException):
+    """Raised when the jail state could not be obtained."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+        msg = f"Jail launch failed"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
+class JailCommandFailed(IocageException):
+    """Raised when a jail command fails with an exit code > 0."""
+
+    def __init__(self, returncode: int, *args, **kwargs) -> None:  # noqa: T484
+        msg = f"Jail command exited with {returncode}"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
+class JailExecutionAborted(IocageException):
+    """Raised when a jail command fails with an exit code > 0."""
+
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        *args,
+        **kwargs
+    ) -> None:  # noqa: T484
+        msg = f"Jail execution aborted."
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
 # Jail Fstab
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -193,12 +193,12 @@ class JailCommandFailed(IocageException):
 class JailExecutionAborted(IocageException):
     """Raised when a jail command fails with an exit code > 0."""
 
-    def __init__(
+    def __init__(  # noqa: T484
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
         *args,
         **kwargs
-    ) -> None:  # noqa: T484
+    ) -> None:
         msg = f"Jail execution aborted."
         IocageException.__init__(self, msg, *args, **kwargs)
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -535,6 +535,18 @@ class ZFSDatasetRename(ZFSEvent):
         ZFSEvent.__init__(self, zfs_object=dataset, **kwargs)
 
 
+class ZFSDatasetDestroy(ZFSEvent):
+    """Rename a ZFS dataset."""
+
+    def __init__(  # noqa: T484
+        self,
+        dataset: libzfs.ZFSDataset,
+        **kwargs
+    ) -> None:
+
+        ZFSEvent.__init__(self, zfs_object=dataset, **kwargs)
+
+
 class ZFSSnapshotRename(ZFSEvent):
     """Rename a ZFS snapshot."""
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -348,18 +348,6 @@ class JailForkExec(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
-class JailExec(JailEvent):
-    """Execute a command in a jail."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
 class JailClone(JailEvent):
     """Clone a jail."""
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -300,18 +300,6 @@ class JailRename(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
-class JailVnetConfiguration(JailEvent):
-    """Configure networking for VNET jails."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
 class JailZfsShareMount(JailEvent):
     """Share ZFS datasets with the jail."""
 
@@ -324,56 +312,8 @@ class JailZfsShareMount(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
-class JailServicesStart(JailEvent):
-    """Start the jails services."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
-class JailServicesStop(JailEvent):
-    """Stops the jails services."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
 class JailDestroy(JailEvent):
     """Destroy the jail."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
-class JailNetworkTeardown(JailEvent):
-    """Teardown a jails VNET network devices."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
-class JailMountTeardown(JailEvent):
-    """Teardown basejail mountpoints."""
 
     def __init__(  # noqa: T484
         self,

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -39,6 +39,7 @@ import iocage.lib.ZFS
 
 # MyPy
 import iocage.lib.Types
+CommandOutput = typing.Tuple[typing.Optional[str], typing.Optional[str], int]
 
 
 def init_zfs(
@@ -398,8 +399,12 @@ def to_string(
 def exec_generator(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,
-    **subprocess_args: typing.Dict[str, typing.Any]
-) -> typing.Generator[str, None, typing.Tuple[str, str, int]]:
+    **subprocess_args: typing.Any
+) -> typing.Generator[
+    str,
+    None,
+    CommandOutput
+]:
     """Execute a command in an interactive shell."""
     if isinstance(command, str):
         command = [command]
@@ -454,9 +459,8 @@ def exec_passthru(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,
     print_lines: bool=True
-) -> typing.Tuple[str, str, int]:
+) -> CommandOutput:
     """Execute a command in an interactive shell."""
-
     lines = exec_generator(
         command,
         logger=logger,
@@ -469,7 +473,10 @@ def exec_passthru(
                 print(line)
                 sys.stdout.flush()
     except StopIteration as return_statement:
-        return return_statement.value
+
+        output: CommandOutput
+        output = return_statement.value
+        return output
 
 
 # ToDo: replace with (u)mount library

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -409,7 +409,7 @@ def exec_passthru(
 
 
 # ToDo: replace with (u)mount library
-def umount(
+def umount_command(
     mountpoint: typing.Optional[typing.Union[
         iocage.lib.Types.AbsolutePath,
         typing.List[iocage.lib.Types.AbsolutePath],
@@ -432,6 +432,29 @@ def umount(
         cmd += mountpoint
     elif isinstance(mountpoint, iocage.lib.Types.AbsolutePath):
         cmd.append(str(mountpoint))
+
+    if ignore_error is True:
+        cmd += ["||", ":"]
+
+    return cmd
+
+
+def umount(
+    mountpoint: typing.Optional[typing.Union[
+        iocage.lib.Types.AbsolutePath,
+        typing.List[iocage.lib.Types.AbsolutePath],
+    ]]=None,
+    options: typing.Optional[typing.List[str]]=None,
+    force: bool=False,
+    ignore_error: bool=False,
+    logger: typing.Optional[iocage.lib.Logger.Logger]=None
+) -> None:
+
+    cmd = umount_command(
+        mountpoint=mountpoint,
+        options=options,
+        force=force
+    )
 
     try:
         iocage.lib.helpers.exec(cmd)

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -133,11 +133,11 @@ def get_userland_version() -> str:
     return match[1]
 
 
-def exec(  # noqa: T484
+def exec(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,
     ignore_error: bool=False,
-    **subprocess_args
+    **subprocess_args: typing.Any
 ) -> typing.Tuple[
     typing.Optional[str],
     typing.Optional[str],

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -437,10 +437,11 @@ def exec_generator(
         stdout = ""
         if child.stdout is not None:
             for line in iter(child.stdout.readline, ""):
+                line = line.replace("\r\n", "\n").replace("\r", "")
                 if (line is "") and (child.poll() is not None):
                     continue
                 stdout += f"{line}"
-                yield line.replace("\r", "").replace("\n", "")
+                yield line.split()
             child.stdout.close()
 
         if child.stderr is not None:

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -418,8 +418,8 @@ def umount_command(
     force: bool=False,
     ignore_error: bool=False,
     logger: typing.Optional[iocage.lib.Logger.Logger]=None
-) -> None:
-    """Unmount a mountpoint."""
+) -> typing.List[str]:
+    """Return the command to unmount a mountpoint."""
     cmd = ["/sbin/umount"]
 
     if force is True:
@@ -449,7 +449,7 @@ def umount(
     ignore_error: bool=False,
     logger: typing.Optional[iocage.lib.Logger.Logger]=None
 ) -> None:
-
+    """Unmount a mountpoint."""
     cmd = umount_command(
         mountpoint=mountpoint,
         options=options,

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -195,7 +195,7 @@ def exec(
 def _prettify_output(output: str) -> str:
     return "\n".join(map(
         lambda line: f"    {line}",
-        output.split("\n")
+        output.splitlines()
     ))
 
 
@@ -437,11 +437,10 @@ def exec_generator(
         stdout = ""
         if child.stdout is not None:
             for line in iter(child.stdout.readline, ""):
-                line = line.replace("\r\n", "\n").replace("\r", "")
                 if (line is "") and (child.poll() is not None):
                     continue
                 stdout += f"{line}"
-                yield line.split()
+                yield line.replace("\r", "").replace("\n", "")
             child.stdout.close()
 
         if child.stderr is not None:


### PR DESCRIPTION
closes #311 

- the jail network is configured entirely in the exec.prestart hook
- postpones command execution by bundling them to a singe shell script
- stopping jails requires a temporary jail.conf file so that exec.prestop, exec.stop and exec.poststop hooks are executed
- responds to KeyboardInterruption during jail command execution
- allows to set  `--user` in exec CLI command (e.g. `ioc exec -u gronke my-jail whoami`)