### PR TITLE
escape network interface names and properties

### DIFF
--- a/iocage/lib/Firewall.py
+++ b/iocage/lib/Firewall.py
@@ -23,6 +23,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """iocage firewall module."""
 import typing
+import shlex
 
 import sysctl
 
@@ -65,30 +66,45 @@ class Firewall:
                         logger=self.logger
                     )
 
-    def delete_rule(self, rule_number: typing.Union[int, str]) -> None:
+    def delete_rule(
+        self,
+        rule_number: typing.Union[int, str],
+        insecure: bool=False
+    ) -> None:
         """Delete a firewall rule by its number."""
         command = [
             self.IPFW_COMMAND,
             "-q", "delete",
-            self._offset_rule_number(rule_number)
+            self._offset_rule_number(rule_number, insecure=insecure)
         ]
         self._exec(command, ignore_error=True)
 
     def add_rule(
         self,
         rule_number: typing.Union[int, str],
-        rule_arguments: typing.List[str]
+        rule_arguments: typing.List[str],
+        insecure: bool=False
     ) -> None:
         """Add a rule to the firewall configuration."""
         command = [
             self.IPFW_COMMAND,
             "-q", "add",
-            self._offset_rule_number(rule_number)
+            self._offset_rule_number(rule_number, insecure=insecure)
         ] + rule_arguments
 
         self._exec(command)
 
-    def _offset_rule_number(self, rule_number: typing.Union[int, str]) -> str:
+    def _offset_rule_number(
+        self,
+        rule_number: typing.Union[int, str],
+        insecure: bool=False
+    ) -> str:
+        if insecure is True:
+            raise NotImplementedError(
+                "Insecure rule numbers supported by Firewall"
+            )
+        if isinstance(rule_number, str) is True:
+            raise ValueError("Firewall rule_number must be a number")
         _rule_number = int(rule_number)
         return str(_rule_number + self.IPFW_RULE_OFFSET)
 
@@ -110,15 +126,25 @@ class QueuingFirewall(Firewall, iocage.lib.CommandQueue.CommandQueue):
 
     def __init__(  # noqa: T484
         self,
+        insecure: bool=False,
         **firewall_arguments
     ) -> None:
         self.clear_command_queue()
+
+        # disable shlex.quote on rule numbers (e.g. $IOCAGE_JID)
+        self.insecure = insecure
+
         Firewall.__init__(self, **firewall_arguments)
 
-    def _offset_rule_number(self, rule_number: typing.Union[int, str]) -> str:
+    def _offset_rule_number(
+        self,
+        rule_number: typing.Union[int, str],
+        insecure: bool=False
+    ) -> str:
         if isinstance(rule_number, int):
             return str(rule_number + self.IPFW_RULE_OFFSET)
-        return f"$(expr {rule_number} + {self.IPFW_RULE_OFFSET})"
+        _rule_number = rule_number if insecure else self._escape(rule_number)
+        return f"$(expr {_rule_number} + {self.IPFW_RULE_OFFSET})"
 
     def _exec(
         self,
@@ -129,3 +155,6 @@ class QueuingFirewall(Firewall, iocage.lib.CommandQueue.CommandQueue):
         if ignore_error is True:
             command_line += " || true"
         self.append_command_queue(command_line)
+
+    def _escape(self, value: str) -> str:
+        return str(shlex.quote(value))

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -351,7 +351,9 @@ class Network:
 
     def __configure_firewall(self, mac_address: str) -> typing.List[str]:
 
-        self.logger.verbose("Configuring Secure VNET Firewall")
+        self.logger.verbose(
+            f"Configuring Secure VNET Firewall for {self._escaped_nic_name}"
+        )
         firewall_rule_number = f"$IOCAGE_JID"
 
         for protocol in ["ipv4", "ipv6"]:

--- a/iocage/lib/Network.py
+++ b/iocage/lib/Network.py
@@ -24,6 +24,7 @@
 """iocage network abstraction module."""
 import typing
 import shlex
+import ipaddress
 from hashlib import sha224
 
 import iocage.lib.BridgeInterface
@@ -356,7 +357,13 @@ class Network:
         for protocol in ["ipv4", "ipv6"]:
             addresses = self.__getattribute__(f"{protocol}_addresses")
             for address in addresses:
-                _address = str(address)
+                try:
+                    _address = str(address.ip)
+                except ipaddress.AddressValueError as e:
+                    self.logger.warn(
+                        f"Firewall permit not possible for address '{address}'"
+                    )
+                    continue
                 self.firewall.add_rule(firewall_rule_number, [
                     "allow", protocol,
                     "from", _address, "to", "any",


### PR DESCRIPTION
Network interface names may contain arbitrary UTF-8 characters. Quotation with shlex.quote mitigates command injection via network interface names or interface properties.

### Proof of Concept
```
ioc set vnet=on interfaces=";cat /etc/passwd" ... myjail
```