### PR TITLE
source /.iocage/.env in exec_start task

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -423,7 +423,7 @@ class JailGenerator(JailResource):
         if self.config["vnet"]:
             _started, _start = self._start_vimage_network()
             exec_started += _started
-            exec_start += _start
+            exec_start += [f". {self._relative_hook_script_dir}/.env"] + _start
             exec_start += self._configure_localhost_commands()
             exec_start += self._configure_routes_commands()
             if self.host.ipfw_enabled is True:


### PR DESCRIPTION
Fixes an issue configuring VNET devices within the jail.