### PR TITLE
Fix VNET router advertisements and DHCP

### DIFF
--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -607,7 +607,7 @@ class BaseConfig(dict):
         try:
             if self.special_properties.is_special_property(key):
                 special_property = self.special_properties.get_or_create(key)
-                special_property.set(value)
+                special_property.set(value, skip_on_error=skip_on_error)
                 self.update_special_property(key)
                 return
 

--- a/iocage/lib/Config/Jail/Properties/Defaultrouter.py
+++ b/iocage/lib/Config/Jail/Properties/Defaultrouter.py
@@ -109,7 +109,7 @@ class DefaultrouterMixin:
     def _gateway_address(self) -> typing.Optional[str]:
         try:
             return self._ipaddress_class.__str__(self)  # noqa: T484
-        except AttributeError:
+        except Exception:
             return None
 
     def __str__(self) -> str:

--- a/iocage/lib/Config/Jail/Properties/Defaultrouter.py
+++ b/iocage/lib/Config/Jail/Properties/Defaultrouter.py
@@ -63,7 +63,12 @@ class DefaultrouterMixin:
         self.skip_on_error = skip_on_error
         self.static_interface = None
 
-    def set(self, data: IPAddressInput, notify: bool=True) -> None:
+    def set(
+        self,
+        data: IPAddressInput,
+        notify: bool=True,
+        skip_on_error: bool=False
+    ) -> None:
         """Set the defaultrouter property."""
         gateway: typing.Optional[typing.Union[
             str,

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -179,12 +179,17 @@ class ResourceLimitProp(ResourceLimitValue):
                 self.config.data[self.property_name]
             )
 
-    def set(self, data: _ResourceLimitInputType) -> None:
+    def set(
+        self,
+        data: _ResourceLimitInputType,
+        skip_on_error: bool=False
+    ) -> None:
         """
         Set the resource limit value.
 
         Setting it to None will remove it from the configuration.
         """
+        error_log_level = "warn" if (skip_on_error is True) else "error"
         if data is None:
             name = self.property_name
             config = self.config
@@ -200,7 +205,15 @@ class ResourceLimitProp(ResourceLimitValue):
             action = data.action
             per = data.per
         else:
-            raise TypeError("invalid ResourceLimit input type")
+            e = iocage.lib.errors.InvalidJailConfigValue(
+                reason="invalid ResourceLimit input type",
+                property_name=self.property_name,
+                jail=self.config.jail,
+                logger=self.logger,
+                level=error_log_level
+            )
+            if skip_on_error is False:
+                raise e
 
         self.amount = amount
         self.action = action

--- a/iocage/lib/IPAddress.py
+++ b/iocage/lib/IPAddress.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Iocage wrappers for ipaddress.IPv4Interface and ipaddress.IPv6Interface."""
+import typing
+import ipaddress
+
+
+class IPv4Interface(ipaddress.IPv4Interface):
+    """ipaddress.IPv4Interface extention that accepts DHCP as input."""
+
+    _ip: typing.Union[str, int]
+
+    def __init__(self, address: typing.Union[str, int]) -> None:
+        if isinstance(address, str) and (address.lower() == "dhcp"):
+            self._ip = "dhcp"
+        else:
+            super().__init__(address)
+
+    def __str__(self) -> str:
+        """Return 'dhcp' or the string representation of the IP."""
+        if isinstance(self._ip, int):
+            return super().__str__()
+        return str(self._ip)
+
+    def __hash__(self) -> int:
+        """Return the IPs hash or -1 for DHCP."""
+        if (self._ip == "dhcp"):
+            return -1
+        return super().__hash__()
+
+
+class IPv6Interface(ipaddress.IPv6Interface):
+    """ipaddress.IPv6Interface extention that accepts ACCEPT_RTADV as input."""
+
+    _ip: typing.Union[str, int]
+
+    def __init__(self, address: typing.Union[str, int]) -> None:
+        if isinstance(address, str) and (address.lower() == "accept_rtadv"):
+            self._ip = "accept_rtadv"
+        else:
+            super().__init__(address)
+
+    def __str__(self) -> str:
+        """Return 'accept_rtadv' or the string representation of the IP."""
+        if isinstance(self._ip, int):
+            return super().__str__()
+        return str(self._ip)
+
+    def __hash__(self) -> int:
+        """Return the IPs hash or -1 for ACCEPT_RTADV."""
+        if (self._ip == "accept_rtadv"):
+            return -1
+        return super().__hash__()


### PR DESCRIPTION
With #438 a regression was introduced that prevented jails from being configured/started with accept_rtadv for `ip6_addr` or DHCP for `ip4_addr`.

- Configuration errors in special config properties when listing jails causes warnings instead of errors
- `dhcp` or `accept_rtadv` are treaded as valid IP address input (for internal processing)