### PR TITLE
Fix compatibility with iocage_legacy configuration in ZFS properties

### DIFF
--- a/iocage/lib/Config/Jail/Properties/Resolver.py
+++ b/iocage/lib/Config/Jail/Properties/Resolver.py
@@ -151,10 +151,11 @@ class ResolverProp(collections.MutableSequence):
             elif isinstance(value, list):
                 self._entries += list(value)  # noqa: T484
             else:
+                jail = self.config.jail if "jail" in dir(self.config) else None
                 raise iocage.lib.errors.InvalidJailConfigValue(
                     reason="value can be list or string",
                     property_name=self.property_name,
-                    jail=self.config.jail,
+                    jail=jail,
                     logger=self.logger,
                     level=error_log_level
                 )

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -254,13 +254,13 @@ class Resource(metaclass=abc.ABCMeta):
 
     def _detect_config_type(self) -> int:
 
-        if self.config_json.exists:
+        if self.config_json.exists is True:
             return self.CONFIG_TYPES.index("json")
 
-        if self.config_ucl.exists:
+        if self.config_ucl.exists is True:
             return self.CONFIG_TYPES.index("ucl")
 
-        if self.config_zfs.exists:
+        if self.config_zfs.exists is True:
             return self.CONFIG_TYPES.index("zfs")
 
         return 0

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -149,7 +149,7 @@ class Resource(metaclass=abc.ABCMeta):
             name = f"{self.dataset.name}{self.DEFAULT_ZFS_DATASET_SUFFIX}"
             dataset = self.zfs.get_or_create_dataset(name)
         else:
-            dataset = None
+            dataset = self.dataset
 
         self._config_zfs = iocage.lib.Config.Type.ZFS.DatasetConfigZFS(
             dataset=dataset,


### PR DESCRIPTION
Mistakenly the ZFS dataset from which the dataset properties of iocage_legacy jails were read was `None` instead of the Resource dataset itself. This changes fix an issue interfacing with existing iocage_legacy jails with configuration in ZFS properties.