### PR TITLE
Resource Update launch command error handling

### DIFF
--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -133,10 +133,13 @@ def cli(  # noqa: T484
         exit(1)
 
     fetch_updates = bool(kwargs["fetch_updates"])
-    ctx.parent.print_events(release.fetch(
-        update=kwargs["update"],
-        fetch_updates=fetch_updates
-    ))
+    try:
+        ctx.parent.print_events(release.fetch(
+            update=kwargs["update"],
+            fetch_updates=fetch_updates
+        ))
+    except iocage.lib.errors.IocageException:
+        exit(1)
 
     exit(0)
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -601,7 +601,7 @@ class JailGenerator(JailResource):
             for event in fork_exec_events:
                 continue
         except iocage.lib.errors.IocageException as e:
-            jailForkExecEvent.fail(e)
+            yield jailForkExecEvent.fail(e)
             raise e
         else:
             yield jailForkExecEvent.end()

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -422,8 +422,10 @@ class JailGenerator(JailResource):
 
         if self.config["exec_prestart"] is not None:
             exec_prestart += [self.config["exec_prestart"]]
-        if self.config["exec_start"] is not None:
+
+        if self.config["exec_start"] is not None and (single_command is None):
             exec_start += [self.config["exec_start"]]
+
         if self.config["exec_poststart"] is not None:
             exec_poststart += [self.config["exec_poststart"]]
 

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -351,6 +351,18 @@ class Updater:
             )
             yield executeReleaseUpdateEvent.fail(err)
             raise e
+        finally:
+            jail.state.query()
+            if jail.running:
+                self.logger.debug(
+                    "The update jail is still running. "
+                    "Force-stopping it now."
+                )
+                for event in iocage.lib.Jail.JailGenerator.stop(
+                    jail,
+                    force=True
+                ):
+                    yield event
 
         yield executeReleaseUpdateEvent.end()
 

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -166,9 +166,9 @@ def exec(
     if stderr is not None:
         stderr = stderr.decode("UTF-8").strip()
 
-    if stdout is not None:
+    if (stdout is not None):
         stdout = stdout.decode("UTF-8").strip()
-        if logger and stdout:
+        if logger:
             logger.spam(_prettify_output(stdout))
 
     returncode = child.wait()
@@ -195,7 +195,7 @@ def exec(
 def _prettify_output(output: str) -> str:
     return "\n".join(map(
         lambda line: f"    {line}",
-        output.splitlines()
+        output.strip().splitlines()
     ))
 
 


### PR DESCRIPTION
fixes #331 

With the recent change of the jail start and fork_exec processing via shell-script a regression was introduced that caused resource updates to report a failure even though there were no updates available to install.