### PR TITLE
NullFSBasejailStorege and ZFSBasejailStorage inherit from Storage

### DIFF
--- a/iocage/lib/NullFSBasejailStorage.py
+++ b/iocage/lib/NullFSBasejailStorage.py
@@ -22,11 +22,12 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage NullFS basejail storage backend."""
+import iocage.lib.Storage
 import iocage.lib.StandaloneJailStorage
 import iocage.lib.helpers
 
 
-class NullFSBasejailStorage:
+class NullFSBasejailStorage(iocage.lib.Storage.Storage):
     """iocage NullFS basejail storage backend."""
 
     def apply(self, release=None):

--- a/iocage/lib/ZFSBasejailStorage.py
+++ b/iocage/lib/ZFSBasejailStorage.py
@@ -22,10 +22,11 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage ZFS basejail storage backend."""
+import iocage.lib.Storage
 import iocage.lib.helpers
 
 
-class ZFSBasejailStorage:
+class ZFSBasejailStorage(iocage.lib.Storage.Storage):
     """iocage ZFS basejail storage backend."""
 
     def apply(self, release=None):


### PR DESCRIPTION
This fixes an issue when renaming NullFS or ZFS basejails.