### PR TITLE
Fix existing launch script .env file causing network teardown failure

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -727,6 +727,7 @@ class JailGenerator(JailResource):
         try:
             self._write_jail_conf(force=force)
             self._destroy_jail()
+            self._remove_script_env_file()
         except Exception as e:
             if force is True:
                 yield jailDestroyEvent.skip()
@@ -753,6 +754,10 @@ class JailGenerator(JailResource):
                 self.logger.warn(str(e))
             else:
                 raise e
+
+    def _remove_script_env_file(self) -> None:
+        if os.path.isfile(self.script_env_path) is True:
+            os.remove(self.script_env_path)
 
     def _write_temporary_script_env(self) -> None:
         self.logger.debug(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -515,7 +515,8 @@ class JailGenerator(JailResource):
         if jailed is False:
             pre_commands.append(
                 f"export IOCAGE_JID="
-                f"$(/usr/sbin/jls -j {self.identifier} jid 2>/dev/null || :)"
+                f"$(/usr/sbin/jls -j {shlex.quote(self.identifier)} jid"
+                " 2>/dev/null || :)"
             )
 
         if isinstance(commands, str):
@@ -526,11 +527,11 @@ class JailGenerator(JailResource):
             _commands = commands
 
         post_commands: typing.List[str] = []
-        env_path = self.script_env_path
         if (jailed is False) and (write_env is True):
             if self.running:
                 post_commands.append(
-                    f"echo \"export IOCAGE_JID={self.jid}\" > {env_path}"
+                    f"echo \"export IOCAGE_JID={shlex.quote(str(self.jid))}\""
+                    f" > {shlex.quote(self.script_env_path)}"
                 )
                 file_pipe = ">>"
             else:
@@ -538,7 +539,7 @@ class JailGenerator(JailResource):
 
             post_commands += [(
                 f"env | grep ^IOCAGE_NIC | sed 's/^/export /' {file_pipe} "
-                f"{self.jail.script_env_path}"
+                f"{shlex.quote(self.jail.script_env_path)}"
             )]
         else:
             post_commands = []

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -679,6 +679,7 @@ class JailGenerator(JailResource):
         if self.running and (os.path.isfile(self.script_env_path) is False):
             # when a jail was started from other iocage variants
             self._write_temporary_script_env()
+            exec_poststop.append(f"rm \"{shlex.quote(self.script_env_path)}\"")
 
         self._write_hook_script(
             "prestop",


### PR DESCRIPTION
fixes #323 

Every time a jail is successfully stopped, the launch script `.env` file can be deleted.