### PR TITLE
preserve hard-links in backup archives

### DIFF
--- a/iocage/lib/ResourceBackup.py
+++ b/iocage/lib/ResourceBackup.py
@@ -281,6 +281,7 @@ class LaunchableResourceBackup:
                 "rsync",
                 "-av",
                 "--links",
+                "--hard-links",
                 "--safe-links",
                 f"{temp_root_dir}/",
                 f"{self.resource.root_dataset.mountpoint}/"
@@ -504,6 +505,7 @@ class LaunchableResourceBackup:
                 "-av",
                 "--checksum",
                 "--links",
+                "--hard-links",
                 "--safe-links",
                 f"--compare-dest={compare_dest}/",
                 f"{self.resource.root_dataset.mountpoint}/",


### PR DESCRIPTION
There are several hard-linked files in `root/rescue/` that grow up in size when being exported or imported without preserving hard-links.