### PR TITLE
Fix resource limit defaults

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -597,7 +597,7 @@ class BaseConfig(dict):
         """
         try:
             return self._getitem_user(key)
-        except KeyError:
+        except (KeyError, TypeError):
             pass
 
         raise KeyError(f"Item not found: {key}")

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -531,11 +531,6 @@ class BaseConfig(dict):
             return False
 
     def _getitem_user(self, key: str) -> typing.Any:
-        try:
-            # passthrough existing properties
-            return self.__getattribute__(key)
-        except AttributeError:
-            pass
 
         # special property
         if self.special_properties.is_special_property(key) is True:

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -533,10 +533,14 @@ class BaseConfig(dict):
     def _getitem_user(self, key: str) -> typing.Any:
 
         # special property
+        _rlimits = iocage.lib.Config.Jail.Properties.ResourceLimit.properties
         if self.special_properties.is_special_property(key) is True:
             is_existing = key in self.data.keys()
+            is_resource_limit = key in _rlimits
             if is_existing is True:
                 return self.special_properties.get_or_create(key)
+            elif is_resource_limit is True:
+                return None
 
         # data with mappings
         method_name = f"_get_{key}"

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -112,8 +112,10 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
         try:
             return super().__getitem__(key)
         except KeyError:
-            # fall back to default
-            return self.host.defaults.config[key]
+            pass
+
+        # fall back to default
+        return self.host.defaults.config[key]
 
     @property
     def all_properties(self) -> list:


### PR DESCRIPTION
fixes #444 

Resource limits are listed in the ResourceLimits module and do not have an explicit default property. https://github.com/iocage/libiocage/blob/1fcbbbe9a100e7a064708526b685e81ab66704fb/iocage/lib/Config/Jail/Properties/ResourceLimit.py#L28-L54

When a resource limit is unset it is `None`.