### PR TITLE
disable iocage package sources on the host

### DIFF
--- a/iocage/lib/Pkg.py
+++ b/iocage/lib/Pkg.py
@@ -289,7 +289,7 @@ class Pkg:
         self._update_repo_conf(
             repo_name=repo_name,
             directory="/usr/local/etc/pkg/repos",
-            enabled=True,
+            enabled=False,
             url=f"pkg+{base_url}",
             mirror_type="srv",
             fingerprints="/usr/share/keys/pkg"


### PR DESCRIPTION
- prevents the host from installing packages from iocage upstream package sources

The Pkg feature does not require the host remotes to be enabled because the `--repository` flag overrides the pkg source active state.