### PR TITLE
forward log level in InvalidJailConfigAddress error

### DIFF
--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -399,7 +399,8 @@ class InvalidJailConfigAddress(InvalidJailConfigValue):
             property_name=property_name,
             jail=jail,
             reason=reason,
-            level=level
+            level=level,
+            logger=logger
         )
 
 

--- a/iocage/lib/errors.py
+++ b/iocage/lib/errors.py
@@ -391,13 +391,15 @@ class InvalidJailConfigAddress(InvalidJailConfigValue):
         value: str,
         property_name: str,
         jail: typing.Optional[iocage.lib.Jail.JailGenerator]=None,
-        logger: typing.Optional[Logger]=None
+        logger: typing.Optional[Logger]=None,
+        level: str="error"
     ) -> None:
         reason = f"expected \"<nic>|<address>\" but got \"{value}\""
         super().__init__(
             property_name=property_name,
             jail=jail,
-            reason=reason
+            reason=reason,
+            level=level
         )
 
 


### PR DESCRIPTION
Fixes an issue raising an IocageException when attempting to set invalid IP address.