### PR TITLE
Error handling when launching a jail

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1515,12 +1515,6 @@ class JailGenerator(JailResource):
             passthru=passthru
         )
 
-        if returncode > 0:
-            raise iocage.lib.errors.JailCommandFailed(
-                returncode=returncode,
-                logger=None
-            )
-
         return stdout, stderr, returncode
 
     def _get_value(self, key: str) -> str:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1428,6 +1428,10 @@ class JailGenerator(JailResource):
             passthru=passthru
         )
         if returncode > 0:
+            self.logger.verbose(
+                f"Jail '{self.humanreadable_name}' was not started",
+                jail=self
+            )
             return stdout, stderr, returncode
 
         self.state.query()
@@ -1514,6 +1518,12 @@ class JailGenerator(JailResource):
             command,
             passthru=passthru
         )
+
+        if returncode > 0:
+            message = f"Jail {self.humanreadable_name} command failed."
+        else:
+            message = f"Jail {self.humanreadable_name} command finished."
+        self.logger.verbose(message)
 
         return stdout, stderr, returncode
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -411,8 +411,7 @@ class JailGenerator(JailResource):
         exec_start: typing.List[str] = []
         exec_started: typing.List[str] = [
             f"echo \"export IOCAGE_JID=$IOCAGE_JID\" > {self.script_env_path}",
-            "set -e",
-            "set -u",
+            "set -eu",
         ]
         exec_poststart: typing.List[str] = []
 
@@ -467,9 +466,7 @@ class JailGenerator(JailResource):
         self._write_hook_script(
             "poststart",
             self._wrap_hook_script_command_string([
-                "set -u",
-                "set -e",
-                "set -x",
+                "set -eu",
                 "/bin/echo running exec.started hook on the host",
                 f"/bin/sh {self.get_hook_script_path('started')} 2>&1",
                 "/bin/echo running exec.start hook in the jail",
@@ -539,7 +536,7 @@ class JailGenerator(JailResource):
 
         EOF_IDENTIFIER = f"EOF{random.getrandbits(64)}"
         output: typing.List[str] = [
-            "set -e",
+            "set -eu",
             "echo 'Executing jail start scripts'",
             "jexec -j {self.identifier} /bin/sh <<{EOF_IDENTIFIER}"
         ] + commands + [
@@ -1506,10 +1503,9 @@ class JailGenerator(JailResource):
         self._write_hook_script("command", "\n".join(
             ["set +e"] +
             (["service ipfw onestop"] if self.host.ipfw_enabled else []) +
-            ["set -e"] +
             [
+                "set -e"
                 f". {self._relative_hook_script_dir}/start.sh",
-                "set -e",
                 jail_command,
             ]
         ))


### PR DESCRIPTION
Attaching a pseudo-terminal to the jail launch command resulted in invalid error detection on jail launch. Failing commands did not influence the jail start command exit code and did not revert the operations accordingly.