### PR TITLE
exit successfully on ioc get -p when pool found

### DIFF
--- a/iocage/cli/get.py
+++ b/iocage/cli/get.py
@@ -63,11 +63,13 @@ def cli(
     host = iocage.lib.Host.Host(logger=logger)
 
     if _pool is True:
+        exit_status = 0
         try:
             print(host.datasets.active_pool.name)
         except Exception:
+            exit_status = 1
             print("No active pool found")
-        exit(1)
+        exit(exit_status)
 
     if jail == "":
         prop = ""

--- a/iocage/cli/get.py
+++ b/iocage/cli/get.py
@@ -63,13 +63,12 @@ def cli(
     host = iocage.lib.Host.Host(logger=logger)
 
     if _pool is True:
-        exit_status = 0
         try:
             print(host.datasets.active_pool.name)
         except Exception:
-            exit_status = 1
             print("No active pool found")
-        exit(exit_status)
+            exit(1)
+        exit(0)
 
     if jail == "":
         prop = ""


### PR DESCRIPTION
previously, `ioc get -p` would always exit 1, regardless of success.
This fixes #407