### PR TITLE
Prevent ioc console -s from stacktracing when jail startup fails

### DIFF
--- a/iocage/cli/console.py
+++ b/iocage/cli/console.py
@@ -50,11 +50,12 @@ def cli(ctx, jail, start):
     except iocage.lib.errors.JailNotFound:
         exit(1)
 
-    if not ioc_jail.running:
-        if start is True:
-            ctx.parent.print_events(ioc_jail.start())
-
     try:
+        if not ioc_jail.running:
+            if start is True:
+                ctx.parent.print_events(ioc_jail.start())
+
         ioc_jail.exec_console()
     except iocage.lib.errors.IocageException:
         exit(1)
+


### PR DESCRIPTION
The start task of the `ioc console -s` command was not included in the try/except block hiding the stacktrace for `IocageException`. We can omit this because the logger instance already notified the user about any issue derived from IocageException.