### PR TITLE
Attach pseudo-terminal on jail start

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1566,7 +1566,6 @@ class JailGenerator(JailResource):
             command_string = (
                 "IOCAGE_JID="
                 f"$(/usr/sbin/jls -j {shlex.quote(self.identifier)} jid)"
-                "\necho JID JID JID $IOCAGE_JID"
                 "\n" + command_string
             )
         if hook_name == "poststop":

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1463,7 +1463,6 @@ class JailGenerator(JailResource):
                 output = (stdout, None, output[2],)
                 return output
         except (KeyboardInterrupt, SystemExit):
-            list(self.stop(force=True))
             raise iocage.lib.errors.JailExecutionAborted(
                 jail=self,
                 logger=None

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -503,6 +503,7 @@ class JailGenerator(JailResource):
                     single_command,
                     passthru=passthru
                 )
+            self.logger.spam(stdout)
         except iocage.lib.errors.IocageException as e:
             yield jailLaunchEvent.fail(e)
             raise e

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -533,7 +533,6 @@ def exec_passthru(
                 print(line)
                 sys.stdout.flush()
     except StopIteration as return_statement:
-
         output: CommandOutput
         output = return_statement.value
         return output


### PR DESCRIPTION
Some init scripts (such as graylog) require a TTY. Jail access to our control TTY is unwanted and in unattended contexts not possible. Instead we attach a pseudo-tty and clean up after command execution.