### PR TITLE
mark launch-script fstab entries as auto-comment line

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1201,7 +1201,8 @@ class JailGenerator(JailResource):
             source=self.launch_script_dir,
             destination=jail_start_script_dir,
             type="nullfs",
-            options="ro"
+            options="ro",
+            comment=self.fstab.AUTO_COMMENT_IDENTIFIER
         ))
         self.fstab.read_file()
         if self.fstab.line_exists(iocage_helper_line) is False:


### PR DESCRIPTION
Auto-comment fstab lines will be ignored when reading an fstab file. It is expected to automatically create them when required - in case of launch scripts this is on jail start.