### PR TITLE
mkdir jail launch scripts dir on jail creation

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -281,7 +281,7 @@ class JailGenerator(JailResource):
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
         self.host = iocage.lib.helpers.init_host(self, host)
-        self._relative_hook_script_dir = "/usr/local/iocage-scripts"
+        self._relative_hook_script_dir = "/.iocage"
 
         if isinstance(data, str):
             data = {


### PR DESCRIPTION
Related to #320 

When a jail is newly created with libiocage and then started with another version of iocage without ever being started, mounting the scripts dir `/.iocage` fails because it does not exist. Now this directory (relative to the jail root dataset) is created when the entry to the fstab file is created, not on start/stop.