### PR TITLE
Enhance updating and Defaultrouter/Addresses special property override behavior

### DIFF
--- a/iocage/cli/update.py
+++ b/iocage/cli/update.py
@@ -57,7 +57,7 @@ def cli(
         logger.error("No jail selector provided")
         exit(1)
 
-    filters = jails + ("template=no,-",)
+    filters = jails + ("template=no,-", "basejail=no",)
     ioc_jails = iocage.lib.Jails.JailsGenerator(
         logger=logger,
         host=ctx.parent.host,
@@ -81,7 +81,7 @@ def cli(
     if len(changed_jails) == 0:
         jails_input = " ".join(list(jails))
         logger.error(
-            f"No jail was updated or matched your input: {jails_input}"
+            f"No non-basejail was updated or matched your input: {jails_input}"
         )
         return False
 

--- a/iocage/lib/Config/Jail/File/Fstab.py
+++ b/iocage/lib/Config/Jail/File/Fstab.py
@@ -349,7 +349,7 @@ class Fstab(
 
         Use save() to write changes to the fstab file.
         """
-        if self.line_exists(line):
+        if self.__contains__(line):
             destination = line["destination"]
             if replace is True:
                 self.logger.verbose(
@@ -390,7 +390,30 @@ class Fstab(
 
         self._lines.append(line)
 
-    def line_exists(
+    def index(
+        self,
+        line: typing.Union[
+            FstabLine,
+            FstabCommentLine,
+            FstabAutoPlaceholderLine
+        ],
+        start: typing.Optional[int]=None,
+        end: typing.Optional[int]=None
+    ) -> int:
+        """Find the index position of a FstabLine in the Fstab instance."""
+        i: int = 0
+        items = list(self)
+        start = 0 if (start is None) else start
+        end = (len(items) - 1) if (end is None) else end
+        for existing_line in items:
+            if (i >= start) and (hash(existing_line) == hash(line)):
+                return i
+            i += 1
+            if (i > end):
+                break
+        raise ValueError("Fstab line does not exist")
+
+    def __contains__(  # noqa: T484
         self,
         line: typing.Union[
             FstabLine,
@@ -557,19 +580,6 @@ class Fstab(
             output = self.basejail_lines + self._lines  # noqa: T484
 
         return iter(output)
-
-    def __contains__(self, value: typing.Union[  # noqa: T484
-        FstabBasejailLine,
-        FstabCommentLine,
-        FstabLine
-    ]) -> bool:
-        """Check if the FstabFile already contains a specific line."""
-        for entry in self:
-            if value["destination"] == entry["destination"]:
-                return True
-            else:
-                return False
-        return False
 
     def replace_path(self, pattern: str, replacement: str) -> None:
         """Replace a path in all fstab entries (source or destination)."""

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1283,8 +1283,7 @@ class JailGenerator(JailResource):
             comment=self.fstab.AUTO_COMMENT_IDENTIFIER
         ))
         self.fstab.read_file()
-        if self.fstab.line_exists(iocage_helper_line) is False:
-            self.fstab.add_line(iocage_helper_line)
+        self.fstab.add_line(iocage_helper_line, replace=True)
         self.fstab.save()
 
     def exec(  # noqa: T484


### PR DESCRIPTION
related to #451

- Prevent the launch-scripts fstab line from being duplicated if it has no auto-comment attached.
- The update CLI command only affects non-basejails
- Improve `contains` and `index` of the Fstab wrapper
- Properly handle user config overrides of Defaultrouter and Addresses special config properties