### PR TITLE
Feature: fstab Hotplugging

### DIFF
--- a/iocage/cli/fstab.py
+++ b/iocage/cli/fstab.py
@@ -116,7 +116,7 @@ def cli_add(
         fstab.new_line(
             source=source,
             destination=desination_path,
-            fs_type="nullfs",
+            type="nullfs",
             options=mount_opts,
             dump="0",
             passnum="0",

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1571,9 +1571,11 @@ class JailGenerator(JailResource):
             "command=/usr/bin/true"
         ]
 
+        _identifier = str(shlex.quote(self.identifier))
+        _jls_command = f"/usr/sbin/jls -j {_identifier} jid"
         self._write_hook_script("host_command", "\n".join(
             [
-                f"IOCAGE_JID=$(jls -j {self.identifier} jid)",
+                f"IOCAGE_JID=$({_jls_command} 2&>1 || echo -1)",
                 "set -e",
                 f"/bin/sh {self.get_hook_script_path('started')}",
                 (
@@ -1657,9 +1659,11 @@ class JailGenerator(JailResource):
         file = self.get_hook_script_path(hook_name)
         existed = os.path.isfile(file)
         if hook_name in ["started", "poststart", "prestop"]:
+            _identifier = str(shlex.quote(self.identifier))
+            _jls_command = f"/usr/sbin/jls -j {_identifier} jid"
             command_string = (
                 "IOCAGE_JID="
-                f"$(/usr/sbin/jls -j {shlex.quote(self.identifier)} jid)"
+                f"$({_jls_command} 2&>1 || echo -1)"
                 "\n" + command_string
             )
         if hook_name == "poststop":

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1355,7 +1355,7 @@ class JailGenerator(JailResource):
 
     def _destroy_jail(self) -> None:
 
-        self._exec_host_command(
+        stdout, stderr, returncode = self._exec_host_command(
             [
                 "/usr/sbin/jail",
                 "-v",
@@ -1366,6 +1366,12 @@ class JailGenerator(JailResource):
             ],
             passthru=False
         )
+
+        if returncode > 0:
+            raise iocage.lib.errors.JailDestructionFailed(
+                jail=self,
+                logger=self.logger
+            )
 
     @property
     def _dhcp_enabled(self) -> bool:

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -694,18 +694,13 @@ class JailGenerator(JailResource):
         raise NotImplemented("_run_hook only supports start/stop")
 
     def _ensure_script_dir(self) -> None:
-        jail_mountpoint_absolute_dir = "/".join([
-            self.root_dataset.mountpoint,
-            self._relative_hook_script_dir
-        ])
-        for _dir in [self.launch_script_dir, jail_mountpoint_absolute_dir]:
-            realpath = os.path.realpath(_dir)
-            if realpath.startswith(self.dataset.mountpoint) is False:
-                raise iocage.lib.errors.SecurityViolationConfigJailEscape(
-                    file=realpath
-                )
-            if os.path.isdir(realpath) is False:
-                os.makedirs(realpath, 0o755)
+        realpath = os.path.realpath(self.launch_script_dir)
+        if realpath.startswith(self.dataset.mountpoint) is False:
+            raise iocage.lib.errors.SecurityViolationConfigJailEscape(
+                file=realpath
+            )
+        if os.path.isdir(realpath) is False:
+            os.makedirs(realpath, 0o755)
 
     def _prepare_stop(self) -> None:
         exec_prestop = []
@@ -1275,20 +1270,7 @@ class JailGenerator(JailResource):
         else:
             self.fstab.release = None
 
-        # launch command mountpoint
-        jail_start_script_dir = "".join([
-            self.root_dataset.mountpoint,
-            self._relative_hook_script_dir
-        ])
-        iocage_helper_line = iocage.lib.Config.Jail.File.Fstab.FstabLine(dict(
-            source=self.launch_script_dir,
-            destination=jail_start_script_dir,
-            type="nullfs",
-            options="ro",
-            comment=self.fstab.AUTO_COMMENT_IDENTIFIER
-        ))
         self.fstab.read_file()
-        self.fstab.add_line(iocage_helper_line, replace=True)
         self.fstab.save()
 
     def exec(  # noqa: T484

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -188,7 +188,7 @@ class JailNotTemplate(IocageException):
 
 
 class JailLaunchFailed(IocageException):
-    """Raised when the jail state could not be obtained."""
+    """Raised when the jail could not be launched."""
 
     def __init__(  # noqa: T484
         self,
@@ -197,6 +197,19 @@ class JailLaunchFailed(IocageException):
         **kwargs
     ) -> None:
         msg = f"Launching jail {jail.full_name} failed"
+        IocageException.__init__(self, msg, *args, **kwargs)
+
+
+class JailDestructionFailed(IocageException):
+    """Raised when the jail could not be destroyed."""
+
+    def __init__(  # noqa: T484
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        *args,
+        **kwargs
+    ) -> None:
+        msg = f"Destroying jail {jail.full_name} failed"
         IocageException.__init__(self, msg, *args, **kwargs)
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -581,11 +581,14 @@ class UnmountFailed(IocageException):
     def __init__(  # noqa: T484
         self,
         mountpoint: typing.Any,
+        reason: typing.Optional[str]=None,
         *args,
         **kwargs
     ) -> None:
 
-        msg = f"Failed to unmount {mountpoint}"
+        msg = f"Unmount of {mountpoint} failed"
+        if reason is not None:
+            msg += f": {reason}"
         super().__init__(msg, *args, **kwargs)
 
 

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -624,9 +624,8 @@ def umount(
         options=options,
         force=force
     )
-
     try:
-        iocage.lib.helpers.exec(cmd)
+        iocage.lib.helpers.exec(cmd, logger=logger)
         if logger is not None:
             logger.debug(
                 f"Jail mountpoint {mountpoint} umounted"

--- a/iocage/lib/helpers.py
+++ b/iocage/lib/helpers.py
@@ -631,13 +631,14 @@ def umount(
             logger.debug(
                 f"Jail mountpoint {mountpoint} umounted"
             )
-    except iocage.lib.errors.CommandFailure:
+    except iocage.lib.errors.CommandFailure as e:
         if logger is not None:
             logger.spam(
                 f"Jail mountpoint {mountpoint} not unmounted"
             )
         if ignore_error is False:
             raise iocage.lib.errors.UnmountFailed(
+                reason=str(e),
                 mountpoint=mountpoint,
                 logger=logger
             )


### PR DESCRIPTION
- [x] Mounts added entries when a jail is running
- [x] Unmount a destination when a jail is running before removing the line from fstab
- fixes #346 by allowing changes to a running jail
- removed `**kwargs` from setter function headers. Initially these existed because skip_on_error was optionally read by the setters. Since there was no single occasion in the codebase where this it was used, the optional setter argument was removed entirely.