### PR TITLE
Fix HardenedBSD release updates

### DIFF
--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -441,7 +441,7 @@ class HardenedBSD(Updater):
             "-c",
             f"{self.local_release_updates_dir}/{self.update_conf_name}",
             "-i",  # ignore version check (offline)
-            "-v", "latest", "-U",  # skip version check
+            "-v", str(self.patch_version), "-U",  # skip version check
             "-n",  # no kernel
             "-V",
             "-D",  # no download,
@@ -454,7 +454,6 @@ class HardenedBSD(Updater):
     def _fetch_command(self) -> typing.List[str]:
         return [
             f"{self.host_updates_dir}/{self.update_script_name}",
-            f"{self.host_updates_dir}/temp",
             "-k",
             self.release.name,
             "-f",  # fetch only
@@ -463,7 +462,9 @@ class HardenedBSD(Updater):
             "-V",
             "-T",
             "-t",
-            self.local_temp_dir
+            f"{self.host_updates_dir}/temp",
+            "-r"
+            f"{self.resource.root_path}"
         ]
 
     def _get_release_trunk_file_url(

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -303,7 +303,6 @@ class Updater:
                 shell=True,  # nosec: B604
                 logger=self.logger
             )
-            self._snapshot_after_release_update()
         except Exception as e:
             yield releaseUpdateDownloadEvent.fail(e)
             raise
@@ -357,6 +356,7 @@ class Updater:
             raise
 
         _rollback_snapshot()
+        self._snapshot_after_release_update()
         yield runResourceUpdateEvent.end()
         yield changed
 

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -293,6 +293,11 @@ class Updater:
             raise
 
         yield releaseUpdateDownloadEvent.begin()
+
+        if releaseUpdatePullEvent.skipped is True:
+            yield releaseUpdateDownloadEvent.skip()
+            return
+
         self.logger.verbose(
             f"Fetching updates for release '{self.release.name}'"
         )


### PR DESCRIPTION
- check before downloading a new release if the patchlevel snapshot already exists
- take release snapshots after applying them, not after fetching
- correct/enhance hbsd-update arguments