### PR TITLE
Supress stderr output in resource updates

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -592,7 +592,7 @@ class JailGenerator(JailResource):
             fork_exec_events = JailGenerator.start(
                 self,
                 single_command=command,
-                passthru=True
+                passthru=passthru
             )
             for event in fork_exec_events:
                 continue

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -339,7 +339,8 @@ class Updater:
 
         try:
             self._create_jail_update_dir()
-            for event in jail.fork_exec(
+            for event in iocage.lib.Jail.JailGenerator.fork_exec(
+                jail,
                 " ".join(self._update_command),
                 error_handler=self._install_error_handler
             ):

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -342,6 +342,7 @@ class Updater:
             for event in iocage.lib.Jail.JailGenerator.fork_exec(
                 jail,
                 " ".join(self._update_command),
+                passthru=False,
                 error_handler=self._install_error_handler
             ):
                 yield event


### PR DESCRIPTION
fixes #316

The `passthru` argument is now passed along by the fork_exec function and is explicitly set to `False` for resource updates.