### PR TITLE
prevent rc script from being used incorrectly

### DIFF
--- a/rc.d/ioc
+++ b/rc.d/ioc
@@ -30,6 +30,8 @@ status_cmd="ioc_status"
 extra_commands="status"
 export LANG=$ioc_lang
 
+[ $# -ne 1 ] && rc_usage $_keywords
+
 ioc_start()
 {
     if checkyesno ${rcvar}; then


### PR DESCRIPTION
our rc script only uses one parameter. We should ensure it only ever
receives one. c.f.: https://github.com/iocage/iocage/issues/593