### PR TITLE
Fix migrate CLI command after refactoring IocageEvents

### DIFF
--- a/iocage/cli/migrate.py
+++ b/iocage/cli/migrate.py
@@ -44,7 +44,7 @@ class JailMigrationEvent(iocage.lib.events.IocageEvent):
         jail: 'iocage.lib.Jail.JailGenerator'
     ) -> None:
         self.identifier = jail.full_name
-        iocage.lib.events.IocageEvent.__init__(self, jail=jail)
+        iocage.lib.events.IocageEvent.__init__(self)
 
 
 @click.command(name="migrate", help="Migrate jails to the latest format.")


### PR DESCRIPTION
fixes #477 

- the JailMigrationEvent must not forward its jail parameter