### PR TITLE
Refactor JailConfigValue errors

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -561,8 +561,8 @@ class BaseConfig(dict):
 
             self.data[key] = parsed_value
         except ValueError:
-            error = iocage.lib.errors.JailConfigValueError(
-                key=key,
+            error = iocage.lib.errors.InvalidJailConfigValue(
+                property_name=key,
                 logger=self.logger,
                 level=("warn" if (skip_on_error is True) else "error")
             )

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -134,10 +134,7 @@ class ResourceLimitProp(ResourceLimitValue):
         if property_name not in properties:
             raise iocage.lib.errors.ResourceLimitUnknown(logger=self.logger)
 
-        try:
-            self.__update_from_config()
-        except ValueError:
-            raise iocage.lib.errors.ResourceLimitSyntax(logger=self.logger)
+        self.__update_from_config()
 
         ResourceLimitValue.__init__(self)
 
@@ -145,10 +142,7 @@ class ResourceLimitProp(ResourceLimitValue):
         self,
         value: str
     ) -> typing.Tuple[str, str, str]:
-        try:
-            return ResourceLimitValue._parse_resource_limit(self, value=value)
-        except ValueError:
-            raise iocage.lib.errors.ResourceLimitSyntax(logger=self.logger)
+        return ResourceLimitValue._parse_resource_limit(self, value=value)
 
     def __update_from_config(self) -> None:
         name = self.property_name

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -219,25 +219,6 @@ class FstabDestinationExists(IocageException):
         IocageException.__init__(self, msg, *args, **kwargs)
 
 
-# Jail Resource Limits
-
-
-class ResourceLimitSyntax(IocageException, ValueError):
-    """Raised when a resource limit has invalid syntax."""
-
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        msg = f"The resource limit has invalid syntax"
-        IocageException.__init__(self, msg, *args, **kwargs)
-
-
-class ResourceLimitUnknown(IocageException, KeyError):
-    """Raised when a resource limit has is unknown."""
-
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        msg = f"The specified resource limit is unknown"
-        IocageException.__init__(self, msg, *args, **kwargs)
-
-
 # Security
 
 
@@ -288,14 +269,6 @@ class JailConfigError(IocageException):
     pass
 
 
-class JailConfigValueError(JailConfigError, ValueError):
-    """Raised when a jail config value is invalid."""
-
-    def __init__(self, key: str, *args, **kwargs) -> None:  # noqa: T484
-        msg = f"Invalid config value for '{key}'"
-        super().__init__(msg, *args, **kwargs)
-
-
 class InvalidJailName(JailConfigError):
     """Raised when a jail has an invalid name."""
 
@@ -318,7 +291,7 @@ class JailConigZFSIsNotAllowed(JailConfigError):
         super().__init__(msg, *args, **kwargs)
 
 
-class InvalidJailConfigValue(JailConfigError):
+class InvalidJailConfigValue(JailConfigError, ValueError):
     """Raised when a jail configuration value is invalid."""
 
     def __init__(  # noqa: T484
@@ -358,6 +331,14 @@ class InvalidMacAddress(IocageException, ValueError):
             message=reason,
             **kwargs
         )
+
+
+class ResourceLimitUnknown(IocageException, KeyError):
+    """Raised when a resource limit has is unknown."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+        msg = f"The specified resource limit is unknown"
+        IocageException.__init__(self, msg, *args, **kwargs)
 
 
 class JailConfigNotFound(IocageException):

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -312,7 +312,7 @@ class JailConigZFSIsNotAllowed(JailConfigError):
 
     def __init__(self, *args, **kwargs) -> None:  # noqa: T484
         msg = (
-            "jail_zfs is disabled"
+            "jail_zfs is disabled "
             "despite jail_zfs_dataset is configured"
         )
         super().__init__(msg, *args, **kwargs)


### PR DESCRIPTION
- There were two different exception types for the same event that are now consolidated
- Reduce complexity of JailConfigValue error handling