### PR TITLE
Add basejail_type=nullfs to the defaults

### DIFF
--- a/iocage/lib/Config/Jail/Defaults.py
+++ b/iocage/lib/Config/Jail/Defaults.py
@@ -71,6 +71,7 @@ class JailConfigDefaults(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         "legacy": False,
         "priority": 0,
         "basejail": False,
+        "basejail_type": "nullfs",
         "clonejail": False,
         "defaultrouter": None,
         "defaultrouter6": None,


### PR DESCRIPTION
Fixes an issue listing jails when at least one legacy jail was in the enabled ioc dataset.