### PR TITLE
do not use None as log level

### DIFF
--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -102,7 +102,7 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
                 jail=self.jail,
                 key=key,
                 logger=self.logger,
-                level=("warn" if skip_on_error else None)
+                level=("warn" if skip_on_error else "error")
             )
             if skip_on_error is False:
                 raise err


### PR DESCRIPTION
Fixes an issue printing errors when loading jails with unknown jail config properties. The log_level `None` was incorrectly used as fallback where the string `error` should have been used.