### PR TITLE
correct key of the temporary jail property exec_start

### DIFF
--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -122,7 +122,7 @@ class Updater:
                     "basejail": False,
                     "allow_mount_nullfs": "1",
                     "release": self.release.name,
-                    "exec.start": None,
+                    "exec_start": None,
                     "securelevel": "0",
                     "allow_chflags": True,
                     "vnet": False,


### PR DESCRIPTION
Fixes an issue where jail services were started before the update process. The jail config property `exec.start` does not exist and was corrected to `exec_start`. Services are no longer started during updates of releases and jails.