### PR TITLE
compare parsed_user_input when the filter value does not contain globs

### DIFF
--- a/iocage/lib/Filter.py
+++ b/iocage/lib/Filter.py
@@ -132,16 +132,19 @@ class Term(list):
         if match_filter(value, filter_string) is True:
             return True
 
-        if short is False:
-            return False
-
-        # match against humanreadable names as well
-        has_humanreadble_length = (len(filter_string) == 8)
         has_no_globs = not self._filter_string_has_globs(filter_string)
-        if (has_humanreadble_length and has_no_globs) is True:
-            shortname = iocage.lib.helpers.to_humanreadable_name(value)
-            if shortname == filter_string:
-                return True
+        if has_no_globs is True:
+            # match against humanreadable names as well
+            has_humanreadble_length = (len(filter_string) == 8)
+            if (has_humanreadble_length is True) and (short is True):
+                shortname = iocage.lib.helpers.to_humanreadable_name(value)
+                if shortname == filter_string:
+                    return True
+
+            _parse_user_input = iocage.lib.helpers.parse_user_input
+            parsed_value = _parse_user_input(value)
+            parsed_filter = _parse_user_input(filter_string)
+            return (parsed_value == parsed_filter) is True
 
         return False
 


### PR DESCRIPTION
fixes #448 

When a user enters a jail filter value that contains no glob characters the jail value and the user input are parsed with `iocage.lib.helpers.parse_user_input`. In return various string representations of boolean values can be used to filter resources.

Both commands now result in the same output:
```
ioc list vnet=on
ioc list vnet=yes
```
