### PR TITLE
Configure nameserver during jail start

### DIFF
--- a/iocage/lib/Config/Jail/Properties/Resolver.py
+++ b/iocage/lib/Config/Jail/Properties/Resolver.py
@@ -89,7 +89,14 @@ class ResolverProp(collections.MutableSequence):
             f"Configuring nameserver for Jail '{jail.humanreadable_name}'"
         )
 
-        remote_path = f"{jail.root_path}/{self.conf_file_path}"
+        remote_path = os.path.realpath(
+            f"{jail.root_path}/{self.conf_file_path}"
+        )
+        if remote_path.startswith(jail.root_path) is False:
+            raise iocage.lib.errors.InsecureJailPath(
+                path=remote_path,
+                logger=self.logger
+            )
 
         if self.method == "skip":
             self.logger.verbose("resolv.conf untouched")

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -358,6 +358,18 @@ class JailFstabUpdate(JailEvent):
         JailEvent.__init__(self, jail, **kwargs)
 
 
+class JailResolverConfig(JailEvent):
+    """Update a jails /etc/resolv.conf file."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        **kwargs
+    ) -> None:
+
+        JailEvent.__init__(self, jail, **kwargs)
+
+
 class JailClone(JailEvent):
     """Clone a jail."""
 


### PR DESCRIPTION
- Configures a jails /etc/resolv.conf file before starting a jail (fixes #450)
- Prevent the `/etc/resolv.conf` file relative to the root directory of a jail from being a symbolic link.