### PR TITLE
Feature: Provisioning (ix-iocage-plugin)

### DIFF
--- a/iocage/cli/provision.py
+++ b/iocage/cli/provision.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Provision jails from the CLI.."""
+import typing
+import click
+
+import iocage.lib.errors
+import iocage.lib.Jails
+import iocage.lib.Logger
+
+from .shared.click import IocageClickContext
+
+__rootcmd__ = True
+
+
+@click.command(name="start", help="Trigger provisioning of jails.")
+@click.pass_context
+@click.argument("jails", nargs=-1)
+def cli(
+    ctx: IocageClickContext,
+    jails: typing.Tuple[str, ...]
+) -> None:
+    """Run jail provisioner as defined in jail config."""
+    logger = ctx.parent.logger
+    start_args = {
+        "zfs": ctx.parent.zfs,
+        "host": ctx.parent.host,
+        "logger": logger,
+        "print_function": ctx.parent.print_events
+    }
+
+    if not _provision(jails, **start_args):
+        exit(1)
+
+
+def _provision(
+    filters: typing.Tuple[str, ...],
+    zfs: iocage.lib.ZFS.ZFS,
+    host: iocage.lib.Host.HostGenerator,
+    logger: iocage.lib.Logger.Logger,
+    print_function: typing.Callable[
+        [typing.Generator[iocage.lib.events.IocageEvent, None, None]],
+        None
+    ]
+) -> bool:
+
+    jails = iocage.lib.Jails.JailsGenerator(
+        logger=logger,
+        zfs=zfs,
+        host=host,
+        filters=filters
+    )
+
+    changed_jails = []
+    failed_jails = []
+    for jail in jails:
+        try:
+            print_function(jail.provisioner.provision())
+        except iocage.lib.errors.IocageException:
+            failed_jails.append(jail)
+            continue
+
+        changed_jails.append(jail)
+
+    if len(failed_jails) > 0:
+        return False
+
+    if len(changed_jails) == 0:
+        jails_input = " ".join(list(jails))
+        logger.error(f"No jails started your input: {jails_input}")
+        return False
+
+    return True

--- a/iocage/cli/provision.py
+++ b/iocage/cli/provision.py
@@ -95,6 +95,7 @@ def _provision(
             )
         except iocage.lib.errors.IocageException:
             exit(1)
+
         try:
             print_function(_execute_provisioner(jail))
         except iocage.lib.errors.IocageException:
@@ -118,6 +119,7 @@ def _execute_provisioner(
     jail: 'iocage.lib.Jail.JailsGenerator'
 ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
     for event in jail.provisioner.provision():
-        if isinstance(event, iocage.lib.events.JailLaunch) and event.done:
-            print(event.stdout)
         yield event
+        if isinstance(event, iocage.lib.events.JailCommandExecution):
+            if event.done is True:
+                print(event.stdout)

--- a/iocage/cli/set.py
+++ b/iocage/cli/set.py
@@ -54,7 +54,12 @@ def cli(
 
     # Defaults
     if jail == "defaults":
-        updated_properties = _set_properties(props, host.defaults)
+        updated_properties = _set_properties(
+            properties=props,
+            target=host.defaults,
+            logger=logger,
+            host=host
+        )
         if len(updated_properties) > 0:
             logger.screen("Defaults updated: " + ", ".join(updated_properties))
         else:
@@ -74,7 +79,12 @@ def cli(
     for ioc_jail in ioc_jails:  # type: iocage.lib.Jail.JailGenerator
 
         try:
-            updated_properties = _set_properties(props, ioc_jail)
+            updated_properties = _set_properties(
+                properties=props,
+                target=ioc_jail,
+                logger=logger,
+                host=host
+            )
         except iocage.lib.errors.IocageException:
             exit(1)
 
@@ -97,7 +107,9 @@ def cli(
 
 def _set_properties(
     properties: typing.Iterable[str],
-    target: 'iocage.lib.LaunchableResource.LaunchableResource'
+    target: 'iocage.lib.LaunchableResource.LaunchableResource',
+    logger: iocage.lib.Logger.Logger,
+    host: iocage.lib.Host.HostGenerator
 ) -> set:
 
     updated_properties = set()

--- a/iocage/cli/set.py
+++ b/iocage/cli/set.py
@@ -30,6 +30,7 @@ import iocage.lib.Logger
 import iocage.lib.helpers
 import iocage.lib.Resource
 import iocage.lib.Jails
+
 from .shared.jail import set_properties
 
 __rootcmd__ = True

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -199,6 +199,9 @@ class BaseConfig(dict):
     def _get_name(self) -> str:
         return self._get_id()
 
+    def _set_name(self, name: str, **kwargs) -> None:  # noqa: T484
+        return self._set_id(name=name, **kwargs)
+
     def _get_uuid(self) -> str:
         return self._get_id()
 

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -784,7 +784,7 @@ class BaseConfig(dict):
     def all_properties(self) -> typing.List[str]:
         """Return a list of config object attributes."""
         properties: typing.Set[str] = set()
-        properties = properties.union(self.data.keys())
+        properties = properties.union(self.keys())
         special_properties = iocage.lib.Config.Jail.Properties.properties
         properties = properties.union(special_properties)
         return list(properties)

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -430,6 +430,16 @@ class BaseConfig(dict):
             false="off"
         )
 
+    def _set_cloned_release(  # noqa: T484
+        self,
+        value: typing.Optional[str],
+        **kwargs
+    ) -> None:
+        if (value is None) and "cloned_release" in self.data.keys():
+            del self.data["cloned_release"]
+        self["release"] = value
+        self.data["cloned_release"] = value
+
     def _get_cloned_release(self) -> typing.Optional[str]:
         try:
             return str(self.data["cloned_release"])

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -538,10 +538,10 @@ class BaseConfig(dict):
             pass
 
         # special property
-        is_special_property = self.special_properties.is_special_property(key)
-        is_existing = key in self.data.keys()
-        if (is_special_property and is_existing) is True:
-            return self.special_properties.get_or_create(key)
+        if self.special_properties.is_special_property(key) is True:
+            is_existing = key in self.data.keys()
+            if is_existing is True:
+                return self.special_properties.get_or_create(key)
 
         # data with mappings
         method_name = f"_get_{key}"

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -127,7 +127,12 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "tags": [],
         "template": False,
         "jail_zfs": False,
-        "jail_zfs_dataset": None
+        "jail_zfs_dataset": None,
+        "provisioning": {
+            "method": None,
+            "source": None,
+            "revision": "master"
+        }
     }
 
     def __init__(

--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -86,6 +86,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "ip6_saddrsel": 1,
         "ip6_addr": None,
         "resolver": "/etc/resolv.conf",
+        "host_hostuuid": None,
         "host_hostname": None,
         "host_domainname": None,
         "devfs_ruleset": 4,
@@ -131,7 +132,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "provisioning": {
             "method": None,
             "source": None,
-            "revision": "master"
+            "rev": "master"
         }
     }
 

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -399,10 +399,11 @@ class Fstab(
         ]
     ) -> bool:
         """Return True when the FstabLine already exists."""
-        for existing_line in self.__iter__():
-            if hash(existing_line) == hash(line):
-                return True
-        return False
+        try:
+            self.index(line)
+            return True
+        except ValueError:
+            return False
 
     @property
     def basejail_lines(self) -> typing.List[FstabBasejailLine]:

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -256,12 +256,6 @@ class Fstab(
                 "comment": comment
             })
 
-            if new_line in self._lines:
-                self.logger.error(
-                    "Duplicate mountpoint in fstab: "
-                    f"{destination} already mounted"
-                )
-
             self.add_line(new_line)
 
     def read_file(self) -> None:

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -377,7 +377,7 @@ class Fstab(
             if line["destination"].startswith(self.jail.root_path) is False:
                 line["destination"] = "/".join([
                     self.jail.root_path,
-                    line["destination"]
+                    line["destination"].strip("/")
                 ])
 
             if auto_create_destination is True:

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -79,6 +79,7 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
 
         raise iocage.lib.errors.UnknownJailConfigProperty(
             key=key,
+            jail=self,
             logger=self.logger
         )
 

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -70,6 +70,11 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
                 return str(jail.humanreadable_name)
             raise e
 
+    def _is_known_property(self, key: str) -> bool:
+        key_is_default = key in self.host.defaults.config.keys()
+        key_is_setter = f"_set_{key}" in dict.__dir__(self)
+        key_is_special = key in iocage.lib.Config.Jail.Properties.properties
+        return (key_is_default or key_is_setter or key_is_special) is True
 
     def __setitem__(
         self,
@@ -79,11 +84,7 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
     ) -> None:
         """Set a configuration value."""
         # require the config property to be defined in the defaults
-        key_is_default = key in self.host.defaults.config.keys()
-        key_is_setter = f"_set_{key}" in dict.__dir__(self)
-        key_is_special = key in iocage.lib.Config.Jail.Properties.properties
-
-        if (key_is_default or key_is_setter or key_is_special) is False:
+        if self._is_known_property(key) is False:
             err = iocage.lib.errors.UnknownJailConfigProperty(
                 jail=self.jail,
                 key=key,

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -123,7 +123,7 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
             return super().__getitem__(key)
         except KeyError:
             # fall back to default
-            return self.host.default_config[key]
+            return self.host.defaults.config[key]
 
     @property
     def all_properties(self) -> list:

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -70,18 +70,6 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
                 return str(jail.humanreadable_name)
             raise e
 
-    def __delitem__(self, key: str) -> None:
-        """Delete a setting from the configuration."""
-        for default_key in self.host.defaults.config.keys():
-            if default_key.startswith(f"{key}.") or (default_key == key):
-                BaseConfig.__delitem__(self, key)
-                return
-
-        raise iocage.lib.errors.UnknownJailConfigProperty(
-            key=key,
-            jail=self,
-            logger=self.logger
-        )
 
     def __setitem__(
         self,

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -70,6 +70,18 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
                 return str(jail.humanreadable_name)
             raise e
 
+    def __delitem__(self, key: str) -> None:
+        """Delete a setting from the configuration."""
+        for default_key in self.host.defaults.config.keys():
+            if default_key.startswith(f"{key}.") or (default_key == key):
+                BaseConfig.__delitem__(self, key)
+                return
+
+        raise iocage.lib.errors.UnknownJailConfigProperty(
+            key=key,
+            logger=self.logger
+        )
+
     def __setitem__(
         self,
         key: str,

--- a/iocage/lib/Config/Type/JSON.py
+++ b/iocage/lib/Config/Type/JSON.py
@@ -38,6 +38,8 @@ class ConfigJSON(iocage.lib.Config.Prototype.Prototype):
 
     def map_input(self, data: typing.TextIO) -> typing.Dict[str, typing.Any]:
         """Parse and normalize JSON data."""
+        if data == "":
+            return {}
         result = json.load(data)  # type: typing.Dict[str, typing.Any]
         return result
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -51,6 +51,7 @@ import iocage.lib.VersionedResource
 import iocage.lib.Config.Jail.Properties.ResourceLimit
 import iocage.lib.ResourceSelector
 import iocage.lib.Config.Jail.File.Fstab
+import iocage.lib.Provisioning
 
 
 class JailResource(
@@ -258,6 +259,7 @@ class JailGenerator(JailResource):
     _class_storage = iocage.lib.Storage.Storage
     _state: typing.Optional[iocage.lib.JailState.JailState]
     _relative_hook_script_dir: str
+    _provisioner: 'iocage.lib.Provisioning.Prototype'
 
     def __init__(  # noqa: T484
         self,
@@ -360,6 +362,22 @@ class JailGenerator(JailResource):
         performance optimization when dealing with large numbers of jails.
         """
         object.__setattr__(self, '_state', value)
+
+    @property
+    def provisioner(self) -> 'iocage.lib.Provisioning.prototype.Provisioner':
+        """
+        Return the jails Provisioner instance.
+
+        The provisioner itself is going to interpret the jails configuration
+        dynamically, so that the Provisioner instance can be memoized.
+        """
+        try:
+            return self._provisioner
+        except AttributeError:
+            pass
+
+        self._provisioner = iocage.lib.Provisioning.Provisioner(jail=self)
+        return self._provisioner
 
     def _init_state(self) -> iocage.lib.JailState.JailState:
         state = iocage.lib.JailState.JailState(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1559,9 +1559,9 @@ class JailGenerator(JailResource):
             ]
         ))
 
+        _ipfw_enabled = self.host.ipfw_enabled
         self._write_hook_script("command", "\n".join(
-            ["set +e"] +
-            (["service ipfw onestop"] if self.host.ipfw_enabled else []) +
+            (["set +e", "service ipfw onestop"] if _ipfw_enabled else []) +
             [
                 "set -e",
                 f". {self._relative_hook_script_dir}/start.sh",

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1861,12 +1861,12 @@ class JailGenerator(JailResource):
 
         commands: typing.List[str] = []
 
-        mountpoints = list(filter(
+        fstab_destinations = [line["destination"] for line in self.fstab]
+        system_mountpoints = list(filter(
             os.path.isdir,
             map(
                 self._get_absolute_path_from_jail_asset,
                 [
-                    "/usr/bin",
                     "/dev/fd",
                     "/dev",
                     "/proc",
@@ -1878,6 +1878,8 @@ class JailGenerator(JailResource):
                 ]
             )
         ))
+
+        mountpoints = fstab_destinations + system_mountpoints
 
         commands.append(" ".join(iocage.lib.helpers.umount_command(
             mountpoints,

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1530,7 +1530,10 @@ class JailGenerator(JailResource):
                 )
                 try:
                     while True:
-                        self.logger.spam(next(exec_events), indent=1)
+                        self.logger.spam(
+                            next(exec_events).decode("UTF-8"),
+                            indent=1
+                        )
                 except StopIteration as return_statement:
                     output: iocage.lib.helpers.CommandOutput
                     output = return_statement.value

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1549,6 +1549,7 @@ class JailGenerator(JailResource):
         self._write_hook_script("host_command", "\n".join(
             [
                 f"IOCAGE_JID=$(jls -j {self.identifier} jid)",
+                "set -e",
                 f"/bin/sh {self.get_hook_script_path('started')}",
                 (
                     f"/usr/sbin/jexec {self.identifier} "

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -69,11 +69,15 @@ class JailResource(
         host: 'iocage.lib.Host.HostGenerator',
         jail: typing.Optional['JailGenerator']=None,
         root_datasets_name: typing.Optional[str]=None,
+        fstab: typing.Optional['iocage.lib.Config.Jail.File.Fstab']=None,
         **kwargs
     ) -> None:
 
         self.host = iocage.lib.helpers.init_host(self, host)
         self.root_datasets_name = root_datasets_name
+
+        if fstab is not None:
+            self._fstab = fstab
 
         if jail is not None:
             self._jail = jail

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -356,6 +356,7 @@ class Pkg:
                 "mount_fdescfs": False
             },
             new=True,
+            fstab=source_jail.fstab,
             logger=self.logger,
             zfs=source_jail.zfs,
             host=source_jail.host,

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -258,7 +258,7 @@ class Pkg:
         packages: typing.Union[str, typing.List[str]]
     ) -> typing.List[str]:
         _packages = [packages] if isinstance(packages, str) else packages
-        pattern = re.compile("^(?:[A-z0-9](?:[A-z0-9\-]?[A-z0-9])*)+$")
+        pattern = re.compile("^(?:[A-z0-9](?:[A-z0-9\-\/]?[A-z0-9])*)+$")
         for package in _packages:
             if pattern.match(package) is None:
                 raise iocage.lib.errors.SecurityViolation(

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -373,14 +373,9 @@ class Pkg:
                 source=dataset.mountpoint,
                 destination=destination_dir,
                 options="ro",
+                auto_create_destination=True,
                 replace=True
             )
-            if os.path.isdir(destination_dir) is False:
-                iocage.lib.helpers.makedirs_safe(
-                    destination_dir,
-                    mode=0o755,
-                    logger=self.logger
-                )
             temporary_jail.fstab.save()
         except iocage.lib.errors.FstabDestinationExists:
             pass

--- a/iocage/lib/Provisioning/__init__.py
+++ b/iocage/lib/Provisioning/__init__.py
@@ -96,5 +96,4 @@ class Provisioner(Prototype):
 	) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
 		"""Run the provision method on the enabled provisioner."""
 		Prototype.check_requirements(self)
-		for event in self.__provisioning_module.provision(self):
-			yield event
+		yield from self.__provisioning_module.provision(self)

--- a/iocage/lib/Provisioning/__init__.py
+++ b/iocage/lib/Provisioning/__init__.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""iocage provisioning prototype."""
+import typing
+
+import iocage.lib.errors
+import iocage.lib.helpers
+import iocage.lib.Provisioning.ix
+
+
+class Prototype:
+
+	jail: 'iocage.lib.Jail.JailGenerator'
+	__METHOD: str
+
+	def __init__(
+		self,
+		jail: 'iocage.lib.Jail.JailGenerator'
+	) -> None:
+		self.jail = jail
+
+	@property
+	def method(self) -> str:
+		self.__METHOD
+
+	@property
+	def source(self) -> typing.Optional[str]:
+		config_value = self.jail.config["provisioning.source"]
+		return None if (config_value is None) else str(config_value)
+
+	@property
+	def rev(self) -> typing.Optional[str]:
+		config_value = self.jail.config["provisioning.rev"]
+		return None if (config_value is None) else str(config_value)
+
+	def check_requirements(self) -> None:
+		"""Check requirements before executing the provisioner."""
+		if self.source is None:
+			raise iocage.lib.errors.UndefinedProvisionerSource(
+				logger=self.jail.logger
+			)
+		if self.method is None:
+			raise iocage.lib.errors.UndefinedProvisionerMethod(
+				logger=self.jail.logger
+			)
+
+
+class Provisioner(Prototype):
+
+	@property
+	def method(self) -> str:
+		method = self.jail.config["provisioning.method"]
+		if method in self.__available_provisioning_modules:
+			return method
+		raise iocage.lib.errors.InvalidProvisionerMethod(
+			method,
+			logger=self.jail.logger
+		)
+
+	@property
+	def __available_provisioning_modules(
+		self
+	) -> typing.Dict[str, Prototype]:
+		return dict(
+			ix=iocage.lib.Provisioning.ix
+		)
+
+	@property
+	def __provisioning_module(self) -> 'iocage.lib.Provisioning.Provisioner':
+		"""Return the class of the currently configured provisioner."""
+		return self.__available_provisioning_modules[self.method]
+
+	def provision(
+		self
+	) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
+		"""Run the provision method on the enabled provisioner."""
+		Prototype.check_requirements(self)
+		for event in self.__provisioning_module.provision(self):
+			yield event

--- a/iocage/lib/Provisioning/ix.py
+++ b/iocage/lib/Provisioning/ix.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2014-2018, iocage
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""iocage provisioner for ix-plugins."""
+import typing
+import json
+import urllib.error
+import urllib.request
+
+import iocage.lib.errors
+import iocage.lib.events
+import iocage.lib.Provisioning
+
+
+class PluginDefinition(dict):
+
+    _name: str
+
+    def __init__(
+        self,
+        name: str,
+        logger: 'iocage.lib.Logger.Logger'
+    ) -> None:
+        self.logger = logger
+        self._set_name(name)
+
+    @property
+    def name(self) -> str:
+        """Return the ix-iocage-plugins name."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set the ix-iocage-plugins name."""
+        self._set_name(value)
+
+    def _set_name(self, value: str) -> None:
+        data = self.__download_definition_data(value)
+        self._name = value
+        dict.clear(self)
+        dict.__init__(self, data)
+
+    @property
+    def url(self) -> str:
+        return self.get_url(self.name)
+
+    def __get_url(self, name: str) -> str:
+        return (
+            "https://raw.githubusercontent.com/freenas/iocage-ix-plugins"
+            f"/master/{name}.json"
+        )
+
+    def __download_definition_data(
+        self,
+        name: str
+    ) -> typing.Dict[str, typing.Any]:
+        try:
+            resource = urllib.request.urlopen(self.__get_url(name))  # nosec
+        except urllib.error.HTTPError as e:
+            raise iocage.lib.errors.ProvisioningSourceUnavailable(
+                name=name,
+                logger=self.logger
+            )
+        charset = resource.headers.get_content_charset()  # noqa: T484
+        response = resource.read().decode(charset if charset else "UTF-8")
+        data: typing.Dict[str, typing.Any] = json.loads(response)
+        return data
+
+
+def provision(
+    self: 'iocage.lib.Provisioning.Prototype',
+    event_scope: typing.Optional['iocage.lib.events.Scope']=None
+) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
+    """
+    Provision the jail from an ix-iocage-plugin.
+
+    Installable ix-iocage plugins can be found on the registry repository
+    https://github.com/freenas/iocage-ix-plugins/ and may be configured
+    as a jails provisioning.source property, e.g.:
+
+        ioc set provisioning.method=ix provisioning.source=jenkins myjail
+    """
+    events = iocage.lib.events
+    jailProvisioningEvent = events.JailProvisioning(
+        jail=self.jail,
+        event_scope=event_scope
+    )
+    _scope = jailProvisioningEvent.scope
+    jailProvisioningAssetDownloadEvent = events.JailProvisioningAssetDownload(
+        jail=self.jail,
+        event_scope=_scope
+    )
+
+    yield jailProvisioningEvent.begin()
+
+    try:
+        yield jailProvisioningAssetDownloadEvent.begin()
+        pluginDefinition = PluginDefinition(
+            self.source,
+            logger=self.jail.logger
+        )
+        yield jailProvisioningAssetDownloadEvent.end()
+    except Exception as e:
+        yield jailProvisioningAssetDownloadEvent.fail(e)
+        raise e
+
+    for event in self.jail.fork_exec("whoami"):
+        yield event
+
+    yield jailProvisioningEvent.end()
+

--- a/iocage/lib/Provisioning/ix.py
+++ b/iocage/lib/Provisioning/ix.py
@@ -183,9 +183,12 @@ def __get_empty_dataset(
 ) -> libzfs.ZFSDataset:
     try:
         dataset = zfs.get_dataset(dataset_name)
+    except libzfs.ZFSException as e:
+        dataset = None
+        pass
+    if dataset is not None:
         dataset.umount()
         zfs.delete_dataset_recursive(dataset)
-    except libzfs.ZFSException:
-        pass
+
     output: libzfs.ZFSDataset = zfs.get_or_create_dataset(dataset_name)
     return output

--- a/iocage/lib/Provisioning/ix.py
+++ b/iocage/lib/Provisioning/ix.py
@@ -147,8 +147,14 @@ def provision(
     )
     self.jail.fstab.save()
 
+    if "pkgs" in pluginDefinition.keys():
+        pkg_packages = " ".join(pluginDefinition["pkgs"])
+    else:
+        pkg_packages = pluginDefinition.name
+
     commands = [
-        f"pkg install {pluginDefinition.name}"
+        "ASSUME_ALWAYS_YES=true pkg update",
+        f"ASSUME_ALWAYS_YES=true pkg install -y {pkg_packages}",
         "./ix-plugin/post_install.sh"
     ]
 

--- a/iocage/lib/Provisioning/ix.py
+++ b/iocage/lib/Provisioning/ix.py
@@ -146,7 +146,8 @@ def provision(
         source=plugin_dataset.mountpoint,
         destination="/.ix-plugin",
         options="ro",
-        auto_create_destination=True
+        auto_create_destination=True,
+        replace=True
     )
     self.jail.fstab.save()
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -1127,3 +1127,14 @@ class PkgNotFound(IocageException):
 
         msg = "The pkg package was not found in the local mirror."
         IocageException.__init__(self, msg, *args, **kwargs)
+
+
+# Provisioning
+
+
+class UnknownProvisioner(IocageException):
+    """Raised when an unsupported provisioner method is used."""
+
+    def __init__(self, name: str, *args, **kwargs) -> None:  # noqa: T484
+        msg = f"Unknown provisioner: {name}"
+        IocageException.__init__(self, msg, *args, **kwargs)

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -912,7 +912,6 @@ class JailCommandExecution(JailEvent):
         self.stdout = stdout
         return IocageEvent.end(self, **kwargs)
 
-
 # PKG
 
 

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -375,16 +375,26 @@ def parse_user_input(
     return data
 
 
+def _normalize_data(
+    data: typing.Dict[str, typing.Any]
+) -> typing.Dict[str, typing.Any]:
+    output_data: typing.Dict[str, typing.Any] = {}
+    for key, value in data.items():
+        if type(value) == dict:
+            output_data[key] = _normalize_data(value)
+        else:
+            output_data[key] = to_string(
+                value,
+                true="yes",
+                false="no",
+                none="none"
+            )
+    return output_data
+
+
 def to_json(data: typing.Dict[str, typing.Any]) -> str:
     """Create a JSON string from the input data."""
-    output_data = {}
-    for key, value in data.items():
-        output_data[key] = to_string(
-            value,
-            true="yes",
-            false="no",
-            none="none"
-        )
+    output_data = _normalize_data(data)
     return str(json.dumps(output_data, sort_keys=True, indent=4))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click==6.7
 texttable==1.2.1
 tqdm==4.17.1
 ucl==0.8.0
+gitpython


### PR DESCRIPTION
closes #1 

- introduces nested jail config properties
- embeds provisioning methods:
  - `ix` for ix-iocage-plugins
  -  ~~`ansible` as runner for ansible playbooks stored in a remote git repository~~ will be implemented in another PR

### ix-iocage-plugin install stages

When a jail is configured with `provisioning.method=ix`, the following will happen when running the provisioning command with `provisioning.source=jenkins`:

1. Download https://github.com/freenas/iocage-ix-plugins/blob/master/jenkins.json
2. Read `artifacts` from jenkins.json
3. Clone artifacts repo URL to a child dataset of the jail
4. Start jail with artifacts mounted
5. Install list of `pkgs` in jenkinsk.json within the jail
6. Run `post_install.sh` from the artifacts folder if it exists

### CLI Syntax

```sh
ioc create plextemplate \
    provisioning.method=ix \
    provisioning.source=plexmediaserver \
    template=yes

# run provisioner
ioc provision plextemplate

# create jail from the provisioned template
ioc create -t plextemplate plexjail

# configure network and run plexjail
# ...
```

**Update**: Providing a temporary network connecting is no longer required. The ix-iocage-plugin now installs packages via [iocage.lib.Pkg](https://github.com/iocage/libiocage/blob/master/iocage/lib/Pkg.py) which does not require internet connections within a jail. 
