### PR TITLE
pipe fork_exec stderr to stdout

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1489,8 +1489,10 @@ class JailGenerator(JailResource):
                 (
                     f"/usr/sbin/jexec {self.identifier} "
                     f"{self._relative_hook_script_dir}/command.sh"
+                    " 2>&1"
                 ),
                 f"/bin/sh {self.get_hook_script_path('poststop')}",
+                "exit 0"
             ]
         ))
 


### PR DESCRIPTION
Stdout and stderr are not both read line-by-line. In some occasions stderr caused the command to never terminate which recently caused HardenedBSD updates to hang. This change suppresses stderr by piping it to stderr while executing the fork_exec command.