### PR TITLE
Global CLI flag to specify iocage source datasets

### DIFF
--- a/iocage/cli/__init__.py
+++ b/iocage/cli/__init__.py
@@ -166,8 +166,20 @@ class IOCageCLI(click.MultiCommand):
             return
 
 
-@click.option("--log-level", "-d", default=None)
-@click.option("--source", multiple=True, type=str)
+@click.option(
+    "--log-level",
+    "-d",
+    default=None,
+    help=(
+        f"Set the CLI log level {Logger.LOG_LEVELS}"
+    )
+)
+@click.option(
+    "--source",
+    multiple=True,
+    type=str,
+    help="Globally override the activated iocage dataset(s)"
+)
 @click.command(cls=IOCageCLI)
 @click.version_option(version="0.2.12 09/17/2017", prog_name="ioc")
 @click.pass_context

--- a/iocage/cli/activate.py
+++ b/iocage/cli/activate.py
@@ -39,7 +39,11 @@ __rootcmd__ = True
 def cli(ctx, zpool, mountpoint):
     """Call ZFS set to change the property org.freebsd.ioc:active to yes."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs(logger=logger)
+    zfs = ctx.parent.zfs
+
+    if ctx.parent.user_sources is not None:
+        logger.error("Cannot activate when executed with explicit sources.")
+        exit(1)
 
     iocage_pool = None
 

--- a/iocage/cli/clone.py
+++ b/iocage/cli/clone.py
@@ -57,19 +57,20 @@ def cli(
     """Clone and promote jails."""
     print_function = ctx.parent.print_events
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs(logger=logger)
 
     ioc_source_jail = iocage.lib.Jail.JailGenerator(
         dict(id=source),
         logger=logger,
-        zfs=zfs
+        zfs=ctx.parent.zfs,
+        host=ctx.parent.host
     )
 
     ioc_destination_jail = iocage.lib.Jail.JailGenerator(
         dict(id=destination),
         new=True,
         logger=logger,
-        zfs=zfs
+        zfs=ctx.parent.zfs,
+        host=ctx.parent.host
     )
 
     try:

--- a/iocage/cli/console.py
+++ b/iocage/cli/console.py
@@ -43,6 +43,7 @@ def cli(ctx, jail, start):
         ioc_jail = iocage.lib.Jail.JailGenerator(
             jail,
             logger=logger,
+            zfs=ctx.parent.zfs,
             host=ctx.parent.host
         )
         ioc_jail.state.query()

--- a/iocage/cli/console.py
+++ b/iocage/cli/console.py
@@ -40,7 +40,11 @@ def cli(ctx, jail, start):
     logger = ctx.parent.logger
 
     try:
-        ioc_jail = iocage.lib.Jail.JailGenerator(jail, logger=logger)
+        ioc_jail = iocage.lib.Jail.JailGenerator(
+            jail,
+            logger=logger,
+            host=ctx.parent.host
+        )
         ioc_jail.state.query()
     except iocage.lib.errors.JailNotFound:
         exit(1)

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -99,8 +99,8 @@ def cli(
 ) -> None:
     """Create iocage jails."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs(logger=logger)
-    host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
+    zfs: iocage.lib.ZFS.ZFS = ctx.parent.zfs
+    host: iocage.lib.Host.Host = ctx.parent.host
 
     jail_data: typing.Dict[str, typing.Any] = {}
 

--- a/iocage/cli/deactivate.py
+++ b/iocage/cli/deactivate.py
@@ -38,7 +38,7 @@ __rootcmd__ = True
 def cli(ctx, zpool):
     """Call ZFS set to change the property org.freebsd.ioc:active to no."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs()
+    zfs = ctx.parent.zfs
 
     iocage_pool = None
 

--- a/iocage/cli/destroy.py
+++ b/iocage/cli/destroy.py
@@ -65,9 +65,6 @@ def cli(
     location to stop_jail.
     """
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.ZFS()
-    zfs.logger = logger
-    host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
 
     if filters is None or len(filters) == 0:
         logger.error("No filter specified - cannot select a target to delete")
@@ -84,8 +81,8 @@ def cli(
 
     resources = list(resources_class(
         filters=filters,
-        zfs=zfs,
-        host=host,
+        zfs=ctx.parent.zfs,
+        host=ctx.parent.host,
         logger=logger
     ))
 

--- a/iocage/cli/exec.py
+++ b/iocage/cli/exec.py
@@ -80,7 +80,12 @@ def cli(
             shlex.quote(user_command)
         ]
 
-    ioc_jail = iocage.lib.Jail.JailGenerator(jail, logger=logger)
+    ioc_jail = iocage.lib.Jail.JailGenerator(
+        jail,
+        logger=logger,
+        zfs=ctx.parent.zfs,
+        host=ctx.parent.host
+    )
     ioc_jail.state.query()
 
     if not ioc_jail.exists:

--- a/iocage/cli/export.py
+++ b/iocage/cli/export.py
@@ -67,9 +67,8 @@ def cli(
     as the destination path.
     """
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.ZFS()
-    zfs.logger = logger
-    host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
+    zfs: iocage.lib.ZFS.ZFS = ctx.parent.zfs
+    host: iocage.lib.Host.HostGenerator = ctx.parent.host
     print_events = ctx.parent.print_events
 
     # Recursive exports cannot be imported at the current time

--- a/iocage/cli/fetch.py
+++ b/iocage/cli/fetch.py
@@ -91,7 +91,8 @@ def cli(  # noqa: T484
 ) -> None:
     """Fetch and update releases."""
     logger = ctx.parent.logger
-    host = iocage.lib.Host.HostGenerator(logger=logger)
+    host = ctx.parent.host
+    zfs = ctx.parent.zfs
     prompts = iocage.lib.Prompts.Prompts(host=host, logger=logger)
 
     release_input = kwargs["release"]
@@ -105,6 +106,7 @@ def cli(  # noqa: T484
             release = iocage.lib.Release.ReleaseGenerator(
                 name=release_input,
                 host=host,
+                zfs=zfs,
                 logger=logger
             )
         except Exception:

--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -236,4 +236,4 @@ def cli(
 ) -> None:
     """View and manipulate a jails fstab file."""
     ctx.logger = ctx.parent.logger
-    ctx.host = iocage.lib.Host.HostGenerator(logger=ctx.logger)
+    ctx.host = ctx.parent.logger

--- a/iocage/cli/import.py
+++ b/iocage/cli/import.py
@@ -45,9 +45,8 @@ def cli(
 ) -> None:
     """Restore a jail from a backup archive."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.ZFS()
-    zfs.logger = logger
-    host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
+    zfs: iocage.lib.ZFS.ZFS = ctx.parent.zfs
+    host: iocage.lib.Host.HostGenerator = ctx.parent.host
     print_events = ctx.parent.print_events
 
     ioc_jail = iocage.lib.Jail.JailGenerator(

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -76,12 +76,8 @@ def cli(
 ) -> None:
     """List jails in various formats."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs(logger=logger)
-
-    try:
-        host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
-    except iocage.lib.errors.IocageNotActivated:
-        exit(1)
+    zfs = ctx.parent.zfs
+    host = ctx.parent.host
 
     if output is not None and _long is True:
         logger.error("--output and --long can't be used together")

--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -76,8 +76,7 @@ def cli(
 ) -> None:
     """List jails in various formats."""
     logger = ctx.parent.logger
-    zfs = ctx.parent.zfs
-    host = ctx.parent.host
+    host: iocage.lib.Host.HostGenerator = ctx.parent.host
 
     if output is not None and _long is True:
         logger.error("--output and --long can't be used together")
@@ -125,7 +124,7 @@ def cli(
                 resources = resources_class(
                     logger=logger,
                     host=host,
-                    zfs=zfs,
+                    zfs=ctx.parent.zfs,
                     # ToDo: allow quoted whitespaces from user inputs
                     filters=filters
                 )

--- a/iocage/cli/promote.py
+++ b/iocage/cli/promote.py
@@ -46,12 +46,12 @@ def cli(
 ) -> None:
     """Clone and promote jails."""
     logger = ctx.parent.logger
-    zfs = iocage.lib.ZFS.get_zfs(logger=logger)
 
     ioc_jail = iocage.lib.Jail.JailGenerator(
         dict(id=jail),
         logger=logger,
-        zfs=zfs
+        zfs=ctx.parent.zfs,
+        host=ctx.parent.host
     )
 
     try:

--- a/iocage/cli/rename.py
+++ b/iocage/cli/rename.py
@@ -48,8 +48,10 @@ def cli(
         ioc_jail = iocage.lib.Jail.Jail(
             jail,
             logger=logger,
+            zfs=ctx.parent.zfs,
             host=ctx.parent.host
         )
         print_function(ioc_jail.rename(name))
     except iocage.lib.errors.IocageException:
         exit(1)
+

--- a/iocage/cli/rename.py
+++ b/iocage/cli/rename.py
@@ -45,7 +45,11 @@ def cli(
     print_function = ctx.parent.print_events
 
     try:
-        ioc_jail = iocage.lib.Jail.Jail(jail, logger=logger)
+        ioc_jail = iocage.lib.Jail.Jail(
+            jail,
+            logger=logger,
+            host=ctx.parent.host
+        )
         print_function(ioc_jail.rename(name))
     except iocage.lib.errors.IocageException:
         exit(1)

--- a/iocage/cli/restart.py
+++ b/iocage/cli/restart.py
@@ -71,6 +71,8 @@ def cli(
         exit(1)
 
     ioc_jails = iocage.lib.Jails.JailsGenerator(
+        host=ctx.parent.host,
+        zfs=ctx.parent.zfs,
         logger=logger,
         filters=jails
     )

--- a/iocage/cli/set.py
+++ b/iocage/cli/set.py
@@ -50,7 +50,7 @@ def cli(
     """Set one or many configuration properties of one jail."""
     parent: typing.Any = ctx.parent
     logger: iocage.lib.Logger.Logger = parent.logger
-    host = iocage.lib.Host.HostGenerator(logger=logger)
+    host: iocage.lib.Host.HostGenerator = parent.host
 
     # Defaults
     if jail == "defaults":

--- a/iocage/cli/snapshot.py
+++ b/iocage/cli/snapshot.py
@@ -192,7 +192,7 @@ def cli(
 ) -> None:
     """Take and manage resource snapshots."""
     ctx.logger = ctx.parent.logger
-    ctx.host = iocage.lib.Host.HostGenerator(logger=ctx.logger)
+    ctx.host = ctx.parent.host
 
 
 def _parse_identifier(

--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -48,6 +48,7 @@ def cli(
     """Start one or many jails."""
     logger = ctx.parent.logger
     start_args = {
+        "zfs": ctx.parent.zfs,
         "host": ctx.parent.host,
         "logger": logger,
         "print_function": ctx.parent.print_events
@@ -68,6 +69,7 @@ def cli(
 
 
 def _autostart(
+    zfs: iocage.lib.ZFS.ZFS,
     host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
@@ -79,6 +81,7 @@ def _autostart(
     filters = ("boot=yes", "running=no", "template=no",)
 
     ioc_jails = iocage.lib.Jails.Jails(
+        zfs=zfs,
         host=host,
         logger=logger,
         filters=filters
@@ -108,6 +111,7 @@ def _autostart(
 
 def _normal(
     filters: typing.Tuple[str, ...],
+    zfs: iocage.lib.ZFS.ZFS,
     host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
@@ -120,6 +124,8 @@ def _normal(
 
     jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,
+        zfs=zfs,
+        host=host,
         filters=filters
     )
 

--- a/iocage/cli/start.py
+++ b/iocage/cli/start.py
@@ -48,6 +48,7 @@ def cli(
     """Start one or many jails."""
     logger = ctx.parent.logger
     start_args = {
+        "host": ctx.parent.host,
         "logger": logger,
         "print_function": ctx.parent.print_events
     }
@@ -67,6 +68,7 @@ def cli(
 
 
 def _autostart(
+    host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
         [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
@@ -77,6 +79,7 @@ def _autostart(
     filters = ("boot=yes", "running=no", "template=no",)
 
     ioc_jails = iocage.lib.Jails.Jails(
+        host=host,
         logger=logger,
         filters=filters
     )
@@ -105,6 +108,7 @@ def _autostart(
 
 def _normal(
     filters: typing.Tuple[str, ...],
+    host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
         [typing.Generator[iocage.lib.events.IocageEvent, None, None]],

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -57,6 +57,7 @@ def cli(
     logger = ctx.parent.logger
     stop_args = {
         "logger": logger,
+        "zfs": ctx.parent.zfs,
         "host": ctx.parent.host,
         "print_function": ctx.parent.print_events,
         "force": force
@@ -73,6 +74,7 @@ def cli(
 
         _autostop(
             host=ctx.parent.host,
+            zfs=ctx.parent.zfs,
             logger=logger,
             print_function=ctx.parent.print_events,
             force=force
@@ -84,6 +86,7 @@ def cli(
 
 def _normal(
     filters: typing.Tuple[str, ...],
+    zfs: iocage.lib.Host.HostGenerator,
     host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
@@ -96,6 +99,7 @@ def _normal(
     filters += ("template=no,-",)
 
     jails = iocage.lib.Jails.JailsGenerator(
+        zfs=zfs,
         host=host,
         logger=logger,
         filters=filters
@@ -125,6 +129,7 @@ def _normal(
 
 
 def _autostop(
+    zfs: iocage.lib.ZFS.ZFS,
     host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
@@ -138,6 +143,7 @@ def _autostop(
 
     ioc_jails = iocage.lib.Jails.Jails(
         host=host,
+        zfs=zfs,
         logger=logger,
         filters=filters
     )

--- a/iocage/cli/stop.py
+++ b/iocage/cli/stop.py
@@ -57,6 +57,7 @@ def cli(
     logger = ctx.parent.logger
     stop_args = {
         "logger": logger,
+        "host": ctx.parent.host,
         "print_function": ctx.parent.print_events,
         "force": force
     }
@@ -71,6 +72,7 @@ def cli(
             exit(1)
 
         _autostop(
+            host=ctx.parent.host,
             logger=logger,
             print_function=ctx.parent.print_events,
             force=force
@@ -82,6 +84,7 @@ def cli(
 
 def _normal(
     filters: typing.Tuple[str, ...],
+    host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
         [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
@@ -93,6 +96,7 @@ def _normal(
     filters += ("template=no,-",)
 
     jails = iocage.lib.Jails.JailsGenerator(
+        host=host,
         logger=logger,
         filters=filters
     )
@@ -121,6 +125,7 @@ def _normal(
 
 
 def _autostop(
+    host: iocage.lib.Host.HostGenerator,
     logger: iocage.lib.Logger.Logger,
     print_function: typing.Callable[
         [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
@@ -132,6 +137,7 @@ def _autostop(
     filters = ("running=yes", "template=no",)
 
     ioc_jails = iocage.lib.Jails.Jails(
+        host=host,
         logger=logger,
         filters=filters
     )

--- a/iocage/cli/update.py
+++ b/iocage/cli/update.py
@@ -57,15 +57,11 @@ def cli(
         logger.error("No jail selector provided")
         exit(1)
 
-    zfs = iocage.lib.ZFS.ZFS()
-    zfs.logger = logger
-    host = iocage.lib.Host.Host(logger=logger, zfs=zfs)
-
     filters = jails + ("template=no",)
     ioc_jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,
-        host=host,
-        zfs=zfs,
+        host=ctx.parent.host,
+        zfs=ctx.parent.zfs,
         filters=filters
     )
 

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -112,6 +112,9 @@ class Datasets(dict):
 
     def __init__(
         self,
+        sources: typing.Optional[
+            typing.Dict[str, typing.Union[str, libzfs.ZFSDataset]]
+        ]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None
     ) -> None:
@@ -120,6 +123,10 @@ class Datasets(dict):
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
         self.main_datasets_name = None
+
+        if sources is not None:
+            self.attach_sources(sources)
+            return
 
         try:
             self._configure_from_rc_conf()

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -74,6 +74,7 @@ class HostGenerator:
     def __init__(
         self,
         defaults: typing.Optional[iocage.lib.Resource.DefaultResource]=None,
+        datasets: typing.Optional[iocage.lib.Datasets.Datasets]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None
     ) -> None:
@@ -81,10 +82,13 @@ class HostGenerator:
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
 
-        self.datasets = iocage.lib.Datasets.Datasets(
-            logger=self.logger,
-            zfs=self.zfs
-        )
+        if datasets is not None:
+            self.datasets = datasets
+        else:
+            self.datasets = iocage.lib.Datasets.Datasets(
+                logger=self.logger,
+                zfs=self.zfs
+            )
 
         self.distribution = self._class_distribution(
             host=self,


### PR DESCRIPTION
- Allows using `ioc` without system wide activated pool
- Run `ioc` commands on differing datasets than the host is configured (later on used by tests)