### PR TITLE
ignore: pytest_cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ ENV/
 
 *.orig
 *.rej
+.pytest_cache/


### PR DESCRIPTION
on those rare systems we can actually test on, we can safely ignore this
directory.