### PR TITLE
Fix fetching EOL releases

### DIFF
--- a/iocage/lib/Distribution.py
+++ b/iocage/lib/Distribution.py
@@ -235,25 +235,6 @@ class DistributionGenerator:
 
             return parser.eol_releases
 
-    def _parse_release_version(self, release_version_string: str) -> str:
-        parsed_version = release_version_string.split("-", maxsplit=1)[0]
-        if "." not in parsed_version:
-            parsed_version += ".0"
-        return parsed_version
-
-    def _check_eol(self, release_name: str, eol: typing.List[str]) -> bool:
-        if self.host.distribution.name == "FreeBSD":
-            return release_name in eol
-        elif self.host.distribution.name == "HardenedBSD":
-            if "STABLE" in release_name:
-                # stable releases are explicitly in the EOL list or supported
-                return release_name in eol
-            return self._parse_release_version(release_name) in map(
-                lambda x: self._parse_release_version(x),
-                eol
-            )
-        return False
-
     @property
     def releases(self) -> typing.List['iocage.lib.Release.ReleaseGenerator']:
         """

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -407,15 +407,17 @@ class ReleaseGenerator(ReleaseResource):
         return self._parse_release_version(self.name)
 
     def _parse_release_version(self, release_version_string: str) -> float:
-        parsed_version, suffix = release_version_string.split("-", maxsplit=1)
+        _parts = release_version_string.split("-", maxsplit=1)
+        parsed_version = _parts[0]
         try:
             version = float(parsed_version)
             if self.host.distribution.name == "HardenedBSD":
-                has_stable_suffix = (suffix.upper() == "STABLE") is True
-                if (version == 10.0) and has_stable_suffix:
-                    return 10.4
-                elif (version == 11.0) and has_stable_suffix:
-                    return 11.1
+                if (len(_parts) == 2) and (_parts[1].upper() == "STABLE"):
+                    if (version == 10.0):
+                        return 10.4
+                    elif (version == 11.0):
+                        return 11.1
+
             return version
         except ValueError:
             return float(0)

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -385,17 +385,22 @@ class ReleaseGenerator(ReleaseResource):
             if "STABLE" in self.name:
                 # stable releases are explicitly in the EOL list or supported
                 return (self.name in self.host.distribution.eol_list) is True
-            return (self._parse_release_version(self.name) in map(
+            return (self.version_number in map(
                 lambda x: self._parse_release_version(x),
                 self.host.distribution.eol_list
             )) is True
         return False
 
-    def _parse_release_version(self, release_version_string: str) -> str:
+    @property
+    def version_number(self) -> float:
+        return self._parse_release_version(self.name)
+
+    def _parse_release_version(self, release_version_string: str) -> float:
         parsed_version = release_version_string.split("-", maxsplit=1)[0]
-        if "." not in parsed_version:
-            parsed_version += ".0"
-        return parsed_version
+        try:
+            return float(parsed_version)
+        except ValueError:
+            return float(0)
 
     @property
     def mirror_url(self) -> str:

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -391,8 +391,19 @@ class ReleaseGenerator(ReleaseResource):
             )) is True
         return False
 
+    def _require_release_supported(self) -> None:
+        if self.host.distribution.name == "HardenedBSD":
+            version = self.release.version_number
+            if (version == 0) or (version >= 10.3):
+                return
+            raise iocage.lib.errors.UnsupportedRelease(
+                version=version,
+                logger=self.logger
+            )
+
     @property
     def version_number(self) -> float:
+        """Return the numeric release version number or 0 for CURRENT."""
         return self._parse_release_version(self.name)
 
     def _parse_release_version(self, release_version_string: str) -> float:
@@ -542,6 +553,7 @@ class ReleaseGenerator(ReleaseResource):
     ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
         """Fetch the release from the remote."""
         release_changed = False
+        self._require_release_supported()
 
         events = iocage.lib.events
         fetchReleaseEvent = events.FetchRelease(self)

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -394,7 +394,7 @@ class ReleaseGenerator(ReleaseResource):
     def _require_release_supported(self) -> None:
         if self.host.distribution.name == "HardenedBSD":
             version = self.release.version_number
-            if (version == 0) or (version >= 10.3):
+            if (version == 0) or (version >= 10.4):
                 return
             raise iocage.lib.errors.UnsupportedRelease(
                 version=version,

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -407,9 +407,16 @@ class ReleaseGenerator(ReleaseResource):
         return self._parse_release_version(self.name)
 
     def _parse_release_version(self, release_version_string: str) -> float:
-        parsed_version = release_version_string.split("-", maxsplit=1)[0]
+        parsed_version, suffix = release_version_string.split("-", maxsplit=1)
         try:
-            return float(parsed_version)
+            version = float(parsed_version)
+            if self.host.distribution.name == "HardenedBSD":
+                has_stable_suffix = (suffix.upper() == "STABLE") is True
+                if (version == 10.0) and has_stable_suffix:
+                    return 10.4
+                elif (version == 11.0) and has_stable_suffix:
+                    return 11.1
+            return version
         except ValueError:
             return float(0)
 

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -378,7 +378,24 @@ class ReleaseGenerator(ReleaseResource):
         """
         if not self.check_eol:
             return None
-        return (self.name in self.host.distribution.eol_list) is True
+
+        if self.host.distribution.name == "FreeBSD":
+            return (self.name in self.host.distribution.eol_list) is True
+        elif self.host.distribution.name == "HardenedBSD":
+            if "STABLE" in self.name:
+                # stable releases are explicitly in the EOL list or supported
+                return (self.name in self.host.distribution.eol_list) is True
+            return (self._parse_release_version(self.name) in map(
+                lambda x: self._parse_release_version(x),
+                self.host.distribution.eol_list
+            )) is True
+        return False
+
+    def _parse_release_version(self, release_version_string: str) -> str:
+        parsed_version = release_version_string.split("-", maxsplit=1)[0]
+        if "." not in parsed_version:
+            parsed_version += ".0"
+        return parsed_version
 
     @property
     def mirror_url(self) -> str:

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -400,8 +400,11 @@ class HardenedBSD(Updater):
             "-v", "latest", "-U",  # skip version check
             "-n",  # no kernel
             "-V",
-            "-D",  # no download
-        ] + self._version_dependent_command_attributes
+            "-D",  # no download,
+            "-T",
+            "-t",
+            self.local_temp_dir
+        ]
 
     @property
     def _fetch_command(self) -> typing.List[str]:
@@ -413,25 +416,11 @@ class HardenedBSD(Updater):
             "-f",  # fetch only
             "-c",
             f"{self.host_updates_dir}/{self.update_conf_name}",
-            "-V"
-        ] + self._version_dependent_command_attributes
-
-    @property
-    def _version_dependent_command_attributes(self) -> typing.List[str]:
-        version = self.release.version_number
-        if (version >= 10.4) or (version == 0):
-            return [
-                "-T",
-                "-t",
-                self.local_temp_dir
-            ]  # keep temp
-        elif version >= 10.3:
-            return ["-t", self.local_temp_dir]
-        else:
-            raise iocage.lib.errors.UnsupportedRelease(
-                version=version,
-                logger=self.logger
-            )
+            "-V",
+            "-T",
+            "-t",
+            self.local_temp_dir
+        ]
 
     def _get_release_trunk_file_url(
         self,

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -151,9 +151,6 @@ class Updater:
     def _update_command(self) -> typing.List[str]:
         raise NotImplementedError("To be implemented by inheriting classes")
 
-    def _ensure_release_is_supported(self) -> None:
-        return
-
     def _get_release_trunk_file_url(
         self,
         release: 'iocage.lib.Release.ReleaseGenerator',
@@ -249,7 +246,7 @@ class Updater:
                 logger=self.logger
             )
 
-        self._ensure_release_is_supported()
+        self.resource._require_release_supported()
 
         events = iocage.lib.events
         releaseUpdatePullEvent = events.ReleaseUpdatePull(self.release)
@@ -430,15 +427,11 @@ class HardenedBSD(Updater):
             ]  # keep temp
         elif version >= 10.3:
             return ["-t", self.local_temp_dir]
-
-    def _ensure_release_is_supported(self) -> None:
-        version = self.release.version_number
-        if (version == 0) or (version >= 10.3):
-            return
-        raise iocage.lib.errors.UnsupportedRelease(
-            version=version,
-            logger=self.logger
-        )
+        else:
+            raise iocage.lib.errors.UnsupportedRelease(
+                version=version,
+                logger=self.logger
+            )
 
     def _get_release_trunk_file_url(
         self,

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -68,8 +68,7 @@ class MissingFeature(IocageException, NotImplementedError):
     ) -> None:
         message = (
             f"Missing Feature: '{feature_name}' "
-            "are" if plural is True else "is"
-            " not implemented yet"
+            f"{'are' if plural is True else 'is'} not implemented yet"
         )
         IocageException.__init__(self, message, *args, **kwargs)
 
@@ -948,12 +947,15 @@ class UnsupportedRelease(MissingFeature):
     def __init__(  # noqa: T484
         self,
         version: float,
-        *args,
         **kwargs
     ) -> None:
 
-        msg = f"Release version {version} is currently not supported"
-        super().__init__(msg, plural=True *args, **kwargs)
+        feature_name = f"Support for release version {version}"
+        super().__init__(
+            feature_name=feature_name,
+            plural=True,
+            **kwargs
+        )
 
 # Prompts
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -53,6 +53,27 @@ class IocageException(Exception):
             super().__init__(message)
 
 
+# Missing Features
+
+
+class MissingFeature(IocageException, NotImplementedError):
+    """Raised when an iocage feature is not fully implemented yet."""
+
+    def __init__(  # noqa: T484
+            self,
+            feature_name: str,
+            plural: bool=False,
+            *args,
+            **kwargs
+    ) -> None:
+        message = (
+            f"Missing Feature: '{feature_name}' "
+            "are" if plural is True else "is"
+            " not implemented yet"
+        )
+        IocageException.__init__(self, message, *args, **kwargs)
+
+
 # Jails
 
 
@@ -921,6 +942,19 @@ class ReleaseUpdateBranchLookup(IocageException):
         super().__init__(msg, *args, **kwargs)
 
 
+class UnsupportedRelease(MissingFeature):
+    """Raised when interacting with an unsupported release."""
+
+    def __init__(  # noqa: T484
+        self,
+        version: float,
+        *args,
+        **kwargs
+    ) -> None:
+
+        msg = f"Release version {version} is currently not supported"
+        super().__init__(msg, plural=True *args, **kwargs)
+
 # Prompts
 
 
@@ -1058,24 +1092,3 @@ class JailFilterInvalidName(JailFilterException):
             "Cannot select jail with illegal name"
         )
         JailFilterException.__init__(self, msg, *args, **kwargs)
-
-
-# Missing Features
-
-
-class MissingFeature(IocageException, NotImplementedError):
-    """Raised when an iocage feature is not fully implemented yet."""
-
-    def __init__(  # noqa: T484
-            self,
-            feature_name: str,
-            plural: bool=False,
-            *args,
-            **kwargs
-    ) -> None:
-        message = (
-            f"Missing Feature: '{feature_name}' "
-            "are" if plural is True else "is"
-            " not implemented yet"
-        )
-        IocageException.__init__(self, message, *args, **kwargs)


### PR DESCRIPTION
fixes #289

When downloading release updates with freebsd-update.sh the script exists with exit code 1 when a release was fetched that is listed as EOL. We have already warned the user once in the release list, so that we can assume the fetching was intentional and has finished successfully after reading this message.

The hbsd-update tool on older HardenedBSD is lacking flags to keep temporary files. HardenedBSD jails with userland version 10.2 and before are unsupported at all.