### PR TITLE
Implement BaseConfig.get() method

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -518,6 +518,10 @@ class BaseConfig(dict):
         *args: typing.Any
     ) -> typing.Any:
         """Return the config value or its given default."""
+        if len(args) > 1:
+            raise TypeError(
+                f"get() takes 1 positional argument but {len(args)} were given"
+            )
         try:
             return self.__getitem__(key)
         except KeyError:

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -512,6 +512,19 @@ class BaseConfig(dict):
 
         raise KeyError(f"User defined property not found: {key}")
 
+    def get(
+        self,
+        key: str,
+        *args: typing.Any
+    ) -> typing.Any:
+        """Return the config value or its given default."""
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            if len(args) == 0:
+                raise
+            return args[0]
+
     def __getitem__(self, key: str) -> typing.Any:
         """
         Get the user configured value of a jail configuration property.


### PR DESCRIPTION
This allows requesting jail config properties or fallback to a default. e.g.

```
import iocage
jail = iocage.Jail("myjail")
jail.config.get("prop", False)
```

I would expect some changes to the way user defined properties work, so that this method might not last very long. Discussion is still ongoing and in the meanwhile this is a proper way to deal with unset user default properties for automation tasks.