### PR TITLE
Fix release fetching and idempotence on FreeBSD

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1435,7 +1435,6 @@ class JailGenerator(JailResource):
         command: typing.List[str],
         passthru: bool
     ) -> iocage.lib.helpers.CommandOutput:
-
         try:
             if passthru is True:
                 return iocage.lib.helpers.exec_passthru(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -508,7 +508,7 @@ class JailGenerator(JailResource):
             yield jailLaunchEvent.fail(e)
             raise e
 
-        yield jailLaunchEvent.end()
+        yield jailLaunchEvent.end(stdout=stdout)
 
         self._limit_resources()
         self._configure_nameserver()
@@ -600,7 +600,7 @@ class JailGenerator(JailResource):
                 passthru=passthru
             )
             for event in fork_exec_events:
-                continue
+                yield event
         except iocage.lib.errors.IocageException as e:
             yield jailForkExecEvent.fail(e)
             raise e

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1458,6 +1458,7 @@ class JailGenerator(JailResource):
                         stdout=slave_pts
                     )
                     stdout = os.read(master_pts, 10240).decode("UTF-8")
+                    os.fsync(delegate_pts)
                 finally:
                     os.close(master_pts)
                     os.close(slave_pts)

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1444,7 +1444,7 @@ class JailGenerator(JailResource):
                     env=self.env
                 )
             else:
-                master_pts, slave_pts = pty.openpty()
+                controller_pts, delegate_pts = pty.openpty()
                 output: iocage.lib.helpers.CommandOutput
                 try:
                     output = iocage.lib.helpers.exec(
@@ -1453,15 +1453,15 @@ class JailGenerator(JailResource):
                         ignore_error=True,
                         env=self.env,
                         close_fds=True,
-                        stdin=slave_pts,
-                        stderr=slave_pts,
-                        stdout=slave_pts
+                        stdin=delegate_pts,
+                        stderr=delegate_pts,
+                        stdout=delegate_pts
                     )
-                    stdout = os.read(master_pts, 10240).decode("UTF-8")
                     os.fsync(delegate_pts)
+                    stdout = os.read(controller_pts, 10240).decode("UTF-8")
                 finally:
-                    os.close(master_pts)
-                    os.close(slave_pts)
+                    os.close(controller_pts)
+                    os.close(delegate_pts)
                 output = (stdout, None, output[2],)
                 return output
         except (KeyboardInterrupt, SystemExit):

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -503,7 +503,8 @@ class JailGenerator(JailResource):
                     single_command,
                     passthru=passthru
                 )
-            self.logger.spam(stdout)
+            if stdout is not None:
+                self.logger.spam(stdout)
         except iocage.lib.errors.IocageException as e:
             yield jailLaunchEvent.fail(e)
             raise e

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -488,6 +488,7 @@ class FreeBSD(Updater):
         _command = "\n".join([
             "set +e",
             f"OUTPUT=\"$({command})\"",
+            "echo $OUTPUT",
             "RC=$?",
             "if [ $RC -gt 0 ]; then",
             (

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -275,13 +275,20 @@ class JailEvent(IocageEvent):
 class JailLaunch(JailEvent):
     """Launch a jail."""
 
+    stdout: typing.Optional[str]
+
     def __init__(  # noqa: T484
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
         **kwargs
     ) -> None:
-
+        self.stdout = None
         JailEvent.__init__(self, jail, **kwargs)
+
+    def end(self, stdout, **kwargs) -> 'IocageEvent':  # noqa: T484
+        """Successfully finish an event."""
+        self.stdout = stdout
+        return IocageEvent.end(self, **kwargs)
 
 
 class JailRename(JailEvent):


### PR DESCRIPTION
- Attach jail launch command stdout to JailLaunch event on end
- Test update command output for `No updates are available to install.` on FreeBSD and mark the event as skipped
- Fixes an issue where the JailForkExec event hangs when the process did not print to stdout