### PR TITLE
Support JLS with and without --libxo=json

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -354,7 +354,10 @@ class JailGenerator(JailResource):
         object.__setattr__(self, '_state', value)
 
     def _init_state(self) -> iocage.lib.JailState.JailState:
-        state = iocage.lib.JailState.JailState(self.identifier)
+        state = iocage.lib.JailState.JailState(
+            self.identifier,
+            logger=self.logger
+        )
         self.state = state
         state.query()
         return state

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -98,7 +98,7 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
         self
     ) -> typing.Generator['iocage.lib.Resource.Resource', None, None]:
         """Iterate over all jails matching the filter criteria."""
-        self.states.query()
+        self.states.query(logger=self.logger)
 
         iterator = iocage.lib.ListableResource.ListableResource.__iter__(self)
         for jail in iterator:


### PR DESCRIPTION
An issue on latest HardenedBSD with `jls -n` was reported. The `--libxo=json` output seems fine though.

We initially have implemented parsing jls output with libxo. This PR brings back support for this method and detects the userland version to decide whether to use json or list output.