### PR TITLE
Flatten one-shot Jail execution when not using JailGenerator

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1536,6 +1536,7 @@ class JailGenerator(JailResource):
 
         self._write_hook_script("host_command", "\n".join(
             [
+                f"IOCAGE_JID=$(jls -j {self.identifier} jid)",
                 f"/bin/sh {self.get_hook_script_path('started')}",
                 (
                     f"/usr/sbin/jexec {self.identifier} "

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1049,6 +1049,7 @@ class JailGenerator(JailResource):
         resource: typing.Optional[typing.Union[
             'JailGenerator',
             'iocage.lib.Release.ReleaseGenerator',
+            str
         ]]=None
     ) -> None:
         """
@@ -1060,6 +1061,9 @@ class JailGenerator(JailResource):
                 The (new) jail is created from this resource.
                 If no resource is specified, an empty dataset will be created
         """
+        if isinstance(resource, str):
+            resource = iocage.Release(resource)
+
         if isinstance(resource, JailGenerator):
             self.create_from_template(template=resource)
         elif isinstance(resource, iocage.lib.Release.ReleaseGenerator):

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -2076,3 +2076,18 @@ class Jail(JailGenerator):
                 requires it to be stopped.
         """
         return list(JailGenerator.destroy(self, force=force))
+
+    def fork_exec(  # noqa: T484
+        self,
+        command: str,
+        **temporary_config_override
+    ) -> str:
+        """Execute a one-shot jail and return its stdout."""
+        events = JailGenerator.fork_exec(
+            self,
+            command=command,
+            passthru=False
+        )
+        for event in events:
+            if isinstance(event, iocage.lib.events.JailLaunch) and event.done:
+                return str(event.stdout)

--- a/iocage/lib/NetworkInterface.py
+++ b/iocage/lib/NetworkInterface.py
@@ -281,7 +281,7 @@ class QueuingNetworkInterface(
                 f"export {self.shell_variable_nic_name}=\"$({_command})\""
             )
         else:
-            self.append_command_queue(_command)
+            self.append_command_queue(f"{_command} > /dev/null")
 
         return ""
 


### PR DESCRIPTION
- Jail is a simplified wrapper around JailGenerator
- Jail.fork_exec returns a string containing stdout
- A jails JID is explicitly looked up before executing the host_commands