### PR TITLE
Update import after refactoring

### DIFF
--- a/iocage/lib/Config/Type/UCL.py
+++ b/iocage/lib/Config/Type/UCL.py
@@ -28,7 +28,7 @@ import ucl
 
 import iocage.lib.Config
 import iocage.lib.Config.Prototype
-import iocage.lib.Config.Resource
+import iocage.lib.Config.Dataset
 import iocage.lib.errors
 
 


### PR DESCRIPTION
The libiocage Resource Config was replaced with just a Dataset Config. This change needs to be reflected in importing modules, such as the config type wrapper for UCL jails.