### PR TITLE
Concurrent IocageEvent history stacks

### DIFF
--- a/iocage/cli/__init__.py
+++ b/iocage/cli/__init__.py
@@ -77,6 +77,7 @@ def set_to_dict(data: typing.Set[str]) -> typing.Dict[str, str]:
 def print_events(
     generator: typing.Generator[typing.Union[IocageEvent, bool], None, None]
 ) -> typing.Optional[bool]:
+
     lines: typing.Dict[str, str] = {}
     for event in generator:
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1508,7 +1508,7 @@ class JailGenerator(JailResource):
             ["set +e"] +
             (["service ipfw onestop"] if self.host.ipfw_enabled else []) +
             [
-                "set -e"
+                "set -e",
                 f". {self._relative_hook_script_dir}/start.sh",
                 jail_command,
             ]

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -584,11 +584,6 @@ class JailGenerator(JailResource):
         self.require_jail_existing()
         self.require_jail_stopped()
 
-        events: typing.Any = iocage.lib.events
-        jailForkExecEvent = events.JailForkExec(jail=self)
-
-        yield jailForkExecEvent.begin()
-
         original_config = self.config
         config_data = original_config.data
 
@@ -610,11 +605,6 @@ class JailGenerator(JailResource):
             )
             for event in fork_exec_events:
                 yield event
-        except iocage.lib.errors.IocageException as e:
-            yield jailForkExecEvent.fail(e)
-            raise e
-        else:
-            yield jailForkExecEvent.end()
         finally:
             self.config = original_config
 

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -70,22 +70,25 @@ class Storage:
 
     def rename(
         self,
-        new_name: str
+        new_name: str,
+        event_scope: typing.Optional[int]=None
     ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
         """Rename the dataset and its snapshots."""
-        for event in self._rename_dataset(new_name):
+        for event in self._rename_dataset(new_name, event_scope=event_scope):
             yield event
-        for event in self._rename_snapshot(new_name):
+        for event in self._rename_snapshot(new_name, event_scope=event_scope):
             yield event
 
     def _rename_dataset(
         self,
-        new_name: str
+        new_name: str,
+        event_scope: typing.Optional[int]
     ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
 
         current_dataset_name = self.jail.dataset.name
         renameDatasetEvent = iocage.lib.events.ZFSDatasetRename(
-            dataset=self.jail.dataset
+            dataset=self.jail.dataset,
+            scope=event_scope
         )
         yield renameDatasetEvent.begin()
 
@@ -107,13 +110,15 @@ class Storage:
 
     def _rename_snapshot(
         self,
-        new_name: str
+        new_name: str,
+        event_scope: typing.Optional[int]
     ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
 
         root_dataset_properties = self.jail.root_dataset.properties
 
         renameSnapshotEvent = iocage.lib.events.ZFSSnapshotRename(
-            snapshot=self.jail.dataset
+            snapshot=self.jail.dataset,
+            scope=event_scope
         )
         yield renameSnapshotEvent.begin()
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -339,18 +339,6 @@ class JailFstabUpdate(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
-class JailForkExec(JailEvent):
-    """A group of multiple action events executed sequentially."""
-
-    def __init__(  # noqa: T484
-        self,
-        jail: 'iocage.lib.Jail.JailGenerator',
-        **kwargs
-    ) -> None:
-
-        JailEvent.__init__(self, jail, **kwargs)
-
-
 class JailClone(JailEvent):
     """Clone a jail."""
 


### PR DESCRIPTION
- Allows to execute events of the same kind in parallel
- All public methods that yield events accept `event_scope` that might be `None` (to create a new Scope) or of type `iocage.lib.events.Scope` (to use the existing scope)