### PR TITLE
pass a ReleaseGenerator instead of a string to Fstab

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -115,10 +115,15 @@ class JailResource(
         except AttributeError:
             pass
 
+        try:
+            release = self.release
+        except AttributeError:
+            release = None
+
         jail = self.jail
         fstab = iocage.lib.Config.Jail.File.Fstab.Fstab(
             jail=jail,
-            release=self.config["release"],
+            release=release,
             logger=self.logger,
             host=jail.host
         )


### PR DESCRIPTION
fixes a regression introduced with #398

- Fstab requires a ReleaseGenerator instead of the release name string