### PR TITLE
Feature: pkg

### DIFF
--- a/iocage/cli/pkg.py
+++ b/iocage/cli/pkg.py
@@ -22,7 +22,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-"""Console subcommand for the CLI."""
+"""Jail package management subcommand for the CLI."""
 import click
 
 import iocage.lib.Jail
@@ -38,7 +38,7 @@ __rootcmd__ = True
 @click.argument("jail")
 @click.argument("packages", nargs=-1)
 def cli(ctx, jail, packages):
-    """Run jexec to login into the specified jail."""
+    """Manage packages within jails using an offline mirror."""
     logger = ctx.parent.logger
 
     try:

--- a/iocage/cli/pkg.py
+++ b/iocage/cli/pkg.py
@@ -54,6 +54,7 @@ def cli(ctx, jail, packages):
     try:
         pkg = iocage.lib.Pkg.Pkg(
             logger=logger,
+            zfs=ctx.parent.zfs,
             host=ctx.parent.host
         )
         events = pkg.fetch_and_install(

--- a/iocage/cli/pkg.py
+++ b/iocage/cli/pkg.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Console subcommand for the CLI."""
+import click
+
+import iocage.lib.Jail
+import iocage.lib.Pkg
+import iocage.lib.Logger
+import iocage.lib.errors
+
+__rootcmd__ = True
+
+
+@click.command(name="pkg", help="Manage packages in a jail.")
+@click.pass_context
+@click.argument("jail")
+@click.argument("packages", nargs=-1)
+def cli(ctx, jail, packages):
+    """Run jexec to login into the specified jail."""
+    logger = ctx.parent.logger
+
+    try:
+        ioc_jail = iocage.lib.Jail.JailGenerator(
+            jail,
+            logger=logger,
+            zfs=ctx.parent.zfs,
+            host=ctx.parent.host
+        )
+    except iocage.lib.errors.JailNotFound:
+        exit(1)
+
+    try:
+        pkg = iocage.lib.Pkg.Pkg(
+            logger=logger,
+            host=ctx.parent.host
+        )
+        events = pkg.fetch_and_install(
+            jail=ioc_jail,
+            packages=list(packages)
+        )
+        ctx.parent.print_events(events)
+    except iocage.lib.errors.IocageException:
+        exit(1)
+

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -108,12 +108,15 @@ class BaseConfig(dict):
         if len(data.keys()) == 0:
             return
 
-        current_id = self["id"]
+        # the name is used in many other variables and needs to be set first
+        for key in ["id", "name", "uuid"]:
+            if key in data.keys():
+                self["id"] = data[key]
+                break
+
         for key, value in data.items():
-
-            if (key in ["id", "name", "uuid"]) and (current_id is not None):
-                value = current_id
-
+            if key in ["id", "name", "uuid"]:
+                continue
             self.__setitem__(  # noqa: T484
                 key,
                 value,

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -314,7 +314,8 @@ class Fstab(
         options: str="ro",
         dump: str="0",
         passnum: str="0",
-        comment: typing.Optional[str]=None
+        comment: typing.Optional[str]=None,
+        replace: bool=False
     ) -> None:
         """
         Append a new line to the fstab file.
@@ -331,7 +332,7 @@ class Fstab(
             "comment": comment
         })
 
-        self.add_line(line)
+        self.add_line(line, replace=replace)
 
     def add_line(
         self,
@@ -339,7 +340,8 @@ class Fstab(
             FstabLine,
             FstabCommentLine,
             FstabAutoPlaceholderLine
-        ]
+        ],
+        replace: bool=False
     ) -> None:
         """
         Directly append a FstabLine type.
@@ -352,10 +354,17 @@ class Fstab(
             self.logger.debug(f"Adding line to fstab: {line}")
 
         if self.line_exists(line):
-            raise iocage.lib.errors.FstabDestinationExists(
-                mountpoint=line["destination"],
-                logger=self.logger
-            )
+            destination = line["destination"]
+            if replace is True:
+                self.logger.spam(
+                    f"Replacing fstab line with destination {destination}"
+                )
+                return
+            else:
+                raise iocage.lib.errors.FstabDestinationExists(
+                    mountpoint=destination,
+                    logger=self.logger
+                )
 
         self._lines.append(line)
 

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -39,7 +39,6 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
 
     def __init__(
         self,
-        data: dict={},
         jail: typing.Optional['iocage.lib.Jail.JailGenerator']=None,
         new: bool=False,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None,
@@ -52,21 +51,7 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         )
 
         self.host = iocage.lib.helpers.init_host(self, host)
-
-        if len(data.keys()) == 0:
-            self.data = {
-                "id": None
-            }
-
         self.jail = jail
-
-        # the name is used in many other variables and needs to be set first
-        for key in ["id", "name", "uuid"]:
-            if key in data.keys():
-                self["id"] = data[key]
-                break
-
-        self.clone(data)
 
     def update_special_property(self, name: str) -> None:
         """Triggered when a special property was updated."""

--- a/iocage/lib/Datasets.py
+++ b/iocage/lib/Datasets.py
@@ -85,6 +85,11 @@ class RootDatasets:
         """Get or create the iocage jails dataset."""
         return self._get_or_create_dataset("jails")
 
+    @property
+    def pkg(self) -> libzfs.ZFSDataset:
+        """Get or create the pkg cache."""
+        return self._get_or_create_dataset("pkg")
+
     def _get_or_create_dataset(
         self,
         asset_name: str

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -488,15 +488,12 @@ class JailGenerator(JailResource):
 
         def _stop_failed_jail(
         ) -> typing.Generator['iocage.lib.events.IocageEvent', None, None]:
-            if single_command is None:
-                stop_events = self.stop(
-                    force=True,
-                    event_scope=jailLaunchEvent.scope
-                )
-                for event in stop_events:
-                    yield event
-            else:
-                self._run_poststop_hook_manually()
+            stop_events = self.stop(
+                force=True,
+                event_scope=jailLaunchEvent.scope
+            )
+            for event in stop_events:
+                yield event
         jailLaunchEvent.add_rollback_step(_stop_failed_jail)
 
         if self.is_basejail is True:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -318,11 +318,11 @@ class JailGenerator(JailResource):
                 pass
 
         self.config = iocage.lib.Config.Jail.JailConfig.JailConfig(
-            data=data,
             host=self.host,
             jail=self,
             logger=self.logger
         )
+        self.config.clone(data)
 
         self.storage = self._class_storage(
             safe_mode=False,

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -598,11 +598,11 @@ class JailGenerator(JailResource):
             config_data[key] = value
 
         self.config = iocage.lib.Config.Jail.JailConfig.JailConfig(
-            data=original_config.data,
             host=self.host,
             jail=self,
             logger=self.logger
         )
+        self.config.clone(original_config.data)
 
         try:
             fork_exec_events = JailGenerator.start(

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -66,7 +66,7 @@ class Pkg:
         yield packageFetchEvent.begin()
         try:
             iocage.lib.helpers.exec([
-                "pkg",
+                "/usr/sbin/pkg",
                 "fetch",
                 "--yes",
                 "--dependencies",
@@ -112,7 +112,7 @@ class Pkg:
         yield packageInstallEvent.begin()
         try:
             self._get_temporary_jail(jail).fork_exec(" ".join([
-                "pkg",
+                "/usr/sbin/pkg",
                 "install",
                 "--yes",
                 "--repository", "libiocage"

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -27,7 +27,6 @@ import typing
 import math
 import os.path
 import re
-import urllib
 
 import libzfs
 import ucl
@@ -184,34 +183,29 @@ class Pkg:
             pkg_archive_name = self._get_latest_pkg_archive(dataset.mountpoint)
             command = "\n".join([
                 "export ASSUME_ALWAYS_YES=yes",
-                "set -xe",
                 " ".join([
                     "/usr/sbin/pkg",
                     "add",
-                    f"{self.package_source_directory}/All/{pkg_archive_name}",
-                    "2>&1 | cat -",
+                    f"{self.package_source_directory}/All/{pkg_archive_name}"
                 ]),
                 " ".join([
                     "/usr/sbin/pkg",
                     "update",
                     "--force",
-                    "--repository", "libiocage",
-                    "2>&1 | cat -",
+                    "--repository", "libiocage"
                 ]),
                 " ".join([
                     "/usr/sbin/pkg",
                     "install",
                     "--yes",
                     "--repository", "libiocage",
-                    " ".join(packages),
-                    "2>&1 | cat -",
-                ]),
-                "exit 0"
+                    " ".join(packages)
+                ])
             ])
             temporary_jail = self._get_temporary_jail(jail)
             jail_exec_events = temporary_jail.fork_exec(
                 command,
-                passthru=True,
+                passthru=False,
                 event_scope=packageInstallEvent.scope
             )
             skipped = False
@@ -329,9 +323,10 @@ class Pkg:
         release_major_version: int
     ) -> libzfs.ZFSDataset:
         """Return the global package mirror dataset for the release."""
-        return self.zfs.get_or_create_dataset(
+        dataset: libzfs.ZFSDataset = self.zfs.get_or_create_dataset(
             f"{self.host.datasets.main.pkg.name}/{release_major_version}"
         )
+        return dataset
 
     def _get_temporary_jail(
         self,

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Pkg abstraction for Resources."""
+import typing
+import os.path
+import re
+
+import libzfs
+import ucl
+
+import iocage.lib.events
+import iocage.lib.LaunchableResource
+
+
+class Pkg:
+    """iocage pkg management utility."""
+
+    _dataset: libzfs.ZFSDataset
+    package_source_directory: str = "/.iocage/pkg"
+
+    def __init__(
+        self,
+        host: typing.Optional['iocage.lib.Host.Host']=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
+    ) -> None:
+        self.logger = iocage.lib.helpers.init_logger(self, logger)
+        self.host = iocage.lib.helpers.init_host(self, host)
+
+    def fetch(
+        self,
+        packages: typing.Union[str, typing.List[str]],
+        event_scope: typing.Optional['iocage.lib.events.Scope']=None
+    ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
+        """Fetch a bunch of packages to the local mirror."""
+
+        _packages = self._normalize_packages(packages)
+
+        packageFetchEvent = iocage.lib.events.PackageFetch(
+            packages=_packages,
+            logger=self.logger,
+            scope=event_scope
+        )
+
+        yield packageFetchEvent.begin()
+        try:
+            iocage.lib.helpers.exec([
+                "pkg",
+                "fetch",
+                "-y",
+                "-d",
+                "-o", self.dataset.mountpoint,
+                " ".join(packages)
+            ])
+            yield packageFetchEvent.end()
+        except Exception as e:
+            yield packageFetchEvent.fail(e)
+            raise e
+
+    def install(
+        self,
+        packages: typing.Union[str, typing.List[str]],
+        jail: 'iocage.lib.Jail.JailGenerator',
+        event_scope: typing.Optional['iocage.lib.events.Scope']=None
+    ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
+        """Install locally mirrored packages to a jail."""
+
+        _packages = self._normalize_packages(packages)
+
+        packageInstallEvent = iocage.lib.events.PackageInstall(
+            packages=_packages,
+            jail=jail,
+            logger=self.logger,
+            scope=event_scope
+        )
+
+        packageConfigurationEvent = iocage.lib.events.PackageConfiguration(
+            jail=jail,
+            logger=self.logger,
+            scope=event_scope
+        )
+
+        yield packageConfigurationEvent.begin()
+        try:
+            self._update_repo_conf(jail)
+        except Exception as e:
+            yield packageConfigurationEvent.fail(e)
+            raise e
+        yield packageConfigurationEvent.end()
+
+        yield packageInstallEvent.begin()
+        try:
+            self._get_temporary_jail(jail).fork_exec(" ".join([
+                "pkg",
+                "install",
+                "-y",
+                "-r", "libiocage"
+                " ".join(packages)
+            ]))
+        except Exception as e:
+            yield packageInstallEvent.fail(e)
+            raise e
+        yield packageInstallEvent.end()
+
+    def fetch_and_install(
+        self,
+        packages: typing.Union[str, typing.List[str]],
+        jail: 'iocage.lib.Jail.JailGenerator',
+        event_scope: typing.Optional['iocage.lib.events.Scope']=None
+    ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
+        """Mirror and install packages to a jail."""
+        for event in self.fetch(packages, event_scope=event_scope):
+            yield event
+        for event in self.install(packages, jail, event_scope=event_scope):
+            yield event
+
+    def _normalize_packages(
+        self,
+        packages: typing.Union[str, typing.List[str]]
+    ) -> typing.List[str]:
+        _packages = [packages] if isinstance(packages, str) else packages
+        pattern = re.compile("^(?:[A-z0-9](?:[A-z0-9\-]?[A-z0-9])*)+$")
+        for package in _packages:
+            if pattern.match(package) is None:
+                raise iocage.lib.errors.SecurityViolation(
+                    reason="Invalid package name",
+                    logger=self.logger
+                )
+        return _packages
+
+    def _update_repo_conf(self, jail: 'iocage.lib.Jail.JailGenerator') -> None:
+        jail_directory = "/usr/local/etc/pkg/repos/"
+        host_directory = f"{jail.root_path}/{jail_directory}"
+
+        iocage.lib.helpers.makedirs_safe(
+            host_directory,
+            logger=self.logger
+        )
+
+        repo_config_data = {
+            "libiocage": {
+                "ENABLED": False,
+                "URL": self.package_source_directory
+            }
+        }
+
+        config_path = f"{host_directory}/libiocage.conf"
+        if os.path.exists(config_path) and os.path.islink(config_path):
+            raise iocage.lib.errors.SecurityViolation(
+                reason="Refusing to write to a symlink",
+                logger=self.logger
+            )
+        with open(config_path, "w") as f:
+            f.write(ucl.dump(repo_config_data))
+
+    @property
+    def dataset(self):
+        """Return the global package mirror dataset."""
+        return self.host.datasets.main.pkg
+
+    def _get_temporary_jail(
+        self,
+        source_jail: 'iocage.lib.Jail.JailGenerator'
+    ) -> 'iocage.lib.Jail.JailGenerator':
+        temporary_name = source_jail.name + "_pkg"
+        temporary_jail = iocage.lib.Jail.JailGenerator(
+            {
+                "name": temporary_name,
+                "basejail": source_jail.config["basejail"],
+                "release": source_jail.release.name,
+                "exec_start": None,
+                "vnet": False,
+                "ip4_addr": None,
+                "ip6_addr": None,
+                "defaultrouter": None,
+                "mount_devfs": False,
+                "mount_fdescfs": False
+            },
+            new=True,
+            logger=self.logger,
+            zfs=source_jail.zfs,
+            host=source_jail.host,
+            dataset=source_jail.dataset
+        )
+
+        root_path = temporary_jail.root_path
+        destination_dir = f"{root_path}{self.package_source_directory}"
+        temporary_jail.fstab.file = "fstab_pkg"
+        temporary_jail.fstab.new_line(
+            source=self.dataset.mountpoint,
+            destination=destination_dir,
+            options="ro"
+        )
+        if os.path.isdir(destination_dir) is False:
+            iocage.lib.helpers.makedirs_safe(
+                destination_dir,
+                mode=0o755,
+                logger=self.logger
+            )
+        temporary_jail.fstab.save()
+
+        return temporary_jail

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -24,8 +24,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """Pkg abstraction for Resources."""
 import typing
+import math
 import os.path
 import re
+import urllib
 
 import libzfs
 import ucl
@@ -38,25 +40,29 @@ class Pkg:
     """iocage pkg management utility."""
 
     _dataset: libzfs.ZFSDataset
-    package_source_directory: str = "/.iocage/pkg"
-    pkg_repository_name: str = "libiocage"
+    package_source_directory: str = "/.iocage-pkg"
 
     def __init__(
         self,
+        zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         host: typing.Optional['iocage.lib.Host.Host']=None,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None
     ) -> None:
+        self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.host = iocage.lib.helpers.init_host(self, host)
 
     def fetch(
         self,
         packages: typing.Union[str, typing.List[str]],
+        release: 'iocage.lib.Release.ReleaseGenerator',
         event_scope: typing.Optional['iocage.lib.events.Scope']=None
     ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
         """Fetch a bunch of packages to the local mirror."""
-
         _packages = self._normalize_packages(packages)
+        _packages.append("pkg")
+        release_major_version = math.floor(release.version_number)
+        dataset = self._get_release_mirror_dataset(release_major_version)
 
         packageFetchEvent = iocage.lib.events.PackageFetch(
             packages=_packages,
@@ -66,18 +72,80 @@ class Pkg:
 
         yield packageFetchEvent.begin()
         try:
-            iocage.lib.helpers.exec([
+            self.logger.spam("Configuring host pkg repositories")
+            self._config_host_repo(release_major_version)
+            self.logger.spam("Update from release pkg remote")
+            self._update_host_repo(release_major_version)
+            self.logger.spam("Mirroring packages")
+            self._mirror_packages(_packages, dataset, release_major_version)
+            self.logger.spam("Build mirror index")
+            self._build_mirror_index(dataset)
+        except iocage.lib.errors.IocageException as e:
+            yield packageFetchEvent.fail(e)
+            raise e
+        yield packageFetchEvent.end()
+
+    def _update_host_repo(self, release_major_version: int) -> None:
+        iocage.lib.helpers.exec(
+            [
+                "/usr/sbin/pkg",
+                "update",
+                "--repository", self._get_repo_name(release_major_version)
+            ],
+            logger=self.logger,
+            env=dict(
+                SIGNATURE_TYPE="fingerprints"
+            )
+        )
+
+    def _mirror_packages(
+        self,
+        packages: typing.List[str],
+        dataset: libzfs.ZFSDataset,
+        release_major_version: int
+    ) -> None:
+        iocage.lib.helpers.exec(
+            [
                 "/usr/sbin/pkg",
                 "fetch",
                 "--yes",
                 "--dependencies",
-                "--output", self.dataset.mountpoint,
-                " ".join(packages)
-            ])
-            yield packageFetchEvent.end()
-        except Exception as e:
-            yield packageFetchEvent.fail(e)
-            raise e
+                "--repository", self._get_repo_name(release_major_version),
+                "--output", dataset.mountpoint,
+            ] + packages,
+            logger=self.logger,
+            env=dict(
+                SIGNATURE_TYPE="fingerprints"
+            )
+        )
+
+    def _build_mirror_index(self, dataset: libzfs.ZFSDataset) -> None:
+        iocage.lib.helpers.exec(
+            [
+                "/usr/sbin/pkg",
+                "repo",
+                dataset.mountpoint
+            ],
+            env=dict(
+                SIGNATURE_TYPE="fingerprints",
+                FINGERPRINTS="/usr/share/keys/pkg"
+            ),
+            logger=self.logger
+        )
+
+    def _get_base_url(self, release_major_version: int) -> str:
+        """Return the distributions pkg base url for the major release."""
+        if self.host.distribution.name == "HardenedBSD":
+            return (
+                "https://pkg.hardenedbsd.org/HardenedBSD/pkg/"
+                f"FreeBSD:{release_major_version}:{self.host.processor}"
+            )
+        else:
+            return (
+                "https://pkg.freebsd.org/"
+                f"FreeBSD:{release_major_version}:{self.host.processor}/"
+                "latest"
+            )
 
     def install(
         self,
@@ -86,8 +154,9 @@ class Pkg:
         event_scope: typing.Optional['iocage.lib.events.Scope']=None
     ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
         """Install locally mirrored packages to a jail."""
-
         _packages = self._normalize_packages(packages)
+        release_major_version = math.floor(jail.release.version_number)
+        dataset = self._get_release_mirror_dataset(release_major_version)
 
         packageInstallEvent = iocage.lib.events.PackageInstall(
             packages=_packages,
@@ -104,7 +173,7 @@ class Pkg:
 
         yield packageConfigurationEvent.begin()
         try:
-            self._update_repo_conf(jail)
+            self._config_jail_repo(jail)
         except Exception as e:
             yield packageConfigurationEvent.fail(e)
             raise e
@@ -112,17 +181,62 @@ class Pkg:
 
         yield packageInstallEvent.begin()
         try:
-            self._get_temporary_jail(jail).fork_exec(" ".join([
-                "/usr/sbin/pkg",
-                "install",
-                "--yes",
-                "--repository", self.pkg_repository_name,
-                " ".join(packages)
-            ]))
+            pkg_archive_name = self._get_latest_pkg_archive(dataset.mountpoint)
+            command = "\n".join([
+                "export ASSUME_ALWAYS_YES=yes",
+                "set -xe",
+                " ".join([
+                    "/usr/sbin/pkg",
+                    "add",
+                    f"{self.package_source_directory}/All/{pkg_archive_name}",
+                    "2>&1 | cat -",
+                ]),
+                " ".join([
+                    "/usr/sbin/pkg",
+                    "update",
+                    "--force",
+                    "--repository", "libiocage",
+                    "2>&1 | cat -",
+                ]),
+                " ".join([
+                    "/usr/sbin/pkg",
+                    "install",
+                    "--yes",
+                    "--repository", "libiocage",
+                    " ".join(packages),
+                    "2>&1 | cat -",
+                ]),
+                "exit 0"
+            ])
+            temporary_jail = self._get_temporary_jail(jail)
+            jail_exec_events = temporary_jail.fork_exec(
+                command,
+                passthru=True,
+                event_scope=packageInstallEvent.scope
+            )
+            skipped = False
+            for event in jail_exec_events:
+                if isinstance(event, iocage.lib.events.JailLaunch) is True:
+                    if event.done is True:
+                        stdout = event.stdout.strip("\r\n")
+                        skipped = stdout.endswith("already installed")
+                yield event
+            if skipped is True:
+                yield packageInstallEvent.skip()
+            else:
+                yield packageInstallEvent.end()
         except Exception as e:
             yield packageInstallEvent.fail(e)
             raise e
-        yield packageInstallEvent.end()
+
+    def _get_latest_pkg_archive(self, package_source_directory: str) -> str:
+        packages_directory = f"{package_source_directory}/All"
+        for package_archive in os.listdir(packages_directory):
+            if package_archive.endswith(".txz") is False:
+                continue
+            if package_archive.startswith("pkg"):
+                return str(package_archive)
+        raise iocage.lib.errors.PkgNotFound(logger=self.logger)
 
     def fetch_and_install(
         self,
@@ -131,9 +245,9 @@ class Pkg:
         event_scope: typing.Optional['iocage.lib.events.Scope']=None
     ) -> typing.Generator[iocage.lib.events.IocageEvent, None, None]:
         """Mirror and install packages to a jail."""
-        for event in self.fetch(packages, event_scope=event_scope):
+        for event in self.fetch(packages, jail.release, event_scope):
             yield event
-        for event in self.install(packages, jail, event_scope=event_scope):
+        for event in self.install(packages, jail, event_scope):
             yield event
 
     def _normalize_packages(
@@ -150,35 +264,74 @@ class Pkg:
                 )
         return _packages
 
-    def _update_repo_conf(self, jail: 'iocage.lib.Jail.JailGenerator') -> None:
-        jail_directory = "/usr/local/etc/pkg/repos/"
-        host_directory = f"{jail.root_path}/{jail_directory}"
+    def _get_repo_name(self, release_major_version: int) -> str:
+        return f"iocage-release-{release_major_version}"
 
+    def _config_jail_repo(self, jail: 'iocage.lib.Jail.JailGenerator') -> None:
+        jail_directory = "/usr/local/etc/pkg/repos"
+        host_directory = f"{jail.root_path}/{jail_directory}"
+        self._update_repo_conf(
+            repo_name="libiocage",
+            url=f"file://{self.package_source_directory}",
+            directory=host_directory,
+            signature_type="none"
+        )
+
+    def _config_host_repo(
+        self,
+        release_major_version: int
+    ) -> None:
+        repo_name = self._get_repo_name(release_major_version)
+        base_url = self._get_base_url(release_major_version)
+        self._update_repo_conf(
+            repo_name=repo_name,
+            directory="/usr/local/etc/pkg/repos",
+            enabled=True,
+            url=f"pkg+{base_url}",
+            mirror_type="srv",
+            fingerprints="/usr/share/keys/pkg"
+        )
+
+    def _update_repo_conf(
+        self,
+        repo_name: str,
+        directory: str,
+        url: str,
+        enabled: bool=True,
+        signature_type: str="fingerprints",
+        **repo_kwargs: typing.Union[str, bool]
+    ) -> None:
         iocage.lib.helpers.makedirs_safe(
-            host_directory,
+            directory,
             logger=self.logger
         )
 
         repo_config_data = {
-            self.pkg_repository_name: {
-                "ENABLED": False,
-                "URL": self.package_source_directory
-            }
+            repo_name: dict(
+                enabled=enabled,
+                url=url,
+                signature_type=signature_type,
+                **repo_kwargs
+            )
         }
 
-        config_path = f"{host_directory}/libiocage.conf"
+        config_path = f"{directory}/{repo_name}.conf"
         if os.path.exists(config_path) and os.path.islink(config_path):
             raise iocage.lib.errors.SecurityViolation(
                 reason="Refusing to write to a symlink",
                 logger=self.logger
             )
         with open(config_path, "w") as f:
-            f.write(ucl.dump(repo_config_data))
+            f.write(ucl.dump(repo_config_data, ucl.UCL_EMIT_JSON))
 
-    @property
-    def dataset(self):
-        """Return the global package mirror dataset."""
-        return self.host.datasets.main.pkg
+    def _get_release_mirror_dataset(
+        self,
+        release_major_version: int
+    ) -> libzfs.ZFSDataset:
+        """Return the global package mirror dataset for the release."""
+        return self.zfs.get_or_create_dataset(
+            f"{self.host.datasets.main.pkg.name}/{release_major_version}"
+        )
 
     def _get_temporary_jail(
         self,
@@ -195,7 +348,7 @@ class Pkg:
                 "ip4_addr": None,
                 "ip6_addr": None,
                 "defaultrouter": None,
-                "mount_devfs": False,
+                "mount_devfs": True,
                 "mount_fdescfs": False
             },
             new=True,
@@ -207,18 +360,24 @@ class Pkg:
 
         root_path = temporary_jail.root_path
         destination_dir = f"{root_path}{self.package_source_directory}"
-        temporary_jail.fstab.file = "fstab_pkg"
-        temporary_jail.fstab.new_line(
-            source=self.dataset.mountpoint,
-            destination=destination_dir,
-            options="ro"
-        )
-        if os.path.isdir(destination_dir) is False:
-            iocage.lib.helpers.makedirs_safe(
-                destination_dir,
-                mode=0o755,
-                logger=self.logger
+
+        release_major_version = math.floor(source_jail.release.version_number)
+        dataset = self._get_release_mirror_dataset(release_major_version)
+        try:
+            temporary_jail.fstab.new_line(
+                source=dataset.mountpoint,
+                destination=destination_dir,
+                options="ro",
+                replace=True
             )
-        temporary_jail.fstab.save()
+            if os.path.isdir(destination_dir) is False:
+                iocage.lib.helpers.makedirs_safe(
+                    destination_dir,
+                    mode=0o755,
+                    logger=self.logger
+                )
+            temporary_jail.fstab.save()
+        except iocage.lib.errors.FstabDestinationExists:
+            pass
 
         return temporary_jail

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -68,9 +68,9 @@ class Pkg:
             iocage.lib.helpers.exec([
                 "pkg",
                 "fetch",
-                "-y",
-                "-d",
-                "-o", self.dataset.mountpoint,
+                "--yes",
+                "--dependencies",
+                "--output", self.dataset.mountpoint,
                 " ".join(packages)
             ])
             yield packageFetchEvent.end()
@@ -114,8 +114,8 @@ class Pkg:
             self._get_temporary_jail(jail).fork_exec(" ".join([
                 "pkg",
                 "install",
-                "-y",
-                "-r", "libiocage"
+                "--yes",
+                "--repository", "libiocage"
                 " ".join(packages)
             ]))
         except Exception as e:

--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -39,6 +39,7 @@ class Pkg:
 
     _dataset: libzfs.ZFSDataset
     package_source_directory: str = "/.iocage/pkg"
+    pkg_repository_name: str = "libiocage"
 
     def __init__(
         self,
@@ -115,7 +116,7 @@ class Pkg:
                 "/usr/sbin/pkg",
                 "install",
                 "--yes",
-                "--repository", "libiocage"
+                "--repository", self.pkg_repository_name,
                 " ".join(packages)
             ]))
         except Exception as e:
@@ -159,7 +160,7 @@ class Pkg:
         )
 
         repo_config_data = {
-            "libiocage": {
+            self.pkg_repository_name: {
                 "ENABLED": False,
                 "URL": self.package_source_directory
             }

--- a/iocage/lib/ZFS.py
+++ b/iocage/lib/ZFS.py
@@ -52,12 +52,11 @@ class ZFS(libzfs.ZFS):
 
     def create_dataset(  # noqa: T484
         self,
-        dataset_name: str,
-        **kwargs
+        dataset_name: str
     ) -> libzfs.ZFSDataset:
         """Automatically get the pool and create a dataset from its name."""
         pool = self.get_pool(dataset_name)
-        pool.create(dataset_name, kwargs, create_ancestors=True)
+        pool.create(dataset_name, {}, create_ancestors=True)
 
         dataset = self.get_dataset(dataset_name)
         dataset.mount()
@@ -65,8 +64,7 @@ class ZFS(libzfs.ZFS):
 
     def get_or_create_dataset(  # noqa: T484
         self,
-        dataset_name: str,
-        **kwargs
+        dataset_name: str
     ) -> libzfs.ZFSDataset:
         """Find or create the dataset, then return it."""
         try:
@@ -74,7 +72,7 @@ class ZFS(libzfs.ZFS):
         except libzfs.ZFSException:
             pass
 
-        return self.create_dataset(dataset_name, **kwargs)
+        return self.create_dataset(dataset_name)
 
     def get_pool(self, name: str) -> libzfs.ZFSPool:
         """Get the pool with a given name."""

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -1111,3 +1111,19 @@ class JailFilterInvalidName(JailFilterException):
             "Cannot select jail with illegal name"
         )
         JailFilterException.__init__(self, msg, *args, **kwargs)
+
+
+# pkg
+
+
+class PkgNotFound(IocageException):
+    """Raised when the pkg package was not found in the local mirror."""
+
+    def __init__(  # noqa: T484
+        self,
+        *args,
+        **kwargs
+    ) -> None:
+
+        msg = "The pkg package was not found in the local mirror."
+        IocageException.__init__(self, msg, *args, **kwargs)

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -868,3 +868,91 @@ class JailStart(JailEvent):
     ) -> None:
 
         JailEvent.__init__(self, jail, **kwargs)
+
+
+class JailProvisioning(JailEvent):
+    """Provision a jail."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
+class JailProvisioningAssetDownload(JailEvent):
+    """Provision a jail."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
+class JailCommandExecution(JailEvent):
+    """Run command in a jail."""
+
+    stdout: typing.Optional[str]
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+        self.stdout = None
+        JailEvent.__init__(self, jail, **kwargs)
+
+    def end(self, stdout, **kwargs) -> 'IocageEvent':  # noqa: T484
+        """Successfully finish an event."""
+        self.stdout = stdout
+        return IocageEvent.end(self, **kwargs)
+
+
+# PKG
+
+
+class PackageFetch(IocageEvent):
+    """Fetch packages for offline installation."""
+
+    packages: typing.List[str]
+
+    def __init__(  # noqa: T484
+        self,
+        packages: typing.List[str],
+        **kwargs
+    ) -> None:
+
+        self.identifier = "global"
+        self.packages = packages
+        IocageEvent.__init__(self, **kwargs)
+
+
+class PackageInstall(JailEvent):
+    """Install packages in a jail."""
+
+    def __init__(  # noqa: T484
+        self,
+        packages: typing.List[str],
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        self.packages = packages
+        JailEvent.__init__(self, jail=jail, **kwargs)
+
+
+class PackageConfiguration(JailEvent):
+    """Install packages in a jail."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail=jail, **kwargs)

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -552,27 +552,18 @@ def exec_generator(
 def exec_passthru(
     command: typing.List[str],
     logger: typing.Optional[iocage.lib.Logger.Logger]=None,
-    print_lines: bool=True,
     **subprocess_args: typing.Any
-) -> CommandOutput:
+) -> None:
     """Execute a command in an interactive shell."""
-    lines = exec_generator(
+    child = subprocess.Popen(  # nosec: B603
         command,
-        logger=logger,
         stdin=sys.stdin,
-        buffer_lines=False,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        close_fds=True,
         **subprocess_args
     )
-    try:
-        while True:
-            line = next(lines)
-            if print_lines is True:
-                sys.stdout.buffer.write(line)
-                sys.stdout.flush()
-    except StopIteration as return_statement:
-        output: CommandOutput
-        output = return_statement.value
-        return output
+    child.wait()
 
 
 # ToDo: replace with (u)mount library

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -668,4 +668,6 @@ def makedirs_safe(
                     logger=logger
                 )
         directories.pop()
+    if logger is not None:
+        logger.verbose(f"Safely creating {target} directory")
     os.makedirs(target, mode=mode, exist_ok=True)


### PR DESCRIPTION
Jail package management:
- Globally mirror used packages
- Install packages to jails from offline repository / cache
- Mirror packages for every OS major release version
- Ignore install notes from packages

Quality Assurance:
- [x] Tested on FreeBSD 11.2
- [x] Tested on HardenedBSD
- [x] Verify `graylog` service (our test candidate for services that require a TTY during startup) can be installed and starts up
- [x] Processes in a Jail console still receive control codes (e.g. Ctrl + C)