### PR TITLE
do not raise when jls queries fail

### DIFF
--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -105,11 +105,13 @@ class JailState(dict):
                 "--libxo=json"
             ],
             stderr=subprocess.DEVNULL,
+            ignore_error=True,
             logger=self.logger
         )
 
         if returncode > 0:
-            raise iocage.lib.errors.JailStateUpdateFailed()
+            self.clear()
+            return {}
 
         data = _parse_json(stdout)[self.name]
         self._data = data
@@ -127,11 +129,13 @@ class JailState(dict):
                 "-q"
             ],
             stderr=subprocess.DEVNULL,
+            ignore_error=True,
             logger=self.logger
         )
 
         if returncode > 0:
-            raise iocage.lib.errors.JailStateUpdateFailed()
+            self.clear()
+            return {}
 
         data = _parse(stdout)[self.name]
         self._data = data
@@ -195,11 +199,13 @@ class JailStates(dict):
                 "--libxo=json"
             ],
             stderr=subprocess.DEVNULL,
+            ignore_error=True,
             logger=logger
         )
 
         if returncode > 0:
-            raise iocage.lib.errors.JailStateUpdateFailed()
+            self.clear()
+            return
 
         output_data = _parse_json(stdout)
         for name in output_data:
@@ -214,11 +220,13 @@ class JailStates(dict):
                 "-q"
             ],
             stderr=subprocess.DEVNULL,
+            ignore_error=True,
             logger=logger
         )
 
         if returncode > 0:
-            raise iocage.lib.errors.JailStateUpdateFailed()
+            self.clear()
+            return
 
         output_data = _parse(stdout)
         for name in output_data:

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -166,14 +166,6 @@ class JailNotTemplate(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
-class JailStateUpdateFailed(IocageException):
-    """Raised when the jail state could not be obtained."""
-
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        msg = f"Updating the jail state with jls failed"
-        IocageException.__init__(self, msg, *args, **kwargs)
-
-
 class JailLaunchFailed(IocageException):
     """Raised when the jail state could not be obtained."""
 


### PR DESCRIPTION
fixes #325

The invoked jls command exists with 1 when the jail was not running. Instead of raising an error, the state is emptied.