### PR TITLE
fix handling of defaultrouter for IPv4 and IPv6

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1679,7 +1679,7 @@ class JailGenerator(JailResource):
         defaultrouter = self.config["defaultrouter"]
         defaultrouter6 = self.config["defaultrouter6"]
 
-        if not defaultrouter or defaultrouter6:
+        if (defaultrouter is None) and (defaultrouter6 is None):
             self.logger.spam("no static routes configured")
             return []
 


### PR DESCRIPTION
The routes remained unconfigured when both `defaultrouter` and `defaultrouter6` were configured.