### PR TITLE
replace cli create jail name flag with an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ iocage commands default to the first root data source specified in the file.
 Operations can be pointed to an alternative root by prefixing the subject with the source name followed by a slash.
 
 ```sh
-ioc create -b -n othersource/myjail
+ioc create -b othersource/myjail
 ioc rename othersource/myjail myjail2
 ```
 

--- a/iocage/cli/create.py
+++ b/iocage/cli/create.py
@@ -70,8 +70,6 @@ def validate_count(
 @click.option("--template", "-t", required=False,
               help="Specify the template to use for the new jail instead of"
                    " a RELEASE.")
-@click.option("--name", "-n", default=None,
-              help="Provide a specific name instead of an UUID for this jail.")
 @click.option("--basejail", "-b", is_flag=True, default=False,
               help="Set the new jail type to a basejail. Basejails"
                    " mount the specified RELEASE directories"
@@ -84,6 +82,7 @@ def validate_count(
                    " jails.")
 @click.option("--no-fetch", is_flag=True, default=False,
               help="Do not automatically fetch releases")
+@click.argument("name")
 @click.argument("props", nargs=-1)
 def cli(
     ctx: IocageClickContext,


### PR DESCRIPTION
This change breaks the CLI interface, but IMO it improves the interface.

### Before
```
ioc create -n test
ioc create -b -n test2
ioc create -n test3 vnet=on
```

### After
```
ioc create test
ioc create -b test
ioc create test3 vnet=on
```