### PR TITLE
Allow subprocess_args in exec_passthru helper

### DIFF
--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -458,13 +458,15 @@ def exec_generator(
 def exec_passthru(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,
-    print_lines: bool=True
+    print_lines: bool=True,
+    **subprocess_args: typing.Any
 ) -> CommandOutput:
     """Execute a command in an interactive shell."""
     lines = exec_generator(
         command,
         logger=logger,
-        stdout=sys.stdout
+        stdout=sys.stdout,
+        **subprocess_args
     )
     try:
         while True:


### PR DESCRIPTION
- fixes a bug in fork-exec operations where env was an invalid method argument
- exed_passthru helper can handle additional subprocess_args
- required to pass env variables to subprocess forks for example