### PR TITLE
Fix duplicate root/ preifx of launch scripts after renaming

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -987,7 +987,7 @@ class JailGenerator(JailResource):
         When no new_path_prefix is provided, the jail's root dataset is used.
         """
         if new_path_prefix is None:
-            _new_path_prefix = self.root_dataset.mountpoint
+            _new_path_prefix = self.dataset.mountpoint
         else:
             _new_path_prefix = new_path_prefix
 


### PR DESCRIPTION
- new_path_prefix is a resources dataset, not root_dataset mountpoint