### PR TITLE
Snapshot releases when updating them

### DIFF
--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -392,7 +392,10 @@ class Fstab(
         )
 
         fstab_basejail_lines = []
-        release_root_path = self.release.root_dataset.mountpoint
+        release_root_path = "/".join([
+            self.release.root_dataset.mountpoint,
+            f".zfs/snapshot/{self.jail.release_snapshot.snapshot_name}"
+        ])
         for basedir in basedirs:
 
             source = f"{release_root_path}/{basedir}"

--- a/iocage/lib/Host.py
+++ b/iocage/lib/Host.py
@@ -139,7 +139,7 @@ class HostGenerator:
     @property
     def userland_version(self) -> float:
         """Return the host userland version number."""
-        return float(iocage.lib.helpers.get_userland_version())
+        return float(iocage.lib.helpers.get_os_version()["userland"])
 
     @property
     def release_version(self) -> str:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -30,6 +30,8 @@ import subprocess  # nosec: B404
 import shlex
 import shutil
 
+import libzfs
+
 import iocage.lib.Types
 import iocage.lib.errors
 import iocage.lib.events
@@ -2001,7 +2003,7 @@ class JailGenerator(JailResource):
         return f"{self.source}-{config['id']}"
 
     @property
-    def release(self) -> 'iocage.lib.Release.ReleaseGenerator':
+    def release(self) -> iocage.lib.Release.ReleaseGenerator:
         """Return the iocage.Release instance linked with the jail."""
         return iocage.lib.Release.ReleaseGenerator(
             name=self.config["release"],
@@ -2010,6 +2012,12 @@ class JailGenerator(JailResource):
             host=self.host,
             zfs=self.zfs
         )
+
+    @property
+    def release_snapshot(self) -> libzfs.ZFSSnapshot:
+        """Return the matching release verion snaphsot."""
+        snapshot: libzfs.ZFSSnapshot = self.release.latest_snapshot
+        return snapshot
 
     def __getattribute__(self, key: str) -> typing.Any:
         """Get an attribute from the jail, state or configuration."""

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1167,8 +1167,7 @@ class JailGenerator(JailResource):
             self.zfs.clone_dataset(
                 source=self.dataset,
                 target=destination_dataset_name,
-                delete_existing=delete_existing,
-                snapshot_name=iocage.lib.ZFS.append_snapshot_datetime("clone")
+                delete_existing=delete_existing
             )
         except Exception as e:
             err = iocage.lib.errors.ZFSException(

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -2016,7 +2016,7 @@ class JailGenerator(JailResource):
     @property
     def release_snapshot(self) -> libzfs.ZFSSnapshot:
         """Return the matching release verion snaphsot."""
-        snapshot: libzfs.ZFSSnapshot = self.release.latest_snapshot
+        snapshot: libzfs.ZFSSnapshot = self.release.current_snapshot
         return snapshot
 
     def __getattribute__(self, key: str) -> typing.Any:

--- a/iocage/lib/JailState.py
+++ b/iocage/lib/JailState.py
@@ -30,7 +30,7 @@ import iocage.lib.helpers
 
 JailStatesDict = typing.Dict[str, 'JailState']
 
-_userland_version = float(iocage.lib.helpers.get_userland_version())
+_userland_version = float(iocage.lib.helpers.get_os_version()["userland"])
 if _userland_version >= 11:
     import json
 else:

--- a/iocage/lib/LaunchableResource.py
+++ b/iocage/lib/LaunchableResource.py
@@ -41,29 +41,31 @@ class LaunchableResource(iocage.lib.Resource.Resource):
 
     _rc_conf: typing.Optional[
         iocage.lib.Config.Jail.File.RCConf.ResourceRCConf
-    ] = None
+    ]
     _sysctl_conf: typing.Optional[
         iocage.lib.Config.Jail.File.SysctlConf.SysctlConf
-    ] = None
-    _distribution: typing.Optional[
-        'iocage.lib.Distribution.Distribution'
-    ] = None
+    ]
+    host: 'iocage.lib.Host.HostGenerator'
     _updater: typing.Optional[
         'iocage.lib.ResourceUpdater.LaunchableResourceUpdate'
-    ] = None
+    ]
     _backup: typing.Optional[
         'iocage.lib.ResourceBackup.LaunchableResourceBackup'
-    ] = None
+    ]
     config: iocage.lib.Config.Jail.JailConfig.JailConfig
 
     def __init__(  # noqa: T484
         self,
-        distribution: typing.Optional[
-            'iocage.lib.Distribution.Distribution'
+        host: typing.Optional[
+            'iocage.lib.Host.HostGenerator'
         ]=None,
         **kwargs
     ) -> None:
-        self._distribution = distribution
+        self.host = iocage.lib.helpers.init_host(self, host)
+        self._updater = None
+        self._backup = None
+        self._rc_conf = None
+        self._sysctl_conf = None
         self._updater = None
         self._backup = None
         iocage.lib.Resource.Resource.__init__(self, **kwargs)
@@ -76,11 +78,9 @@ class LaunchableResource(iocage.lib.Resource.Resource):
         if self._updater is not None:
             return self._updater
 
-        if self._distribution is None:
-            self._distribution = iocage.lib.helpers.init_distribution(self)
         updater = iocage.lib.ResourceUpdater.get_launchable_update_resource(
             resource=self,
-            distribution=self._distribution
+            host=self.host
         )
         self._updater = updater
         return updater

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -903,7 +903,10 @@ class ReleaseGenerator(ReleaseResource):
 
     def __str__(self) -> str:
         """Return the release name."""
-        return self.name
+        if self.patchlevel is None:
+            return self.name
+        else:
+            return f"{self.name}-p{self.patchlevel}"
 
     def destroy(
         self,

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -411,7 +411,7 @@ class ReleaseGenerator(ReleaseResource):
         versions: typing.List[int] = []
         snapshots: typing.Dict[int, 'libzfs.ZFSSnapshot'] = {}
         pattern = re.compile("^p(\d+)$")
-        for snapshot in self.dataset.snapshots:
+        for snapshot in self.root_dataset.snapshots:
             match = pattern.match(snapshot.snapshot_name)
             if match is None:
                 continue
@@ -733,7 +733,7 @@ class ReleaseGenerator(ReleaseResource):
             libzfs.ZFSSnapshot: The ZFS snapshot object found or created
 
         """
-        snapshot_name = f"{self.dataset.name}@{identifier}"
+        snapshot_name = f"{self.root_dataset.name}@{identifier}"
         existing_snapshot: typing.Optional[libzfs.ZFSSnapshot] = None
         try:
             existing_snapshot = self.zfs.get_snapshot(snapshot_name)
@@ -753,7 +753,7 @@ class ReleaseGenerator(ReleaseResource):
             existing_snapshot.delete()
             existing_snapshot = None
 
-        self.dataset.snapshot(snapshot_name)
+        self.root_dataset.snapshot(snapshot_name)
         snapshot: libzfs.ZFSSnapshot = self.zfs.get_snapshot(snapshot_name)
         return snapshot
 

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -398,7 +398,7 @@ class ReleaseGenerator(ReleaseResource):
 
         When no snapshot was taken before `p0` is automatically created.
         """
-        version_snapshots = sorted(self.version_snapshots)
+        version_snapshots = self.version_snapshots
         if len(version_snapshots) == 0:
             self.logger.verbose("No release snapshot found - using @p0")
             return self.snapshot("p0")

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -392,6 +392,16 @@ class ReleaseGenerator(ReleaseResource):
         return False
 
     @property
+    def current_snapshot(self) -> libzfs.ZFSSnapshot:
+        """Return the manually configured or the latest release snapshot."""
+        if self.patchlevel is not None:
+            for snapshot in self.version_snapshots:
+                if snapshot.snapshot_name == f"p{self.patchlevel}":
+                    return snapshot
+
+        return self.latest_snapshot
+
+    @property
     def latest_snapshot(self) -> libzfs.ZFSSnapshot:
         """
         Return or create the latest version snapshot.

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -48,10 +48,10 @@ class Updater:
     def __init__(
         self,
         resource: 'iocage.lib.LaunchableResource.LaunchableResource',
-        distribution: 'iocage.lib.Distribution.Distribution'
+        host: 'iocage.lib.Host.HostGenerator'
     ) -> None:
         self.resource = resource
-        self.distribution = distribution
+        self.host = host
 
     @property
     def logger(self) -> 'iocage.lib.Logger.Logger':
@@ -545,18 +545,18 @@ class FreeBSD(Updater):
 
 
 def get_launchable_update_resource(  # noqa: T484
-    distribution: 'iocage.lib.Distribution.Distribution',
+    host: 'iocage.lib.Host.HostGenerator',
     **kwargs
 ) -> Updater:
     """Return an updater instance for the host distribution."""
     _class: typing.Type[Updater]
 
-    if distribution.name == "HardenedBSD":
+    if host.distribution.name == "HardenedBSD":
         _class = HardenedBSD
     else:
         _class = FreeBSD
 
     return _class(
-        distribution=distribution,
+        host=host,
         **kwargs
     )

--- a/iocage/lib/StandaloneJailStorage.py
+++ b/iocage/lib/StandaloneJailStorage.py
@@ -40,8 +40,8 @@ class StandaloneJailStorage(iocage.lib.Storage.Storage):
 
     def setup(
         self,
-        release: 'iocage.lib.Release.ReleaseGenerator'
+        resource: 'iocage.lib.Resource.Resource'
     ) -> None:
         """Configure the jail storage."""
         self.logger.verbose("Cloning the release once to the root dataset")
-        self.clone_release(release)
+        self.clone_resource(resource)

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -50,19 +50,43 @@ class Storage:
         # jailed=on already exist
         self.safe_mode = safe_mode
 
-    def clone_release(
+    def clone_resource(
+        self,
+        resource: 'iocage.lib.Resource.Resource'
+    ) -> None:
+        """Clone another resource to a the current dataset_name."""
+        if isinstance(resource, iocage.lib.Release.ReleaseGenerator) is True:
+            self._clone_release(resource)
+        else:
+            self._clone_jail(resource)
+
+    def _clone_release(
         self,
         release: 'iocage.lib.Release.ReleaseGenerator'
     ) -> None:
         """Clone a release to a the current dataset_name."""
-        jail_name = self.jail.humanreadable_name
         self.zfs.clone_snapshot(
-            snapshot=release.latest_snapshot,
-            target=self.jail.root_dataset_name
+            release.latest_snapshot,
+            self.jail.root_dataset_name
         )
         jail_name = self.jail.humanreadable_name
         self.logger.verbose(
             f"Cloned release '{release.name}' to {jail_name}",
+            jail=self.jail
+        )
+
+    def _clone_jail(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator'
+    ) -> None:
+        """Clone a release to a the current dataset_name."""
+        self.zfs.clone_dataset(
+            jail.root_dataset,
+            self.jail.root_dataset_name
+        )
+        jail_name = self.jail.humanreadable_name
+        self.logger.verbose(
+            f"Cloned jail '{jail.name}' to {jail_name}",
             jail=self.jail
         )
 

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -56,11 +56,9 @@ class Storage:
     ) -> None:
         """Clone a release to a the current dataset_name."""
         jail_name = self.jail.humanreadable_name
-        snapshot_name = iocage.lib.ZFS.append_snapshot_datetime(jail_name)
-        self.zfs.clone_dataset(
-            source=release.root_dataset,
-            target=self.jail.root_dataset_name,
-            snapshot_name=snapshot_name
+        self.zfs.clone_snapshot(
+            snapshot=release.latest_snapshot,
+            target=self.jail.root_dataset_name
         )
         jail_name = self.jail.humanreadable_name
         self.logger.verbose(

--- a/iocage/lib/ZFS.py
+++ b/iocage/lib/ZFS.py
@@ -232,6 +232,20 @@ class ZFS(libzfs.ZFS):
         dataset = self.get_dataset(target)
         dataset.mount()
 
+    def rename_snapshot_recursive(
+        self,
+        snapshot: libzfs.ZFSSnapshot,
+        new_name: str
+    ) -> None:
+        """Rename a snapshot recursively."""
+        # ToDo: replace after https://github.com/freenas/py-libzfs/pull/10
+        snapshots_recursive = filter(
+            lambda x: x.snapshot_name == snapshot.snapshot_name,
+            snapshot.parent.snapshots_recursive
+        )
+        for _snapshot in snapshots_recursive:
+            _snapshot.rename(new_name)
+
     @property
     def _has_logger(self) -> bool:
         return ("_logger" in self.__dir__())

--- a/iocage/lib/ZFS.py
+++ b/iocage/lib/ZFS.py
@@ -91,7 +91,7 @@ class ZFS(libzfs.ZFS):
         self,
         dataset: libzfs.ZFSDataset,
         delete_snapshots: bool=True,
-        delete_origin_snapshot: bool=True
+        delete_origin_snapshot: bool=False
     ) -> None:
         """Recursively delete a dataset."""
         for child in dataset.children:

--- a/iocage/lib/ZFSBasejailStorage.py
+++ b/iocage/lib/ZFSBasejailStorage.py
@@ -39,7 +39,9 @@ class ZFSBasejailStorage(iocage.lib.Storage.Storage):
     def setup(self, release):
         """Configure the jail storage."""
         iocage.lib.StandaloneJailStorage.StandaloneJailStorage.setup(
-            self, release)
+            self,
+            release
+        )
 
     def clone(self, release):
         """Clone ZFS basejail datasets from a release."""
@@ -65,7 +67,6 @@ class ZFSBasejailStorage(iocage.lib.Storage.Storage):
             self.zfs.clone_dataset(
                 source=source_dataset,
                 target=target_dataset_name,
-                snapshot_name=self.jail.name,
                 delete_existing=True
             )
 

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -607,7 +607,21 @@ class ZFSSnapshotClone(ZFSEvent):
         **kwargs
     ) -> None:
 
-        msg = "Could not clone to {target}"
+        msg = f"Could not clone to {target}"
+        ZFSEvent.__init__(self, msg=msg, zfs_object=snapshot, **kwargs)
+
+
+class ZFSSnapshotRollback(ZFSEvent):
+    """Rollback a ZFS dataset to a snapshot."""
+
+    def __init__(  # noqa: T484
+        self,
+        snapshot: libzfs.ZFSSnapshot,
+        target: str,
+        **kwargs
+    ) -> None:
+
+        msg = f"Rolling back {target} to snapshot {snapshot.snapshot_name}"
         ZFSEvent.__init__(self, msg=msg, zfs_object=snapshot, **kwargs)
 
 

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -121,16 +121,29 @@ def init_logger(
             return new_logger
 
 
-def get_userland_version() -> str:
+def get_os_version() -> typing.Dict[str, typing.Union[str, int, float]]:
     """Get the hosts userland version."""
     f = open("/bin/freebsd-version", "r", re.MULTILINE, encoding="utf-8")
     # ToDo: move out of the function
-    pattern = re.compile("USERLAND_VERSION=\"(\d{2}\.\d)\-([A-z0-9\-]+)\"")
+    pattern = re.compile(
+        "USERLAND_VERSION=\""
+        "(?P<userland>\d{1,2}(?:\.\d)?)"
+        "\-"
+        "(?P<name>[A-z0-9\-]+?)"
+        "(?:-"
+        "p(?P<patch>\d+)"
+        ")?\""
+    )
     content = f.read()
     match = pattern.search(content)  # type: typing.Optional[typing.Match[str]]
     if match is None:
         raise iocage.lib.errors.HostUserlandVersionUnknown()
-    return match[1]
+    output: typing.Dict[str, typing.Union[str, int, float]] = {
+        "userland": float(match["userland"]),
+        "name": match["name"],
+        "patch": int(match["patch"] if (match["patch"] is not None) else 0)
+    }
+    return output
 
 
 def exec(

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -121,9 +121,11 @@ def init_logger(
             return new_logger
 
 
-def get_os_version() -> typing.Dict[str, typing.Union[str, int, float]]:
+def get_os_version(
+        version_file: str="/bin/freebsd-version"
+) -> typing.Dict[str, typing.Union[str, int, float]]:
     """Get the hosts userland version."""
-    f = open("/bin/freebsd-version", "r", re.MULTILINE, encoding="utf-8")
+    f = open(version_file, "r", re.MULTILINE, encoding="utf-8")
     # ToDo: move out of the function
     pattern = re.compile(
         "USERLAND_VERSION=\""


### PR DESCRIPTION
Initially every jail that was created took a snapshot from its selected release. Instead of doing this we now only take one snapshot after a release has been updated.

Jails will always relate to the release snapshot they were created from. The total number of snapshots is dependend to the number of released patch versions rather than the number of created jails.