### PR TITLE
use makedirs_safe when creating mountpoints for NullFS Basejails

### DIFF
--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -166,6 +166,9 @@ class Storage:
     def create_jail_mountpoint(self, basedir: str) -> None:
         """Ensure the destination mountpoint exists relative to the jail."""
         basedir = f"{self.jail.root_dataset.mountpoint}/{basedir}"
+        if os.path.islink(basedir):
+            self.logger.verbose("Deleting existing symlink {basedir}")
+            os.unlink(basedir)
         iocage.lib.helpers.makedirs_safe(basedir)
 
     def _mount_procfs(self) -> None:

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -166,9 +166,7 @@ class Storage:
     def create_jail_mountpoint(self, basedir: str) -> None:
         """Ensure the destination mountpoint exists relative to the jail."""
         basedir = f"{self.jail.root_dataset.mountpoint}/{basedir}"
-        if not os.path.isdir(basedir):
-            self.logger.verbose(f"Creating mountpoint {basedir}")
-            os.makedirs(basedir)
+        iocage.lib.helpers.makedirs_safe(basedir)
 
     def _mount_procfs(self) -> None:
         try:


### PR DESCRIPTION
The destination directory of NullFS mountpoints are within the jails root directory. Since this directory is controlled by the jail, the host **must not trust it**.

fixes #441 where iocage_legacy created a symbolic link at the location `/usr/lib32`.