### PR TITLE
Fix static interface routes for defaultrouter6

### DIFF
--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1788,7 +1788,9 @@ class JailGenerator(JailResource):
                 f"setting pointopoint route to {gateway} via {nic}"
             )
             commands.append(" ".join(
-                ["/sbin/route", "-q", "add", gateway, "-iface", nic]
+                ["/sbin/route", "-q", "add"] +
+                (["-6"] if (ipv6 is True) else []) +
+                [gateway, "-iface", nic]
             ))
 
         self.logger.verbose(


### PR DESCRIPTION
Using the static interface route syntax defaultrouter6="<gateway>@<interface>" did not result in properly configured routes. The `-6` flag was missing on the route command.