### PR TITLE
enhance data input of ResourceLimitValue on init

### DIFF
--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -75,9 +75,15 @@ class ResourceLimitValue:
         _values: ResourceLimitValueTuple = (None, None, None,)
         if len(args) > 0:
             _values = self._parse_resource_limit(str(args[0]))
-        self.amount = kwargs.get("amount", _values[0])
-        self.action = kwargs.get("action", _values[1])
-        self.per = kwargs.get("per", _values[2])
+
+        amount = kwargs.get("amount", _values[0])
+        self.amount = amount if isinstance(amount, str) else None
+
+        action = kwargs.get("action", _values[1])
+        self.action = action if isinstance(action, str) else None
+
+        per = kwargs.get("per", _values[2])
+        self.per = per if isinstance(per, str) else None
 
     @property
     def is_unset(self) -> bool:

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -53,6 +53,12 @@ properties: typing.List[str] = [
     "writeiops"
 ]
 
+ResourceLimitValueTuple = typing.Tuple[
+    typing.Optional[str],
+    typing.Optional[str],
+    typing.Optional[str]
+]
+
 
 class ResourceLimitValue:
     """Model of a resource limits value."""
@@ -66,7 +72,7 @@ class ResourceLimitValue:
         *args: typing.List[str],
         **kwargs: typing.Dict[str, typing.Union[int, str]]
     ) -> None:
-        _values = (None, None, None,)
+        _values: ResourceLimitValueTuple = (None, None, None,)
         if len(args) > 0:
             _values = self._parse_resource_limit(str(args[0]))
         self.amount = kwargs.get("amount", _values[0])
@@ -78,11 +84,7 @@ class ResourceLimitValue:
         """Return whether any parameter is None."""
         return (None in [self.amount, self.action, self.per]) is True
 
-    def _parse_resource_limit(self, value: str) -> typing.Tuple[
-        typing.Optional[str],
-        typing.Optional[str],
-        typing.Optional[str]
-    ]:
+    def _parse_resource_limit(self, value: str) -> ResourceLimitValueTuple:
 
         if (value is False) or (value is None) or (value == "None=None/None"):
             amount = None

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -61,10 +61,17 @@ class ResourceLimitValue:
     action: typing.Optional[str]
     per: typing.Optional[str]
 
-    def __init__(self) -> None:
-        self.amount = None
-        self.action = None
-        self.per = None
+    def __init__(
+        self,
+        *args: typing.List[str],
+        **kwargs: typing.Dict[str, typing.Union[int, str]]
+    ) -> None:
+        _values = (None, None, None,)
+        if len(args) > 0:
+            _values = self._parse_resource_limit(str(args[0]))
+        self.amount = kwargs.get("amount", _values[0])
+        self.action = kwargs.get("action", _values[1])
+        self.per = kwargs.get("per", _values[2])
 
     @property
     def is_unset(self) -> bool:


### PR DESCRIPTION
- ResourceLimitValue may be initialised with a positional argument (str or int)
- ResourceLimit accepts named properties `amount`, `action` and `per`
- Both inputs (positional and named arguments) may be combined - the named arguments overwrite properties parsed from the positional argument.