### PR TITLE
Purge *args and **kwargs

### DIFF
--- a/iocage/cli/list.py
+++ b/iocage/cli/list.py
@@ -179,31 +179,30 @@ def _print_list(
         print(separator.join(_lookup_resource_values(resource, columns)))
 
 
-def _print_json(  # noqa: T484
+def _print_json(
     resources: typing.Generator[
         iocage.lib.Jails.JailsGenerator,
         None,
         None
     ],
     columns: list,
-    **json_dumps_args
+    # json.dumps arguments
+    indent: int=2,
+    sort_keys: bool=True
 ) -> None:
 
-    if "indent" not in json_dumps_args.keys():
-        json_dumps_args["indent"] = 2
-
-    if "sort_keys" not in json_dumps_args.keys():
-        json_dumps_args["sort_keys"] = True
-
     output = []
-
     for resource in resources:
         output.append(dict(zip(
             columns,
             _lookup_resource_values(resource, columns)
         )))
 
-    print(json.dumps(output, **json_dumps_args))
+    print(json.dumps(
+        output,
+        indent=indent,
+        sort_keys=sort_keys
+    ))
 
 
 def _lookup_resource_values(

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -756,14 +756,13 @@ class BaseConfig(dict):
 class JailConfigList(list):
     """Jail configuration property in form of a list."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
-        *args,
+        data: typing.List[str]=[],
         delimiter: str=" ",
-        **kwargs
     ) -> None:
         self.delimiter = delimiter
-        list.__init__(self, *args, **kwargs)
+        list.__init__(self, data)
 
     def __str__(self) -> str:
         """Return the string representation in iocage format."""

--- a/iocage/lib/Config/Jail/BaseConfig.py
+++ b/iocage/lib/Config/Jail/BaseConfig.py
@@ -164,7 +164,7 @@ class BaseConfig(dict):
     def _get_id(self) -> str:
         return str(self.data["id"])
 
-    def _set_id(self, name: str, **kwargs) -> None:  # noqa: T484
+    def _set_id(self, name: str) -> None:
 
         if ("id" in self.data.keys()) and (self.data["id"] == name):
             # We do not want to set the same name twice.

--- a/iocage/lib/Config/Jail/Properties/Addresses.py
+++ b/iocage/lib/Config/Jail/Properties/Addresses.py
@@ -62,15 +62,19 @@ IPInterfaceList = typing.Union[
 class AddressSet(set):
     """Set of IP addresses."""
 
+    property_name: str
     config: typing.Optional['iocage.lib.Config.Jail.JailConfig.JailConfig']
+    logger: typing.Optional['iocage.lib.Logger.Logger']
 
     def __init__(
         self,
         config: typing.Optional[
             'iocage.lib.Config.Jail.JailConfig.JailConfig'
         ]=None,
-        property_name: str="ip4_address"
+        property_name: str="ip4_address",
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
     ) -> None:
+        self.logger = logger
         self.config = config
         set.__init__(self)
         self.property_name = property_name

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -33,17 +33,18 @@ class InterfaceProp(dict):
     """Special jail config property Interfaces."""
 
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
-    property_name: str = "interfaces"
+    property_name: str
     delimiter: str = ","
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         config: typing.Optional[
             'iocage.lib.Config.Jail.JailConfig.JailConfig'
         ]=None,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None,
-        **kwargs
+        property_name: str="interfaces"
     ) -> None:
+        self.property_name = property_name
         dict.__init__(self, {})
         self.logger = logger
         if config is not None:

--- a/iocage/lib/Config/Jail/Properties/Interfaces.py
+++ b/iocage/lib/Config/Jail/Properties/Interfaces.py
@@ -34,6 +34,7 @@ class InterfaceProp(dict):
 
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str
+    logger: typing.Optional['iocage.lib.Logger.Logger']
     delimiter: str = ","
 
     def __init__(
@@ -41,8 +42,8 @@ class InterfaceProp(dict):
         config: typing.Optional[
             'iocage.lib.Config.Jail.JailConfig.JailConfig'
         ]=None,
-        logger: typing.Optional['iocage.lib.Logger.Logger']=None,
-        property_name: str="interfaces"
+        property_name: str="interfaces",
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None
     ) -> None:
         self.property_name = property_name
         dict.__init__(self, {})

--- a/iocage/lib/Config/Jail/Properties/Resolver.py
+++ b/iocage/lib/Config/Jail/Properties/Resolver.py
@@ -38,16 +38,16 @@ import iocage.lib.Logger
 class ResolverProp(collections.MutableSequence):
     """Handle the special jail property (DNS) Resolver."""
 
-    config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     property_name: str
+    config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
     none_matches: typing.List[str] = ["/dev/null", "-", ""]
     _entries: typing.List[str] = []
 
     def __init__(
         self,
         config: 'iocage.lib.Config.Jail.JailConfig.JailConfig',
+        property_name: str="resolver",
         logger: typing.Optional[iocage.lib.Logger.Logger]=None,
-        property_name: str="resolver"
     ) -> None:
         self.property_name = property_name
         self.logger = iocage.lib.helpers.init_logger(self, logger)

--- a/iocage/lib/Config/Jail/Properties/Resolver.py
+++ b/iocage/lib/Config/Jail/Properties/Resolver.py
@@ -39,17 +39,17 @@ class ResolverProp(collections.MutableSequence):
     """Handle the special jail property (DNS) Resolver."""
 
     config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
-    property_name: str = "resolver"
+    property_name: str
     none_matches: typing.List[str] = ["/dev/null", "-", ""]
     _entries: typing.List[str] = []
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         config: 'iocage.lib.Config.Jail.JailConfig.JailConfig',
         logger: typing.Optional[iocage.lib.Logger.Logger]=None,
-        **kwargs
+        property_name: str="resolver"
     ) -> None:
-
+        self.property_name = property_name
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.config = config
         self.config.attach_special_property(

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -71,7 +71,7 @@ class ResourceLimitValue:
     def __init__(
         self,
         *args: typing.List[str],
-        **kwargs: typing.Dict[str, typing.Union[int, str]]
+        **kwargs: typing.Union[int, str]
     ) -> None:
         _values: ResourceLimitValueTuple = (None, None, None,)
         if len(args) > 0:

--- a/iocage/lib/Config/Jail/Properties/ResourceLimit.py
+++ b/iocage/lib/Config/Jail/Properties/ResourceLimit.py
@@ -143,6 +143,9 @@ _ResourceLimitInputType = typing.Optional[
 class ResourceLimitProp(ResourceLimitValue):
     """Special jail config property for resource limits."""
 
+    property_name: str
+    config: 'iocage.lib.Config.Jail.JailConfig.JailConfig'
+
     def __init__(
         self,
         property_name: str,
@@ -150,7 +153,6 @@ class ResourceLimitProp(ResourceLimitValue):
             'iocage.lib.Config.Jail.BaseConfig.BaseConfig'
         ]=None,
         logger: typing.Optional['iocage.lib.Logger.Logger']=None,
-        skip_on_error: bool=False
     ) -> None:
 
         self.logger = logger

--- a/iocage/lib/Config/Jail/Properties/__init__.py
+++ b/iocage/lib/Config/Jail/Properties/__init__.py
@@ -68,7 +68,13 @@ def _get_class(property_name: str) -> Property:
     raise ValueError("A special property class with this name was not found")
 
 
-def init_property(property_name: str, **kwargs) -> Property:  # noqa: T484
+def init_property(
+    property_name: str,
+    config: typing.Optional[
+        'iocage.lib.Config.Jail.JailConfig.JailConfig'
+    ]=None,
+    logger: typing.Optional[iocage.lib.Logger.Logger]=None
+) -> Property:  # noqa: T484
     """
     Instantiate a special jail config property.
 
@@ -83,13 +89,17 @@ def init_property(property_name: str, **kwargs) -> Property:  # noqa: T484
                 - defaultrouter
                 - defaultrouter6
 
-        **kwargs:
-            Arguments passed to the special property class
+        config (iocage.lib.Config.Jail.JailConfig.JailConfig):
+            The special property keeps reference to this JailConfig instance
+
+        logger (iocage.lib.Logger.Logger): (optional):
+            Logger instance that the class is initialized with
     """
     target_class = _get_class(property_name)
     out = target_class(
         property_name=property_name,
-        **kwargs
+        config=config,
+        logger=logger
     )
     return out
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1694,7 +1694,7 @@ class JailGenerator(JailResource):
         'iocage.lib.Network.StartedCommandList',
         'iocage.lib.Network.JailCommandList'
     ]:
-        self.logger.debug("Starting VNET/VIMAGE", jail=self)
+        self.logger.debug("Starting VNET/VIMAGE")
 
         started: typing.List[str] = []
         start: typing.List[str] = []

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -67,11 +67,16 @@ class JailResource(
 
     def __init__(  # noqa: T484
         self,
-        host: 'iocage.lib.Host.HostGenerator',
-        jail: typing.Optional['JailGenerator']=None,
+        jail: 'JailGenerator',
+        dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
+        logger: typing.Optional[iocage.lib.Logger.Logger]=None,
+        zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
+        host: typing.Optional[iocage.lib.Host.HostGenerator]=None,
+        fstab: typing.Optional['iocage.lib.Config.Jail.File.Fstab.Fstab']=None,
         root_datasets_name: typing.Optional[str]=None,
-        fstab: typing.Optional['iocage.lib.Config.Jail.File.Fstab']=None,
-        **kwargs
     ) -> None:
 
         self.host = iocage.lib.helpers.init_host(self, host)
@@ -85,7 +90,12 @@ class JailResource(
 
         iocage.lib.LaunchableResource.LaunchableResource.__init__(
             self,
-            **kwargs  # noqa: T484
+            dataset=dataset,
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
+            logger=logger,
+            zfs=zfs
         )
 
     @property
@@ -268,10 +278,14 @@ class JailGenerator(JailResource):
     def __init__(  # noqa: T484
         self,
         data: typing.Union[str, typing.Dict[str, typing.Any]]={},
-        root_datasets_name: typing.Optional[str]=None,
+        dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.lib.Logger.Logger']=None,
         zfs: typing.Optional['iocage.lib.ZFS.ZFS']=None,
         host: typing.Optional['iocage.lib.Host.Host']=None,
-        logger: typing.Optional['iocage.lib.Logger.Logger']=None,
+        root_datasets_name: typing.Optional[str]=None,
         new: bool=False,
         **resource_args
     ) -> None:
@@ -308,11 +322,14 @@ class JailGenerator(JailResource):
         JailResource.__init__(
             self,
             jail=self,
-            root_datasets_name=root_datasets_name,
-            host=self.host,
+            dataset=dataset,
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
             logger=self.logger,
             zfs=self.zfs,
-            **resource_args
+            host=self.host,
+            root_datasets_name=root_datasets_name
         )
 
         if not new and (("id" not in data) or (data["id"] is None)):

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -275,7 +275,7 @@ class JailGenerator(JailResource):
     _relative_hook_script_dir: str
     _provisioner: 'iocage.lib.Provisioning.Prototype'
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         data: typing.Union[str, typing.Dict[str, typing.Any]]={},
         dataset: typing.Optional[libzfs.ZFSDataset]=None,
@@ -286,8 +286,7 @@ class JailGenerator(JailResource):
         zfs: typing.Optional['iocage.lib.ZFS.ZFS']=None,
         host: typing.Optional['iocage.lib.Host.Host']=None,
         root_datasets_name: typing.Optional[str]=None,
-        new: bool=False,
-        **resource_args
+        new: bool=False
     ) -> None:
         """
         Initialize a Jail.

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1205,13 +1205,12 @@ class JailGenerator(JailResource):
         self.require_jail_not_existing()
 
         self.logger.verbose(
-            f"Creating jail '{self.config['id']}'",
-            jail=self
+            f"Creating jail '{self.config['id']}'"
         )
 
         for key, value in self.config.data.items():
             msg = f"{key} = {value}"
-            self.logger.spam(msg, jail=self, indent=1)
+            self.logger.spam(msg, indent=1)
 
         self.create_resource()
 

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1496,15 +1496,13 @@ class JailGenerator(JailResource):
         )
         if returncode > 0:
             self.logger.verbose(
-                f"Jail '{self.humanreadable_name}' was not started",
-                jail=self
+                f"Jail '{self.humanreadable_name}' was not started"
             )
             return stdout, stderr, returncode
 
         self.state.query()
         self.logger.verbose(
-            f"Jail '{self.humanreadable_name}' started with JID {self.jid}",
-            jail=self
+            f"Jail '{self.humanreadable_name}' started with JID {self.jid}"
         )
 
         return stdout, stderr, returncode

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -1776,49 +1776,44 @@ class JailGenerator(JailResource):
         if self.storage_backend is None:
             raise Exception("")
 
-    def require_jail_not_template(self, **kwargs) -> None:  # noqa: T484
+    def require_jail_not_template(self) -> None:
         """Raise JailIsTemplate exception if the jail is a template."""
         if self.config['template'] is True:
             raise iocage.lib.errors.JailIsTemplate(
                 jail=self,
-                logger=self.logger,
-                **kwargs  # noqa: T484
+                logger=self.logger
             )
 
-    def require_jail_not_existing(self, **kwargs) -> None:  # noqa: T484
+    def require_jail_not_existing(self) -> None:
         """Raise JailAlreadyExists exception if the jail already exists."""
         if self.exists:
             raise iocage.lib.errors.JailAlreadyExists(
                 jail=self,
-                logger=self.logger,
-                **kwargs  # noqa: T484
+                logger=self.logger
             )
 
-    def require_jail_existing(self, **kwargs) -> None:  # noqa: T484
+    def require_jail_existing(self) -> None:
         """Raise JailDoesNotExist exception if the jail does not exist."""
         if not self.exists:
             raise iocage.lib.errors.JailDoesNotExist(
                 jail=self,
-                logger=self.logger,
-                **kwargs  # noqa: T484
+                logger=self.logger
             )
 
-    def require_jail_stopped(self, **kwargs) -> None:  # noqa: T484
+    def require_jail_stopped(self) -> None:
         """Raise JailAlreadyRunning exception if the jail is running."""
         if self.running is not False:
             raise iocage.lib.errors.JailAlreadyRunning(
                 jail=self,
-                logger=self.logger,
-                **kwargs  # noqa: T484
+                logger=self.logger
             )
 
-    def require_jail_running(self, **kwargs) -> None:  # noqa: T484
+    def require_jail_running(self) -> None:
         """Raise JailNotRunning exception if the jail is stopped."""
         if not self.running:
             raise iocage.lib.errors.JailNotRunning(
                 jail=self,
-                logger=self.logger,
-                **kwargs  # noqa: T484
+                logger=self.logger
             )
 
     def _teardown_mounts(self) -> typing.List[str]:

--- a/iocage/lib/Jails.py
+++ b/iocage/lib/Jails.py
@@ -68,24 +68,20 @@ class JailsGenerator(iocage.lib.ListableResource.ListableResource):
             logger=logger
         )
 
-    def _create_resource_instance(  # noqa: T484
+    def _create_resource_instance(
         self,
-        dataset: libzfs.ZFSDataset,
-        *class_args,
-        **class_kwargs
+        dataset: libzfs.ZFSDataset
     ) -> iocage.lib.Jail.JailGenerator:
 
-        sources = self.sources
-        class_kwargs["data"] = {
-            "id": dataset.name.split("/").pop()
-        }
-        class_kwargs["root_datasets_name"] = sources.find_root_datasets_name(
-            dataset.name
+        jail = self._class_jail(
+            data=dict(id=dataset.name.split("/").pop()),
+            root_datasets_name=self.sources.find_root_datasets_name(
+                dataset.name
+            ),
+            logger=self.logger,
+            host=self.host,
+            zfs=self.zfs
         )
-        class_kwargs["logger"] = self.logger
-        class_kwargs["host"] = self.host
-        class_kwargs["zfs"] = self.zfs
-        jail = self._class_jail(*class_args, **class_kwargs)
 
         if jail.identifier in self.states:
             self.logger.spam(

--- a/iocage/lib/LaunchableResource.py
+++ b/iocage/lib/LaunchableResource.py
@@ -55,12 +55,17 @@ class LaunchableResource(iocage.lib.Resource.Resource):
     ]
     config: iocage.lib.Config.Jail.JailConfig.JailConfig
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
+        dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
+        logger: typing.Optional[iocage.lib.Logger.Logger]=None,
+        zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         host: typing.Optional[
             'iocage.lib.Host.HostGenerator'
         ]=None,
-        **kwargs
     ) -> None:
         self.host = iocage.lib.helpers.init_host(self, host)
         self._updater = None
@@ -69,7 +74,15 @@ class LaunchableResource(iocage.lib.Resource.Resource):
         self._sysctl_conf = None
         self._updater = None
         self._backup = None
-        iocage.lib.Resource.Resource.__init__(self, **kwargs)
+        iocage.lib.Resource.Resource.__init__(
+            self,
+            dataset=dataset,
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
+            logger=logger,
+            zfs=zfs
+        )
 
     @property
     def updater(

--- a/iocage/lib/ListableResource.py
+++ b/iocage/lib/ListableResource.py
@@ -132,9 +132,7 @@ class ListableResource(list):
     @abc.abstractmethod
     def _create_resource_instance(  # noqa: T484
         self,
-        dataset: libzfs.ZFSDataset,
-        *args,
-        **kwargs
+        dataset: libzfs.ZFSDataset
     ) -> 'iocage.lib.Resource.Resource':
         pass
 

--- a/iocage/lib/Logger.py
+++ b/iocage/lib/Logger.py
@@ -299,13 +299,6 @@ class Logger:
         indent = Logger.INDENT_PREFIX * level
         return "\n".join(map(lambda x: f"{indent}{x}", message.splitlines()))
 
-    def _get_log_file_path(
-        self,
-        level: str,
-        jail: 'iocage.lib.Jail.JailGenerator'=None
-    ) -> str:
-        return self.log_directory
-
     def _create_log_directory(self) -> None:
         if os.geteuid() != 0:
             raise iocage.lib.errors.MustBeRoot(

--- a/iocage/lib/Logger.py
+++ b/iocage/lib/Logger.py
@@ -33,21 +33,17 @@ import iocage.lib.errors
 class LogEntry:
     """A single log entry."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         message: str,
         level: str,
         indent: int=0,
-        logger: 'iocage.lib.Logger.Logger'=None,
-        **kwargs
+        logger: 'iocage.lib.Logger.Logger'=None
     ) -> None:
         self.message = message
         self.level = level
         self.indent = indent
         self.logger = logger
-
-        for key in kwargs.keys():
-            object.__setattr__(self, key, kwargs[key])
 
     def edit(
         self,
@@ -161,18 +157,18 @@ class Logger:
             self._create_log_directory()
         self.log(f"Log directory set to '{log_directory}'", level="spam")
 
-    def log(  # noqa: T484
+    def log(
         self,
         message: str,
         level: str="info",
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Add a log entry."""
         log_entry = LogEntry(
             message=message,
             level=level,
-            logger=self,
-            **kwargs
+            indent=indent,
+            logger=self
         )
 
         if self._should_print_log_entry(log_entry):
@@ -181,59 +177,53 @@ class Logger:
 
         return log_entry
 
-    def verbose(  # noqa: T484
+    def verbose(
         self,
         message: str,
         indent: int=0,
-        **kwargs
     ) -> LogEntry:
         """Add a verbose log entry."""
-        return self.log(message, level="verbose", indent=indent, **kwargs)
+        return self.log(message, level="verbose", indent=indent)
 
-    def error(  # noqa: T484
+    def error(
         self,
         message: str,
-        indent: int=0,
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Add an error log entry."""
-        return self.log(message, level="error", indent=indent, **kwargs)
+        return self.log(message, level="error", indent=indent)
 
-    def warn(  # noqa: T484
+    def warn(
         self,
         message: str,
-        indent: int=0,
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Add a warning log entry."""
-        return self.log(message, level="warn", indent=indent, **kwargs)
+        return self.log(message, level="warn", indent=indent)
 
-    def debug(  # noqa: T484
+    def debug(
         self,
         message: str,
-        indent: int=0,
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Add a debug log entry."""
-        return self.log(message, level="debug", indent=indent, **kwargs)
+        return self.log(message, level="debug", indent=indent)
 
-    def spam(  # noqa: T484
+    def spam(
         self,
         message: str,
-        indent: int=0,
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Add a spam log entry."""
-        return self.log(message, level="spam", indent=indent, **kwargs)
+        return self.log(message, level="spam", indent=indent)
 
-    def screen(  # noqa: T484
+    def screen(
         self,
         message: str,
-        indent: int=0,
-        **kwargs
+        indent: int=0
     ) -> LogEntry:
         """Screen never gets printed to log files."""
-        return self.log(message, level="screen", indent=indent, **kwargs)
+        return self.log(message, level="screen", indent=indent)
 
     def redraw(self, log_entry: LogEntry) -> None:
         """Redraw and update a log entry that was already printed."""

--- a/iocage/lib/Provisioning/ix.py
+++ b/iocage/lib/Provisioning/ix.py
@@ -115,12 +115,9 @@ def provision(
     )
     yield jailProvisioningEvent.begin()
     _scope = jailProvisioningEvent.scope
-    event_kargs = dict(
+    jailProvisioningAssetDownloadEvent = events.JailProvisioningAssetDownload(
         jail=self.jail,
         event_scope=_scope
-    )
-    jailProvisioningAssetDownloadEvent = events.JailProvisioningAssetDownload(
-        **event_kargs
     )
 
     # download provisioning assets

--- a/iocage/lib/Release.py
+++ b/iocage/lib/Release.py
@@ -59,12 +59,17 @@ class ReleaseResource(iocage.lib.LaunchableResource.LaunchableResource):
     host: 'iocage.lib.Host.HostGenerator'
     root_datasets_name: typing.Optional[str]
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
-        host: iocage.lib.Host.HostGenerator,
+        dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
+        logger: typing.Optional[iocage.lib.Logger.Logger]=None,
+        zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
+        host: typing.Optional[iocage.lib.Host.HostGenerator]=None,
         release: typing.Optional['ReleaseGenerator']=None,
         root_datasets_name: typing.Optional[str]=None,
-        **kwargs
     ) -> None:
 
         self.host = iocage.lib.helpers.init_host(self, host)
@@ -72,7 +77,12 @@ class ReleaseResource(iocage.lib.LaunchableResource.LaunchableResource):
 
         iocage.lib.LaunchableResource.LaunchableResource.__init__(
             self,
-            **kwargs
+            dataset=dataset,
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
+            logger=logger,
+            zfs=zfs
         )
 
         self._release = release
@@ -223,13 +233,16 @@ class ReleaseGenerator(ReleaseResource):
     def __init__(  # noqa: T484
         self,
         name: str,
+        dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
         root_datasets_name: typing.Optional[str]=None,
         host: typing.Optional[iocage.lib.Host.HostGenerator]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None,
         check_hashes: bool=True,
         check_eol: bool=True,
-        **release_resource_args
     ) -> None:
         self.logger = iocage.lib.helpers.init_logger(self, logger)
         self.zfs = iocage.lib.helpers.init_zfs(self, zfs)
@@ -265,7 +278,10 @@ class ReleaseGenerator(ReleaseResource):
             logger=self.logger,
             zfs=self.zfs,
             root_datasets_name=root_datasets_name,
-            **release_resource_args
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
+            release=self
         )
 
         self._assets = ["base"]

--- a/iocage/lib/Releases.py
+++ b/iocage/lib/Releases.py
@@ -88,22 +88,19 @@ class ReleasesGenerator(iocage.lib.ListableResource.ListableResource):
         releases = distribution.releases  # type: ReleaseListType
         return releases
 
-    def _create_resource_instance(  # noqa T484
+    def _create_resource_instance(
         self,
-        dataset: libzfs.ZFSDataset,
-        *class_args,
-        **class_kwargs
+        dataset: libzfs.ZFSDataset
     ) -> iocage.lib.Release.ReleaseGenerator:
-
-        sources = self.sources
-        class_kwargs["name"] = self._get_asset_name_from_dataset(dataset)
-        class_kwargs["root_datasets_name"] = sources.find_root_datasets_name(
-            dataset.name
+        return self._class_release(
+            name=self._get_asset_name_from_dataset(dataset),
+            root_datasets_name=self.sources.find_root_datasets_name(
+                dataset.name
+            ),
+            logger=self.logger,
+            host=self.host,
+            zfs=self.zfs
         )
-        class_kwargs["logger"] = self.logger
-        class_kwargs["host"] = self.host
-        class_kwargs["zfs"] = self.zfs
-        return self._class_release(*class_args, **class_kwargs)
 
     def _create_instance(  # noqa: T484
         self,

--- a/iocage/lib/Releases.py
+++ b/iocage/lib/Releases.py
@@ -102,22 +102,8 @@ class ReleasesGenerator(iocage.lib.ListableResource.ListableResource):
             zfs=self.zfs
         )
 
-    def _create_instance(  # noqa: T484
-        self,
-        *args,
-        **kwargs
-    ) -> iocage.lib.Release.ReleaseGenerator:
-        return self._class_release(*args, **kwargs)
-
 
 class Releases(ReleasesGenerator):
     """Model of multiple iocage Releases."""
 
     _class_release = iocage.lib.Release.Release
-
-    def _create_instance(  # noqa: T484
-        self,
-        *args,
-        **kwargs
-    ) -> iocage.lib.Release.Release:
-        return iocage.lib.Release.Release(*args, **kwargs)

--- a/iocage/lib/Resource.py
+++ b/iocage/lib/Resource.py
@@ -95,8 +95,8 @@ class Resource(metaclass=abc.ABCMeta):
         self,
         dataset: typing.Optional[libzfs.ZFSDataset]=None,
         dataset_name: typing.Optional[str]=None,
-        config_type: str="auto",  # auto, json, zfs, ucl
-        config_file: typing.Optional[str]=None,  # 'config.json', 'config', etc
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None
     ) -> None:
@@ -298,10 +298,9 @@ class Resource(metaclass=abc.ABCMeta):
         dataset: libzfs.ZFSDataset = self.zfs.get_dataset(dataset_name)
         return dataset
 
-    def get_or_create_dataset(  # noqa: T484
+    def get_or_create_dataset(
         self,
-        name: str,
-        **kwargs
+        name: str
     ) -> libzfs.ZFSDataset:
         """
         Get or create a child dataset.
@@ -313,8 +312,7 @@ class Resource(metaclass=abc.ABCMeta):
         """
         dataset_name = f"{self.dataset_name}/{name}"
         dataset: libzfs.ZFSDataset = self.zfs.get_or_create_dataset(
-            dataset_name,
-            **kwargs
+            dataset_name
         )
         return dataset
 
@@ -372,20 +370,24 @@ class DefaultResource(Resource):
     DEFAULT_UCL_FILE = "defaults"
     DEFAULT_ZFS_DATASET_SUFFIX = "/.defaults"
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset: typing.Optional[libzfs.ZFSDataset]=None,
+        dataset_name: typing.Optional[str]=None,
+        config_type: str="auto",
+        config_file: typing.Optional[str]=None,
         logger: typing.Optional[iocage.lib.Logger.Logger]=None,
         zfs: typing.Optional[iocage.lib.ZFS.ZFS]=None,
-        **kwargs
     ) -> None:
 
         Resource.__init__(
             self,
             dataset=dataset,
+            dataset_name=dataset_name,
+            config_type=config_type,
+            config_file=config_file,
             logger=logger,
             zfs=zfs,
-            **kwargs
         )
 
         self.config = iocage.lib.Config.Jail.Defaults.JailConfigDefaults(

--- a/iocage/lib/ResourceUpdater.py
+++ b/iocage/lib/ResourceUpdater.py
@@ -629,7 +629,7 @@ class FreeBSD(Updater):
 
 def get_launchable_update_resource(  # noqa: T484
     host: 'iocage.lib.Host.HostGenerator',
-    **kwargs
+    resource: 'iocage.lib.Resource.Resource'
 ) -> Updater:
     """Return an updater instance for the host distribution."""
     _class: typing.Type[Updater]
@@ -641,5 +641,5 @@ def get_launchable_update_resource(  # noqa: T484
 
     return _class(
         host=host,
-        **kwargs
+        resource=resource
     )

--- a/iocage/lib/Storage.py
+++ b/iocage/lib/Storage.py
@@ -72,8 +72,7 @@ class Storage:
         )
         jail_name = self.jail.humanreadable_name
         self.logger.verbose(
-            f"Cloned release '{release.name}' to {jail_name}",
-            jail=self.jail
+            f"Cloned release '{release.name}' to {jail_name}"
         )
 
     def _clone_jail(
@@ -87,8 +86,7 @@ class Storage:
         )
         jail_name = self.jail.humanreadable_name
         self.logger.verbose(
-            f"Cloned jail '{jail.name}' to {jail_name}",
-            jail=self.jail
+            f"Cloned jail '{jail.name}' to {jail_name}"
         )
 
     def rename(

--- a/iocage/lib/ZFS.py
+++ b/iocage/lib/ZFS.py
@@ -63,7 +63,7 @@ class ZFS(libzfs.ZFS):
         dataset.mount()
         return dataset
 
-    def get_or_create_dataset(  # noqa: T484
+    def get_or_create_dataset(
         self,
         dataset_name: str
     ) -> libzfs.ZFSDataset:

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -931,11 +931,12 @@ class InvalidIPAddress(IocageException):
         self,
         reason: str,
         ipv6: bool,
-        logger: typing.Optional[Logger]=None
+        logger: typing.Optional[Logger]=None,
+        level: str="error"
     ) -> None:
         ip_version = 4 + 2 * (ipv6 is True)
         msg = f"Invalid IPv{ip_version} address: {reason}"
-        super().__init__(message=msg, logger=logger)
+        super().__init__(message=msg, logger=logger, level=level)
 
 
 # Release

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -69,7 +69,7 @@ class MissingFeature(IocageException, NotImplementedError):
             f"Missing Feature: '{feature_name}' "
             f"{'are' if plural is True else 'is'} not implemented yet"
         )
-        IocageException.__init__(self, message)
+        IocageException.__init__(self, message=message)
 
 
 # Jails
@@ -83,11 +83,12 @@ class JailException(IocageException):
     def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        message: typing.Optional[str]=None,
+        message: str,
         logger: typing.Optional[Logger]=None
     ) -> None:
         self.jail = jail
         IocageException.__init__(self, message=message, logger=logger)
+
 
 class JailDoesNotExist(JailException):
     """Raised when the jail does not exist."""
@@ -98,7 +99,7 @@ class JailDoesNotExist(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Jail '{jail.humanreadable_name}' does not exist"
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 class JailAlreadyExists(IocageException):
@@ -110,7 +111,7 @@ class JailAlreadyExists(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Jail '{jail.humanreadable_name}' already exists"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailNotRunning(IocageException):
@@ -122,7 +123,7 @@ class JailNotRunning(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Jail '{jail.humanreadable_name}' is not running"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailAlreadyRunning(IocageException):
@@ -135,7 +136,7 @@ class JailAlreadyRunning(IocageException):
     ) -> None:
 
         msg = f"Jail '{jail.humanreadable_name}' is already running"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailNotFound(IocageException):
@@ -148,7 +149,7 @@ class JailNotFound(IocageException):
     ) -> None:
 
         msg = f"No jail matching '{text}' was found"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailNotSupplied(IocageException):
@@ -156,7 +157,7 @@ class JailNotSupplied(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"Please supply a jail"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailUnknownIdentifier(IocageException):
@@ -164,7 +165,7 @@ class JailUnknownIdentifier(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "The jail has no identifier yet"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailBackendMissing(IocageException):
@@ -172,7 +173,7 @@ class JailBackendMissing(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "The jail backend is unknown"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailIsTemplate(JailException):
@@ -186,7 +187,7 @@ class JailIsTemplate(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The jail '{jail.name}' is a template"
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 class JailNotTemplate(JailException):
@@ -200,7 +201,7 @@ class JailNotTemplate(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The jail '{jail.full_name}' is not a template"
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 class JailLaunchFailed(JailException):
@@ -212,7 +213,7 @@ class JailLaunchFailed(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Launching jail {jail.full_name} failed"
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 class JailDestructionFailed(JailException):
@@ -226,7 +227,7 @@ class JailDestructionFailed(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Destroying jail {jail.full_name} failed"
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 class JailCommandFailed(IocageException):
@@ -241,7 +242,7 @@ class JailCommandFailed(IocageException):
     ) -> None:
         self.returncode = returncode
         msg = f"Jail command exited with {returncode}"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailExecutionAborted(JailException):
@@ -253,7 +254,7 @@ class JailExecutionAborted(JailException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Jail execution of {jail.humanreadable_name} aborted."
-        JailException.__init__(self, msg, jail=jail, logger=logger)
+        JailException.__init__(self, message=msg, jail=jail, logger=logger)
 
 
 # Jail Fstab
@@ -264,7 +265,7 @@ class VirtualFstabLineHasNoRealIndex(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The virtual fstab line does not have a real list index"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class FstabDestinationExists(IocageException):
@@ -276,7 +277,7 @@ class FstabDestinationExists(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The mountpoint {mountpoint} already exists in the fstab file"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 # Security
@@ -291,7 +292,7 @@ class SecurityViolation(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Security violation: {reason}"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class InsecureJailPath(SecurityViolation):
@@ -303,7 +304,7 @@ class InsecureJailPath(SecurityViolation):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Insecure path {path} jail escape attempt"
-        SecurityViolation.__init__(self, msg)
+        SecurityViolation.__init__(self, reason=msg)
 
 
 class SecurityViolationConfigJailEscape(SecurityViolation):
@@ -315,7 +316,7 @@ class SecurityViolationConfigJailEscape(SecurityViolation):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The file {file} references a file outsite of the jail resource"
-        SecurityViolation.__init__(self, msg)
+        SecurityViolation.__init__(self, reason=msg)
 
 
 class IllegalArchiveContent(IocageException):
@@ -328,7 +329,7 @@ class IllegalArchiveContent(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Asset {asset_name} contains illegal files - {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # JailConfig
@@ -348,7 +349,7 @@ class InvalidJailName(JailConfigError):
             "Invalid jail name: "
             "Names have to begin and end with an alphanumeric character"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class JailConigZFSIsNotAllowed(JailConfigError):
@@ -359,7 +360,7 @@ class JailConigZFSIsNotAllowed(JailConfigError):
             "jail_zfs is disabled "
             "despite jail_zfs_dataset is configured"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidJailConfigValue(JailConfigError, ValueError):
@@ -379,7 +380,7 @@ class InvalidJailConfigValue(JailConfigError, ValueError):
             msg += f" of jail {jail.humanreadable_name}"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger, level=level)
+        super().__init__(message=msg, logger=logger, level=level)
 
 
 class InvalidJailConfigAddress(InvalidJailConfigValue):
@@ -420,7 +421,7 @@ class ResourceLimitUnknown(IocageException, KeyError):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The specified resource limit is unknown"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class JailConfigNotFound(IocageException):
@@ -433,7 +434,7 @@ class JailConfigNotFound(IocageException):
     ) -> None:
         msg = f"Could not read {config_type} config"
         # This is a silent error internally used
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class DefaultConfigNotFound(IocageException, FileNotFoundError):
@@ -445,7 +446,7 @@ class DefaultConfigNotFound(IocageException, FileNotFoundError):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Default configuration not found at {config_file_path}"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class UnknownJailConfigProperty(IocageException, KeyError):
@@ -462,7 +463,7 @@ class UnknownJailConfigProperty(IocageException, KeyError):
             f"The config property '{key}' "
             f"of jail '{jail.humanreadable_name}' is unknown."
         )
-        IocageException.__init__(self, msg, logger=logger, level=level)
+        IocageException.__init__(self, message=msg, logger=logger, level=level)
 
 
 # Backup
@@ -474,7 +475,7 @@ class BackupInProgress(IocageException):
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = "A backup operation is already in progress"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class ExportDestinationExists(IocageException):
@@ -487,7 +488,7 @@ class ExportDestinationExists(IocageException):
     ) -> None:
 
         msg = "The backup destination {destination} already exists"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 # ListableResource
@@ -501,7 +502,7 @@ class ListableResourceNamespaceUndefined(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The ListableResource needs a namespace for this operation"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 # General
@@ -515,7 +516,7 @@ class IocageNotActivated(IocageException):
             "iocage is not activated yet - "
             "please run `ioc activate <POOL>` first and select a pool"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidLogLevel(IocageException):
@@ -532,17 +533,21 @@ class InvalidLogLevel(IocageException):
             f"Invalid log-level {log_level}. Choose one of "
             f"{available_log_levels_string} or {available_log_levels[-1]}"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class MustBeRoot(IocageException):
     """Raised when iocage is executed without root permission."""
 
-    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
+    def __init__(
+        self,
+        message: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         _msg = (
-            f"Must be root to {msg}"
+            f"Must be root to {message}"
         )
-        super().__init__(_msg, logger=logger)
+        super().__init__(message=_msg, logger=logger)
 
 
 class CommandFailure(IocageException):
@@ -554,7 +559,7 @@ class CommandFailure(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Command exited with {returncode}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class NotAnIocageZFSProperty(IocageException):
@@ -566,7 +571,7 @@ class NotAnIocageZFSProperty(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The ZFS property '{property_name}' is not managed by iocage"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Host, Distribution
@@ -581,7 +586,7 @@ class DistributionUnknown(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Unknown Distribution: {distribution_name}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class HostReleaseUnknown(IocageException):
@@ -589,7 +594,7 @@ class HostReleaseUnknown(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The host release is unknown"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class HostUserlandVersionUnknown(IocageException):
@@ -597,7 +602,7 @@ class HostUserlandVersionUnknown(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"Could not determine the hosts userland version"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class DistributionEOLWarningDownloadFailed(IocageException):
@@ -609,7 +614,7 @@ class DistributionEOLWarningDownloadFailed(IocageException):
         level: str="error"
     ) -> None:
         msg = f"Failed to download the EOL warnings"
-        super().__init__(msg, logger=logger, level=level)
+        super().__init__(message=msg, logger=logger, level=level)
 
 
 # Storage
@@ -625,7 +630,7 @@ class DatasetExists(IocageException):
     ) -> None:
 
         msg = f"Dataset already exists: {dataset_name}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class UnmountFailed(IocageException):
@@ -641,7 +646,7 @@ class UnmountFailed(IocageException):
         msg = f"Unmount of {mountpoint} failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class MountFailed(IocageException):
@@ -654,7 +659,7 @@ class MountFailed(IocageException):
     ) -> None:
 
         msg = f"Failed to mount {mountpoint}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class DatasetNotMounted(IocageException):
@@ -667,7 +672,7 @@ class DatasetNotMounted(IocageException):
     ) -> None:
 
         msg = f"Dataset '{dataset.name}' is not mounted"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class DatasetNotAvailable(IocageException):
@@ -680,7 +685,7 @@ class DatasetNotAvailable(IocageException):
     ) -> None:
 
         msg = f"Dataset '{dataset_name}' is not available"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class DatasetNotJailed(IocageException):
@@ -707,11 +712,11 @@ class ZFSException(IocageException):
 
     def __init__(
         self,
-        msg: str,
+        message: str,
         logger: typing.Optional[Logger]=None
     ) -> None:
 
-        super().__init__(msg, logger=logger)
+        super().__init__(message=message, logger=logger)
 
 
 class ZFSPoolInvalid(IocageException, TypeError):
@@ -728,7 +733,7 @@ class ZFSPoolInvalid(IocageException, TypeError):
         if consequence is not None:
             msg += f": {consequence}"
 
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 class ZFSPoolUnavailable(IocageException):
@@ -741,7 +746,7 @@ class ZFSPoolUnavailable(IocageException):
     ) -> None:
 
         msg = f"ZFS pool '{pool_name}' is UNAVAIL"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class ResourceUnmanaged(IocageException):
@@ -754,7 +759,7 @@ class ResourceUnmanaged(IocageException):
     ) -> None:
 
         msg = f"The resource dataset {dataset_name} is not managed by iocage"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class ConflictingResourceSelection(IocageException):
@@ -771,7 +776,7 @@ class ConflictingResourceSelection(IocageException):
             "The resource was configured with conflicting root sources: "
             f"{source_a} != {source_b}"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Snapshots
@@ -780,8 +785,12 @@ class ConflictingResourceSelection(IocageException):
 class SnapshotError(IocageException):
     """Raised on snapshot related errors."""
 
-    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
-        super().__init__(msg, logger=logger)
+    def __init__(
+        self,
+        message: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
+        super().__init__(message=message, logger=logger)
 
 
 class SnapshotCreation(SnapshotError):
@@ -796,7 +805,7 @@ class SnapshotCreation(SnapshotError):
         msg = "Snapshot creation failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class SnapshotDeletion(SnapshotError):
@@ -811,7 +820,7 @@ class SnapshotDeletion(SnapshotError):
         msg = "Snapshot deletion failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class SnapshotRollback(SnapshotError):
@@ -826,7 +835,7 @@ class SnapshotRollback(SnapshotError):
         msg = "Snapshot rollback failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class SnapshotNotFound(SnapshotError):
@@ -840,7 +849,7 @@ class SnapshotNotFound(SnapshotError):
     ) -> None:
 
         msg = f"Snapshot not found: {dataset_name}@{snapshot_name}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidSnapshotIdentifier(SnapshotError):
@@ -856,7 +865,7 @@ class InvalidSnapshotIdentifier(SnapshotError):
             f"Invalid snapshot identifier syntax: {identifier}"
             "(should be <jail>@<snapshot>)"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Network
@@ -867,7 +876,7 @@ class InvalidInterfaceName(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "Invalid NIC name"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class VnetBridgeMissing(IocageException):
@@ -875,7 +884,7 @@ class VnetBridgeMissing(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "VNET is enabled and requires setting a bridge"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidNetworkBridge(IocageException, ValueError):
@@ -890,7 +899,7 @@ class InvalidNetworkBridge(IocageException, ValueError):
         msg = "Invalid network bridge argument"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class FirewallDisabled(IocageException):
@@ -904,7 +913,7 @@ class FirewallDisabled(IocageException):
         msg = "IPFW is disabled"
         if hint is not None:
             msg += f": {hint}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class FirewallCommandFailure(IocageException):
@@ -912,7 +921,7 @@ class FirewallCommandFailure(IocageException):
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "Firewall Command failed. Is IPFW enabled?"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidIPAddress(IocageException):
@@ -926,7 +935,7 @@ class InvalidIPAddress(IocageException):
     ) -> None:
         ip_version = 4 + 2 * (ipv6 is True)
         msg = f"Invalid IPv{ip_version} address: {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Release
@@ -938,7 +947,7 @@ class ReleaseListUnavailable(IocageException):
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = f"The releases list is unavailable"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class ReleaseAssetHashesUnavailable(IocageException):
@@ -947,7 +956,7 @@ class ReleaseAssetHashesUnavailable(IocageException):
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = f"The releases asset hashes are unavailable"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class UpdateFailure(IocageException):
@@ -963,7 +972,7 @@ class UpdateFailure(IocageException):
         msg = f"Release update of '{name}' failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class InvalidReleaseAssetSignature(UpdateFailure):
@@ -1010,7 +1019,7 @@ class ReleaseNotFetched(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Release '{name}' does not exist or is not fetched locally"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class ReleaseUpdateBranchLookup(IocageException):
@@ -1025,7 +1034,7 @@ class ReleaseUpdateBranchLookup(IocageException):
         msg = f"Update source of release '{release_name}' not found"
         if reason is not None:
             msg += ": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class UnsupportedRelease(MissingFeature):
@@ -1052,7 +1061,7 @@ class InvalidReleaseName(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Invalid release name: {name}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Prompts
@@ -1070,7 +1079,7 @@ class DefaultReleaseNotFound(IocageException):
             f"Release '{host_release_name}' not found: "
             "Could not determine a default source"
         )
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # DevfsRules
@@ -1079,8 +1088,12 @@ class DefaultReleaseNotFound(IocageException):
 class DevfsRuleException(IocageException):
     """Raised on errors in devfs rules."""
 
-    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
-        super().__init__(msg, logger=logger)
+    def __init__(
+        self,
+        message: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
+        super().__init__(message=message, logger=logger)
 
 
 class InvalidDevfsRulesSyntax(DevfsRuleException):
@@ -1095,7 +1108,7 @@ class InvalidDevfsRulesSyntax(DevfsRuleException):
         msg = f"Invalid devfs rules in {devfs_rules_file}"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class DuplicateDevfsRuleset(DevfsRuleException):
@@ -1110,7 +1123,7 @@ class DuplicateDevfsRuleset(DevfsRuleException):
         msg = "Cannot add duplicate ruleset"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 class MissingDevfsRulesetName(DevfsRuleException):
@@ -1122,7 +1135,7 @@ class MissingDevfsRulesetName(DevfsRuleException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = "The devfs ruleset is missing a name"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 # Logger
 
@@ -1130,8 +1143,12 @@ class MissingDevfsRulesetName(DevfsRuleException):
 class LogException(IocageException):
     """Raised when logging fails."""
 
-    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
-        super().__init__(msg, logger=logger)
+    def __init__(
+        self,
+        message: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
+        super().__init__(message=message, logger=logger)
 
 
 class CannotRedrawLine(LogException):
@@ -1145,7 +1162,7 @@ class CannotRedrawLine(LogException):
         msg = "Logger can't redraw line"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, logger=logger)
+        super().__init__(message=msg, logger=logger)
 
 
 # Events
@@ -1160,7 +1177,7 @@ class EventAlreadyFinished(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = "This {event.type} event is already finished"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 # Jail Filter
@@ -1169,19 +1186,23 @@ class EventAlreadyFinished(IocageException):
 class JailFilterException(IocageException):
     """Raised when a jail filter is invalid."""
 
-    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
-        IocageException.__init__(self, msg, logger=logger)
+    def __init__(
+        self,
+        message: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
+        IocageException.__init__(self, message=message, logger=logger)
 
 
 class JailFilterInvalidName(JailFilterException):
     """Raised when the name of a jail filter is invalid."""
 
     def __init__(self, logger: typing.Optional[Logger]=None) -> None:
-        msg = (
+        message = (
             "Invalid jail selector: "
             "Cannot select jail with illegal name"
         )
-        JailFilterException.__init__(self, msg, logger=logger)
+        JailFilterException.__init__(self, message=message, logger=logger)
 
 
 # pkg
@@ -1195,7 +1216,7 @@ class PkgNotFound(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = "The pkg package was not found in the local mirror."
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)
 
 
 # Provisioning
@@ -1210,4 +1231,4 @@ class UnknownProvisioner(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Unknown provisioner: {name}"
-        IocageException.__init__(self, msg, logger=logger)
+        IocageException.__init__(self, message=msg, logger=logger)

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -30,7 +30,7 @@ import libzfs  # noqa: F401
 import iocage.lib.events  # noqa: F401
 import iocage.lib.Jail  # noqa: F401
 import iocage.lib.Types  # noqa: F401
-import iocage.lib.Logger
+from iocage.lib.Logger import Logger
 
 
 class IocageException(Exception):
@@ -39,13 +39,12 @@ class IocageException(Exception):
     def __init__(
         self,
         message: str,
-        logger: typing.Optional[iocage.lib.Logger.Logger]=None,
         level: str="error",
         silent: bool=False,
         append_warning: bool=False,
-        warning: typing.Optional[str]=None
+        warning: typing.Optional[str]=None,
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         if (logger is not None) and (silent is False):
             logger.__getattribute__(level)(message)
             if (append_warning is True) and (warning is not None):
@@ -60,18 +59,17 @@ class IocageException(Exception):
 class MissingFeature(IocageException, NotImplementedError):
     """Raised when an iocage feature is not fully implemented yet."""
 
-    def __init__(  # noqa: T484
-            self,
-            feature_name: str,
-            plural: bool=False,
-            *args,
-            **kwargs
+    def __init__(
+        self,
+        feature_name: str,
+        plural: bool=False,
+        logger: typing.Optional[Logger]=None
     ) -> None:
         message = (
             f"Missing Feature: '{feature_name}' "
             f"{'are' if plural is True else 'is'} not implemented yet"
         )
-        IocageException.__init__(self, message, *args, **kwargs)
+        IocageException.__init__(self, message)
 
 
 # Jails
@@ -80,158 +78,161 @@ class MissingFeature(IocageException, NotImplementedError):
 class JailDoesNotExist(IocageException):
     """Raised when the jail does not exist."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Jail '{jail.humanreadable_name}' does not exist"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailAlreadyExists(IocageException):
     """Raised when the jail already exists."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Jail '{jail.humanreadable_name}' already exists"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailNotRunning(IocageException):
     """Raised when the jail is not running."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Jail '{jail.humanreadable_name}' is not running"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailAlreadyRunning(IocageException):
     """Raised when the jail is already running."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Jail '{jail.humanreadable_name}' is already running"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailNotFound(IocageException):
     """Raised when the jail was not found."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         text: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"No jail matching '{text}' was found"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailNotSupplied(IocageException):
     """Raised when no jail was supplied."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"Please supply a jail"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailUnknownIdentifier(IocageException):
     """Raised when the jail has an unknown identifier."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "The jail has no identifier yet"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailBackendMissing(IocageException):
     """Raised when the jails backend was not found."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "The jail backend is unknown"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailIsTemplate(IocageException):
     """Raised when the jail is a template but should not be."""
 
-    def __init__(self, jail, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"The jail '{jail.name}' is a template"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailNotTemplate(IocageException):
     """Raised when the jail is no template but should be one."""
 
-    def __init__(self, jail, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"The jail '{jail.full_name}' is not a template"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailLaunchFailed(IocageException):
     """Raised when the jail could not be launched."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Launching jail {jail.full_name} failed"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailDestructionFailed(IocageException):
     """Raised when the jail could not be destroyed."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Destroying jail {jail.full_name} failed"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailCommandFailed(IocageException):
     """Raised when a jail command fails with an exit code > 0."""
 
-    def __init__(self, returncode: int, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        returncode: int,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Jail command exited with {returncode}"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailExecutionAborted(IocageException):
     """Raised when a jail command fails with an exit code > 0."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         jail: 'iocage.lib.Jail.JailGenerator',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-        msg = f"Jail execution aborted."
-        IocageException.__init__(self, msg, *args, **kwargs)
+        self.jail = jail
+        message = f"Jail execution of {jail.humanreadable_name} aborted."
+        IocageException.__init__(self, message=message, logger=logger)
 
 
 # Jail Fstab
@@ -240,17 +241,21 @@ class JailExecutionAborted(IocageException):
 class VirtualFstabLineHasNoRealIndex(IocageException):
     """Raised when attempting to access the index of a virtual fstab line."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The virtual fstab line does not have a real list index"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class FstabDestinationExists(IocageException):
     """Raised when the destination directory does not exist."""
 
-    def __init__(self, mountpoint: str, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        mountpoint: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"The mountpoint {mountpoint} already exists in the fstab file"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 # Security
@@ -259,39 +264,50 @@ class FstabDestinationExists(IocageException):
 class SecurityViolation(IocageException):
     """Raised when iocage has security concerns."""
 
-    def __init__(self, reason, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        reason: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Security violation: {reason}"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class InsecureJailPath(SecurityViolation):
     """Raised when a a path points outside of a resource."""
 
-    def __init__(self, path, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        path: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Insecure path {path} jail escape attempt"
-        SecurityViolation.__init__(self, msg, *args, **kwargs)
+        SecurityViolation.__init__(self, msg)
 
 
 class SecurityViolationConfigJailEscape(SecurityViolation):
     """Raised when a file symlinks to a location outside of the jail."""
 
-    def __init__(self, file, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        file: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"The file {file} references a file outsite of the jail resource"
-        SecurityViolation.__init__(self, msg, *args, **kwargs)
+        SecurityViolation.__init__(self, msg)
 
 
 class IllegalArchiveContent(IocageException):
     """Raised when a release asset archive contains malicious content."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         asset_name: str,
         reason: str,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Asset {asset_name} contains illegal files - {reason}"
-        super().__init__(msg, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # JailConfig
@@ -306,34 +322,35 @@ class JailConfigError(IocageException):
 class InvalidJailName(JailConfigError):
     """Raised when a jail has an invalid name."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = (
             "Invalid jail name: "
             "Names have to begin and end with an alphanumeric character"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class JailConigZFSIsNotAllowed(JailConfigError):
     """Raised when a jail is not allowed to use ZFS shares."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = (
             "jail_zfs is disabled "
             "despite jail_zfs_dataset is configured"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidJailConfigValue(JailConfigError, ValueError):
     """Raised when a jail configuration value is invalid."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         property_name: str,
         jail: typing.Optional[iocage.lib.Jail.JailGenerator]=None,
         reason: typing.Optional[str]=None,
-        **kwargs
+        logger: typing.Optional[Logger]=None,
+        level: str="error"
     ) -> None:
 
         msg = f"Invalid value for property '{property_name}'"
@@ -341,82 +358,90 @@ class InvalidJailConfigValue(JailConfigError, ValueError):
             msg += f" of jail {jail.humanreadable_name}"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, **kwargs)
+        super().__init__(msg, logger=logger, level=level)
 
 
 class InvalidJailConfigAddress(InvalidJailConfigValue):
     """Raised when a jail address is invalid."""
 
-    def __init__(self, value: str, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        value: str,
+        property_name: str,
+        jail: typing.Optional[iocage.lib.Jail.JailGenerator]=None,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         reason = f"expected \"<nic>|<address>\" but got \"{value}\""
         super().__init__(
-            reason=reason,
-            **kwargs
+            property_name=property_name,
+            jail=jail,
+            reason=reason
         )
 
 
 class InvalidMacAddress(IocageException, ValueError):
     """Raised when a jail MAC address is invalid."""
 
-    def __init__(self, mac_address: str, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        mac_address: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         reason = f"invalid mac address: \"{mac_address}\""
         IocageException.__init__(
             self,
-            message=reason,
-            **kwargs
+            message=reason
         )
 
 
 class ResourceLimitUnknown(IocageException, KeyError):
     """Raised when a resource limit has is unknown."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The specified resource limit is unknown"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailConfigNotFound(IocageException):
     """Raised when a jail is not configured."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         config_type: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Could not read {config_type} config"
         # This is a silent error internally used
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class DefaultConfigNotFound(IocageException, FileNotFoundError):
     """Raised when no default config was found on the host."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         config_file_path: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Default configuration not found at {config_file_path}"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class UnknownJailConfigProperty(IocageException, KeyError):
     """Raised when a unknown jail config property was used."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         key: str,
         jail: iocage.lib.Jail.JailGenerator,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None,
+        level: str="error"
     ) -> None:
         msg = (
             f"The config property '{key}' "
             f"of jail '{jail.humanreadable_name}' is unknown."
         )
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger, level=level)
 
 
 # Backup
@@ -425,24 +450,23 @@ class UnknownJailConfigProperty(IocageException, KeyError):
 class BackupInProgress(IocageException):
     """Raised when a backup operation is already in progress."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = "A backup operation is already in progress"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class ExportDestinationExists(IocageException):
     """Raised when a backup operation is already in progress."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         destination: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "The backup destination {destination} already exists"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 # ListableResource
@@ -451,13 +475,12 @@ class ExportDestinationExists(IocageException):
 class ListableResourceNamespaceUndefined(IocageException):
     """Raised when a ListableResource was not defined with a namespace."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The ListableResource needs a namespace for this operation"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 # General
@@ -466,56 +489,63 @@ class ListableResourceNamespaceUndefined(IocageException):
 class IocageNotActivated(IocageException):
     """Raised when iocage is not active on any ZFS pool."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = (
             "iocage is not activated yet - "
             "please run `ioc activate <POOL>` first and select a pool"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidLogLevel(IocageException):
     """Raised when the logger was initialized with an invalid log level."""
 
-    def __init__(self, log_level: str, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        log_level: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         available_log_levels = iocage.lib.Logger.Logger.LOG_LEVELS
         available_log_levels_string = ", ".join(available_log_levels[:-1])
         msg = (
             f"Invalid log-level {log_level}. Choose one of "
             f"{available_log_levels_string} or {available_log_levels[-1]}"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class MustBeRoot(IocageException):
     """Raised when iocage is executed without root permission."""
 
-    def __init__(self, msg: str, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
         _msg = (
             f"Must be root to {msg}"
         )
-        super().__init__(_msg, *args, **kwargs)
+        super().__init__(_msg, logger=logger)
 
 
 class CommandFailure(IocageException):
     """Raised when iocage fails to execute a command."""
 
-    def __init__(self, returncode: int, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        returncode: int,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Command exited with {returncode}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class NotAnIocageZFSProperty(IocageException):
     """Raised when iocage attempts to touch a non-iocage ZFS property."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         property_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The ZFS property '{property_name}' is not managed by iocage"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Host, Distribution
@@ -524,38 +554,41 @@ class NotAnIocageZFSProperty(IocageException):
 class DistributionUnknown(IocageException):
     """Raised when the host distribution is unknown or not supported."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         distribution_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Unknown Distribution: {distribution_name}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class HostReleaseUnknown(IocageException):
     """Raised when the host release could not be determined."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"The host release is unknown"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class HostUserlandVersionUnknown(IocageException):
     """Raised when the hosts userland version could not be detected."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = f"Could not determine the hosts userland version"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class DistributionEOLWarningDownloadFailed(IocageException):
     """Raised when downloading EOL warnings failed."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        logger: typing.Optional[Logger]=None,
+        level: str="error"
+    ) -> None:
         msg = f"Failed to download the EOL warnings"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger, level=level)
 
 
 # Storage
@@ -564,113 +597,109 @@ class DistributionEOLWarningDownloadFailed(IocageException):
 class DatasetExists(IocageException):
     """Raised when a dataset already exists."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Dataset already exists: {dataset_name}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class UnmountFailed(IocageException):
     """Raised when an unmount operation fails."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         mountpoint: typing.Any,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Unmount of {mountpoint} failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class MountFailed(IocageException):
     """Raised when a mount operation fails."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         mountpoint: iocage.lib.Types.AbsolutePath,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Failed to mount {mountpoint}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class DatasetNotMounted(IocageException):
     """Raised when a dataset is not mounted but should be."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset: 'libzfs.ZFSDataset',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Dataset '{dataset.name}' is not mounted"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class DatasetNotAvailable(IocageException):
     """Raised when a dataset is not available."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Dataset '{dataset_name}' is not available"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class DatasetNotJailed(IocageException):
     """Raised when a ZFS share was not flagged as such."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset: 'libzfs.ZFSDataset',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         name = dataset.name
         msg = f"Dataset {name} is not jailed."
         warning = f"Run 'zfs set jailed=on {name}' to allow mounting"
-        kwargs["append_warning"] = warning
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(
+            msg,
+            warning=warning,
+            append_warning=True
+        )
 
 
 class ZFSException(IocageException):
     """Raised when a ZFS pool not available."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
-        *args,
-        **kwargs
+        msg: str,
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
-        super().__init__(*args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class ZFSPoolInvalid(IocageException, TypeError):
     """Raised when a ZFS pool is invalid."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         consequence: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "Invalid ZFS pool"
@@ -678,53 +707,50 @@ class ZFSPoolInvalid(IocageException, TypeError):
         if consequence is not None:
             msg += f": {consequence}"
 
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class ZFSPoolUnavailable(IocageException):
     """Raised when a ZFS pool not available."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         pool_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"ZFS pool '{pool_name}' is UNAVAIL"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class ResourceUnmanaged(IocageException):
     """Raised when locating a resources dataset on a root dataset fails."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         dataset_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"The resource dataset {dataset_name} is not managed by iocage"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class ConflictingResourceSelection(IocageException):
     """Raised when a resource was configured with conflicting sources."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         source_a: str,
         source_b: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = (
             "The resource was configured with conflicting root sources: "
             f"{source_a} != {source_b}"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Snapshots
@@ -733,88 +759,83 @@ class ConflictingResourceSelection(IocageException):
 class SnapshotError(IocageException):
     """Raised on snapshot related errors."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        super().__init__(*args, **kwargs)
+    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
+        super().__init__(msg, logger=logger)
 
 
 class SnapshotCreation(SnapshotError):
     """Raised when creating a snapshot failed."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "Snapshot creation failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class SnapshotDeletion(SnapshotError):
     """Raised when deleting a snapshot failed."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "Snapshot deletion failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class SnapshotRollback(SnapshotError):
     """Raised when rolling back a snapshot failed."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "Snapshot rollback failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class SnapshotNotFound(SnapshotError):
     """Raised when a snapshot was not found."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         snapshot_name: str,
         dataset_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Snapshot not found: {dataset_name}@{snapshot_name}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidSnapshotIdentifier(SnapshotError):
     """Raised when a snapshot identifier is invalid."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         identifier: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = (
             f"Invalid snapshot identifier syntax: {identifier}"
             "(should be <jail>@<snapshot>)"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Network
@@ -823,71 +844,68 @@ class InvalidSnapshotIdentifier(SnapshotError):
 class InvalidInterfaceName(IocageException):
     """Raised when a NIC name is invalid."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "Invalid NIC name"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class VnetBridgeMissing(IocageException):
     """Raised when a vnet bridge is missing."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "VNET is enabled and requires setting a bridge"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidNetworkBridge(IocageException, ValueError):
     """Raised when a network bridge is invalid."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = "Invalid network bridge argument"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class FirewallDisabled(IocageException):
     """Raised when the firewall is required but disabled (Secure VNET)."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         hint: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = "IPFW is disabled"
         if hint is not None:
             msg += f": {hint}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class FirewallCommandFailure(IocageException):
     """Raised when a firewall command fails (Secure VNET)."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = "Firewall Command failed. Is IPFW enabled?"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidIPAddress(IocageException):
     """Raised when an invalid IP address was assigned to a network."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: str,
         ipv6: bool,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         ip_version = 4 + 2 * (ipv6 is True)
         msg = f"Invalid IPv{ip_version} address: {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Release
@@ -896,128 +914,124 @@ class InvalidIPAddress(IocageException):
 class ReleaseListUnavailable(IocageException):
     """Raised when the list could not be downloaded from the remote."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = f"The releases list is unavailable"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class ReleaseAssetHashesUnavailable(IocageException):
     """Raised when the list could not be downloaded from the remote."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
 
         msg = f"The releases asset hashes are unavailable"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class UpdateFailure(IocageException):
     """Raised when an update fails."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         name: str,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Release update of '{name}' failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class InvalidReleaseAssetSignature(UpdateFailure):
     """Raised when a release signature is invalid."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         name: str,
         asset_name: str,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Asset {asset_name} has an invalid signature"
         UpdateFailure.__init__(
             self,
             name=name,
-            reason=msg,
-            **kwargs
+            reason=msg
         )
 
 
 class NonReleaseUpdateFetch(UpdateFailure):
     """Raised when attempting to fetch updates for a custom release."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         resource: 'iocage.lib.Resource.ResourceGenerator',
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
 
         msg = f"Updates can only be fetched for releases"
         UpdateFailure.__init__(
             self,
             name=resource.name,
-            reason=msg,
-            **kwargs
+            reason=msg
         )
 
 
 class ReleaseNotFetched(IocageException):
     """Raised when a release was not yet fetched."""
 
-    def __init__(self, name: str, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        name: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Release '{name}' does not exist or is not fetched locally"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class ReleaseUpdateBranchLookup(IocageException):
     """Raised when failing to lookup the remote update branch."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         release_name: str,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Update source of release '{release_name}' not found"
         if reason is not None:
             msg += ": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class UnsupportedRelease(MissingFeature):
     """Raised when interacting with an unsupported release."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         version: float,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         feature_name = f"Support for release version {version}"
         super().__init__(
             feature_name=feature_name,
-            plural=True,
-            **kwargs
+            plural=True
         )
 
 
 class InvalidReleaseName(IocageException):
     """Raised when interacting with an unsupported release."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         name: str,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Invalid release name: {name}"
-        super().__init__(msg, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Prompts
@@ -1026,17 +1040,16 @@ class InvalidReleaseName(IocageException):
 class DefaultReleaseNotFound(IocageException):
     """Raised when the default (host) release does not match a remote."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         host_release_name: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = (
             f"Release '{host_release_name}' not found: "
             "Could not determine a default source"
         )
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # DevfsRules
@@ -1045,56 +1058,50 @@ class DefaultReleaseNotFound(IocageException):
 class DevfsRuleException(IocageException):
     """Raised on errors in devfs rules."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        super().__init__(*args, **kwargs)
+    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
+        super().__init__(msg, logger=logger)
 
 
 class InvalidDevfsRulesSyntax(DevfsRuleException):
     """Raised when a devfs rule has invalid syntax."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         devfs_rules_file: str,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Invalid devfs rules in {devfs_rules_file}"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class DuplicateDevfsRuleset(DevfsRuleException):
     """Raised when a duplicate devfs rule was found."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         devfs_rules_file: str,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = "Cannot add duplicate ruleset"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 class MissingDevfsRulesetName(DevfsRuleException):
     """Raised when a duplicate devfs rule was found."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         devfs_rules_file: str,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = "The devfs ruleset is missing a name"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 # Logger
 
@@ -1102,23 +1109,22 @@ class MissingDevfsRulesetName(DevfsRuleException):
 class LogException(IocageException):
     """Raised when logging fails."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        super().__init__(*args, **kwargs)
+    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
+        super().__init__(msg, logger=logger)
 
 
 class CannotRedrawLine(LogException):
     """Raised when manipulating previous log entries fails."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         reason: typing.Optional[str]=None,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
         msg = "Logger can't redraw line"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(msg, *args, **kwargs)
+        super().__init__(msg, logger=logger)
 
 
 # Events
@@ -1127,15 +1133,13 @@ class CannotRedrawLine(LogException):
 class EventAlreadyFinished(IocageException):
     """Raised when a event is touched that was already finished."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
         event: 'iocage.lib.events.IocageEvent',
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = "This {event.type} event is already finished"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 # Jail Filter
@@ -1144,19 +1148,19 @@ class EventAlreadyFinished(IocageException):
 class JailFilterException(IocageException):
     """Raised when a jail filter is invalid."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
-        IocageException.__init__(self, *args, **kwargs)
+    def __init__(self, msg: str, logger: typing.Optional[Logger]=None) -> None:
+        IocageException.__init__(self, msg, logger=logger)
 
 
 class JailFilterInvalidName(JailFilterException):
     """Raised when the name of a jail filter is invalid."""
 
-    def __init__(self, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(self, logger: typing.Optional[Logger]=None) -> None:
         msg = (
             "Invalid jail selector: "
             "Cannot select jail with illegal name"
         )
-        JailFilterException.__init__(self, msg, *args, **kwargs)
+        JailFilterException.__init__(self, msg, logger=logger)
 
 
 # pkg
@@ -1165,14 +1169,12 @@ class JailFilterInvalidName(JailFilterException):
 class PkgNotFound(IocageException):
     """Raised when the pkg package was not found in the local mirror."""
 
-    def __init__(  # noqa: T484
+    def __init__(
         self,
-        *args,
-        **kwargs
+        logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = "The pkg package was not found in the local mirror."
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)
 
 
 # Provisioning
@@ -1181,6 +1183,10 @@ class PkgNotFound(IocageException):
 class UnknownProvisioner(IocageException):
     """Raised when an unsupported provisioner method is used."""
 
-    def __init__(self, name: str, *args, **kwargs) -> None:  # noqa: T484
+    def __init__(
+        self,
+        name: str,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
         msg = f"Unknown provisioner: {name}"
-        IocageException.__init__(self, msg, *args, **kwargs)
+        IocageException.__init__(self, msg, logger=logger)

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -75,7 +75,21 @@ class MissingFeature(IocageException, NotImplementedError):
 # Jails
 
 
-class JailDoesNotExist(IocageException):
+class JailException(IocageException):
+    """Raised when an exception related to a jail occurs."""
+
+    jail: 'iocage.lib.Jail.JailGenerator'
+
+    def __init__(
+        self,
+        jail: 'iocage.lib.Jail.JailGenerator',
+        message: typing.Optional[str]=None,
+        logger: typing.Optional[Logger]=None
+    ) -> None:
+        self.jail = jail
+        IocageException.__init__(self, message=message, logger=logger)
+
+class JailDoesNotExist(JailException):
     """Raised when the jail does not exist."""
 
     def __init__(
@@ -84,7 +98,7 @@ class JailDoesNotExist(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Jail '{jail.humanreadable_name}' does not exist"
-        IocageException.__init__(self, msg, logger=logger)
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
 class JailAlreadyExists(IocageException):
@@ -107,7 +121,6 @@ class JailNotRunning(IocageException):
         jail: 'iocage.lib.Jail.JailGenerator',
         logger: typing.Optional[Logger]=None
     ) -> None:
-
         msg = f"Jail '{jail.humanreadable_name}' is not running"
         IocageException.__init__(self, msg, logger=logger)
 
@@ -162,8 +175,10 @@ class JailBackendMissing(IocageException):
         IocageException.__init__(self, msg, logger=logger)
 
 
-class JailIsTemplate(IocageException):
+class JailIsTemplate(JailException):
     """Raised when the jail is a template but should not be."""
+
+    jail: 'iocage.lib.Jail.JailGenerator'
 
     def __init__(
         self,
@@ -171,11 +186,13 @@ class JailIsTemplate(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The jail '{jail.name}' is a template"
-        IocageException.__init__(self, msg, logger=logger)
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
-class JailNotTemplate(IocageException):
+class JailNotTemplate(JailException):
     """Raised when the jail is no template but should be one."""
+
+    jail: 'iocage.lib.Jail.JailGenerator'
 
     def __init__(
         self,
@@ -183,10 +200,10 @@ class JailNotTemplate(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"The jail '{jail.full_name}' is not a template"
-        IocageException.__init__(self, msg, logger=logger)
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
-class JailLaunchFailed(IocageException):
+class JailLaunchFailed(JailException):
     """Raised when the jail could not be launched."""
 
     def __init__(
@@ -195,11 +212,13 @@ class JailLaunchFailed(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Launching jail {jail.full_name} failed"
-        IocageException.__init__(self, msg, logger=logger)
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
-class JailDestructionFailed(IocageException):
+class JailDestructionFailed(JailException):
     """Raised when the jail could not be destroyed."""
+
+    jail: 'iocage.lib.Jail.JailGenerator'
 
     def __init__(
         self,
@@ -207,22 +226,25 @@ class JailDestructionFailed(IocageException):
         logger: typing.Optional[Logger]=None
     ) -> None:
         msg = f"Destroying jail {jail.full_name} failed"
-        IocageException.__init__(self, msg, logger=logger)
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
 class JailCommandFailed(IocageException):
     """Raised when a jail command fails with an exit code > 0."""
+
+    returncode: int
 
     def __init__(
         self,
         returncode: int,
         logger: typing.Optional[Logger]=None
     ) -> None:
+        self.returncode = returncode
         msg = f"Jail command exited with {returncode}"
         IocageException.__init__(self, msg, logger=logger)
 
 
-class JailExecutionAborted(IocageException):
+class JailExecutionAborted(JailException):
     """Raised when a jail command fails with an exit code > 0."""
 
     def __init__(
@@ -230,9 +252,8 @@ class JailExecutionAborted(IocageException):
         jail: 'iocage.lib.Jail.JailGenerator',
         logger: typing.Optional[Logger]=None
     ) -> None:
-        self.jail = jail
-        message = f"Jail execution of {jail.humanreadable_name} aborted."
-        IocageException.__init__(self, message=message, logger=logger)
+        msg = f"Jail execution of {jail.humanreadable_name} aborted."
+        JailException.__init__(self, msg, jail=jail, logger=logger)
 
 
 # Jail Fstab

--- a/iocage/lib/events.py
+++ b/iocage/lib/events.py
@@ -39,8 +39,6 @@ EVENT_STATUS = (
     "failed"
 )
 
-EventUpdateData = typing.Dict[str, typing.Any]
-
 
 class Scope(list):
     """An independent event history scope."""


### PR DESCRIPTION
closes #282

In more occasions than required libiocage uses *args and **kwargs arguments. Disabling flake8 complaints by setting `# noqa: T484` led to ignorance of other typing issues.

This chore removes `*args` and `**kwargs` from various places.