### PR TITLE
Jail.fork_exec takes string commands

### DIFF
--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -340,7 +340,7 @@ class Updater:
         try:
             self._create_jail_update_dir()
             for event in jail.fork_exec(
-                self._update_command,
+                " ".join(self._update_command),
                 error_handler=self._install_error_handler
             ):
                 yield event


### PR DESCRIPTION
fixed #314

The interface of `Jail.fork_exex(command: str, ...)` was recently changed, so that no longer list but strings are accepted command input.