### PR TITLE
Fix mounted shared ZFS dataset after teardown

### DIFF
--- a/iocage/lib/ZFSShareStorage.py
+++ b/iocage/lib/ZFSShareStorage.py
@@ -52,6 +52,11 @@ class ZFSShareStorage:
         """Unmount a running jails shared ZFS datasets."""
         for dataset in self.get_zfs_datasets():
             self.logger.verbose(f"Unmounting ZFS Dataset {dataset.name}")
+            self._exec_jail([
+                "/sbin/zfs",
+                "umount",
+                dataset.name
+            ])
             self._exec([
                 "/sbin/zfs",
                 "unjail",


### PR DESCRIPTION
Shared ZFS datasets need to be unmounted from within the jail before teardown. Otherwise the jail cannot be destroyed or renamed due to the existing mountpoint.