### PR TITLE
create updates destination dir in jail when it does not exist

### DIFF
--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -139,6 +139,8 @@ class Updater:
                 destination=destination_dir,
                 options="rw"
             )
+            if os.path.isdir(destination_dir) is False:
+                os.makedirs(destination_dir, 0o755)
             temporary_jail.fstab.save()
             self._temporary_jail = temporary_jail
         return self._temporary_jail


### PR DESCRIPTION
Fixes an issue where jails could not be updated because the fstab destination mountpoint did not exist.