### PR TITLE
ignore: pytest_cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ ENV/
 
 *.orig
 *.rej
+.pytest_cache/


### PR DESCRIPTION
on those rare systems we can actually test on, we don't want
.pytest_cache/ in our git status