### PR TITLE
fstab cli command ctx.host must be a HostGenerator

### DIFF
--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -236,4 +236,4 @@ def cli(
 ) -> None:
     """View and manipulate a jails fstab file."""
     ctx.logger = ctx.parent.logger
-    ctx.host = ctx.parent.logger
+    ctx.host = ctx.parent.host


### PR DESCRIPTION
Fixes the broken fstab CLI command.