### PR TITLE
Enhance migration command robustness

### DIFF
--- a/iocage/cli/migrate.py
+++ b/iocage/cli/migrate.py
@@ -97,7 +97,10 @@ def _migrate_jails(
             continue
 
         if jail.running is True:
-            yield event.fail(iocage.lib.errors.JailAlreadyRunning(jail=jail))
+            yield event.fail(iocage.lib.errors.JailAlreadyRunning(
+                jail=jail,
+                logger=logger
+            ))
             continue
 
         if iocage.lib.helpers.validate_name(jail.config["tag"]):

--- a/iocage/cli/migrate.py
+++ b/iocage/cli/migrate.py
@@ -144,7 +144,7 @@ def _migrate_jails(
 
         except iocage.lib.errors.IocageException as e:
             yield event.fail(e)
-            print(e)
+            continue
 
         if name != temporary_name:
             # the jail takes the old jails name

--- a/iocage/cli/migrate.py
+++ b/iocage/cli/migrate.py
@@ -140,7 +140,11 @@ def _migrate_jails(
             yield from new_jail.clone_from_jail(jail, event_scope=event.scope)
             new_jail.save()
             new_jail.promote()
-            yield from jail.destroy(force=True, event_scope=event.scope)
+            yield from jail.destroy(
+                force=True,
+                force_stop=True,
+                event_scope=event.scope
+            )
 
         except iocage.lib.errors.IocageException as e:
             yield event.fail(e)

--- a/iocage/cli/migrate.py
+++ b/iocage/cli/migrate.py
@@ -140,7 +140,7 @@ def _migrate_jails(
             yield from new_jail.clone_from_jail(jail, event_scope=event.scope)
             new_jail.save()
             new_jail.promote()
-            yield from jail.destroy(event_scope=event.scope)
+            yield from jail.destroy(force=True, event_scope=event.scope)
 
         except iocage.lib.errors.IocageException as e:
             yield event.fail(e)

--- a/iocage/lib/Config/Jail/JailConfig.py
+++ b/iocage/lib/Config/Jail/JailConfig.py
@@ -71,6 +71,9 @@ class JailConfig(iocage.lib.Config.Jail.BaseConfig.BaseConfig):
                 return str(jail.humanreadable_name)
             raise e
 
+    def _get_legacy(self) -> bool:
+        return self.legacy
+
     def _is_known_property(self, key: str) -> bool:
         key_is_default = key in self.host.defaults.config.keys()
         key_is_setter = f"_set_{key}" in dict.__dir__(self)

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -966,13 +966,17 @@ class JailGenerator(JailResource):
         if force is False:
             self.require_jail_stopped()
 
-        stop_events = JailGenerator.stop(
-            self,
-            force=True,
-            event_scope=event_scope
-        )
-        for event in stop_events:
-            yield event
+        try:
+            stop_events = JailGenerator.stop(
+                self,
+                force=True,
+                event_scope=event_scope,
+                log_errors=False
+            )
+            for event in stop_events:
+                yield event
+        except iocage.lib.errors.JailDestructionFailed:
+            pass
 
         zfsDatasetDestroyEvent = iocage.lib.events.ZFSDatasetDestroy(
             dataset=self.dataset,

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -708,6 +708,8 @@ class JailGenerator(JailResource):
             os.makedirs(realpath, 0o755)
 
     def _prepare_stop(self) -> None:
+        self._ensure_script_dir()
+
         exec_prestop = []
         exec_stop = []
         exec_poststop = self._teardown_mounts() + self._clear_resource_limits()

--- a/iocage/lib/Jail.py
+++ b/iocage/lib/Jail.py
@@ -951,16 +951,16 @@ class JailGenerator(JailResource):
         if event_scope is None:
             event_scope = iocage.lib.events.Scope()
 
-        if self.running is True and force is True:
-            stop_events = JailGenerator.stop(
-                self,
-                force=True,
-                event_scope=event_scope
-            )
-            for event in stop_events:
-                yield event
-        else:
+        if force is False:
             self.require_jail_stopped()
+
+        stop_events = JailGenerator.stop(
+            self,
+            force=True,
+            event_scope=event_scope
+        )
+        for event in stop_events:
+            yield event
 
         zfsDatasetDestroyEvent = iocage.lib.events.ZFSDatasetDestroy(
             dataset=self.dataset,

--- a/iocage/lib/ZFS.py
+++ b/iocage/lib/ZFS.py
@@ -119,7 +119,7 @@ class ZFS(libzfs.ZFS):
             self.logger.verbose(f"Deleting dataset {dataset.name}")
         try:
             dataset.umount()
-            self.logger.spam("Dataset unmounted")
+            self.logger.spam(f"Dataset {dataset.name} unmounted")
         except libzfs.ZFSException:
             pass
         dataset.delete()


### PR DESCRIPTION
closes #477

- Force a full stop when destroying jails during migration to address an issue with remaining mounts from iocage_legacy when using custom fstab entries
- Errors while attempting an already stopped jail do not result in error log messages. The forced stop will sequentially teardown all the jails assets, so that we may ignore the outcome.
- For performance reasons the forced stop is not the default on Jail.destroy