### PR TITLE
Update of multiple jails

### DIFF
--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -378,6 +378,18 @@ class ReleaseEvent(IocageEvent):
         IocageEvent.__init__(self, release=release, **kwargs)
 
 
+class ReleaseUpdate(ReleaseEvent):
+    """Update a release."""
+
+    def __init__(  # noqa: T484
+        self,
+        release: 'iocage.lib.Release.ReleaseGenerator',
+        **kwargs
+    ) -> None:
+
+        ReleaseEvent.__init__(self, release, **kwargs)
+
+
 class FetchRelease(ReleaseEvent):
     """Fetch release assets."""
 
@@ -450,20 +462,8 @@ class ReleaseConfiguration(FetchRelease):
         FetchRelease.__init__(self, release, **kwargs)
 
 
-class ReleaseUpdate(ReleaseEvent):
-    """Update a release."""
-
-    def __init__(  # noqa: T484
-        self,
-        release: 'iocage.lib.Release.ReleaseGenerator',
-        **kwargs
-    ) -> None:
-
-        ReleaseEvent.__init__(self, release, **kwargs)
-
-
 class ReleaseUpdatePull(ReleaseUpdate):
-    """Pull release updater and patches from the remote."""
+    """Pull resource updater and patches from the remote."""
 
     def __init__(  # noqa: T484
         self,
@@ -475,7 +475,7 @@ class ReleaseUpdatePull(ReleaseUpdate):
 
 
 class ReleaseUpdateDownload(ReleaseUpdate):
-    """Download release updates/patches."""
+    """Download resource updates/patches."""
 
     def __init__(  # noqa: T484
         self,
@@ -486,28 +486,56 @@ class ReleaseUpdateDownload(ReleaseUpdate):
         ReleaseUpdate.__init__(self, release, **kwargs)
 
 
-class RunReleaseUpdate(ReleaseUpdate):
-    """Run the update of a release."""
+# Resource
+
+
+class ResourceEvent(IocageEvent):
+    """Event with a resource."""
 
     def __init__(  # noqa: T484
         self,
-        release: 'iocage.lib.Release.ReleaseGenerator',
+        resource: 'iocage.lib.Resource.ResourceGenerator',
         **kwargs
     ) -> None:
 
-        ReleaseUpdate.__init__(self, release, **kwargs)
+        self.identifier = resource.full_name
+        IocageEvent.__init__(self, **kwargs)
 
 
-class ExecuteReleaseUpdate(ReleaseUpdate):
+class ResourceUpdate(ResourceEvent):
+    """Update a resource."""
+
+    def __init__(  # noqa: T484
+        self,
+        resource: 'iocage.lib.Resource.ResourceGenerator',
+        **kwargs
+    ) -> None:
+
+        ResourceEvent.__init__(self, resource, **kwargs)
+
+
+class RunResourceUpdate(ResourceUpdate):
+    """Run the update of a resource."""
+
+    def __init__(  # noqa: T484
+        self,
+        resource: 'iocage.lib.Resource.ResourceGenerator',
+        **kwargs
+    ) -> None:
+
+        ResourceUpdate.__init__(self, resource, **kwargs)
+
+
+class ExecuteResourceUpdate(ResourceUpdate):
     """Execute the updater script in a jail."""
 
     def __init__(  # noqa: T484
         self,
-        release: 'iocage.lib.Release.ReleaseGenerator',
+        resource: 'iocage.lib.Resource.ResourceGenerator',
         **kwargs
     ) -> None:
 
-        ReleaseUpdate.__init__(self, release, **kwargs)
+        ResourceUpdate.__init__(self, resource, **kwargs)
 
 
 # ZFS

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -49,15 +49,15 @@ class IocageEvent:
     identifier: typing.Optional[str]
     _started_at: float
     _stopped_at: float
-    _pending: bool = False
-    skipped: bool = False
-    done: bool = True
-    reverted: bool = False
-    error: typing.Optional[typing.Union[bool, BaseException]] = None
+    _pending: bool
+    skipped: bool
+    done: bool
+    reverted: bool
+    error: typing.Optional[typing.Union[bool, BaseException]]
     _rollback_steps: typing.List[typing.Callable[[], typing.Optional[
         typing.Generator['IocageEvent', None, None]
-    ]]] = []
-    _child_events: typing.List['IocageEvent'] = []
+    ]]]
+    _child_events: typing.List['IocageEvent']
 
     def __init__(  # noqa: T484
         self,
@@ -68,6 +68,14 @@ class IocageEvent:
         for event in IocageEvent.HISTORY:
             if event.__hash__() == self.__hash__():
                 return event  # type: ignore
+
+        self._pending = False
+        self.skipped = False
+        self.done = True
+        self.reverted = False
+        self.error = None
+        self._rollback_steps = []
+        self._child_events = []
 
         self.data = kwargs
         self._rollback_steps = []


### PR DESCRIPTION
- Prevent events from behaving as singleton
- Use the resource as identifier of update events

The event identifier of ReleaseUpdate events was the releases full_name. When updating resources that had the same event, the identifier led to confusion in the event history stack.