### PR TITLE
Human readable object representation of jail config and state

### DIFF
--- a/iocage/Config/Jail/BaseConfig.py
+++ b/iocage/Config/Jail/BaseConfig.py
@@ -694,6 +694,10 @@ class BaseConfig(dict):
         """Return the JSON object with all user configured settings."""
         return str(iocage.helpers.to_json(self.data))
 
+    def __repr__(self) -> str:
+        """Return the confgured settings in human and robot friendly format."""
+        return self.__str__()
+
     def __dir__(self) -> typing.List[str]:
         """Return a list of config object attributes."""
         properties = set()

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -165,6 +165,13 @@ class JailState(dict):
         """Iterate over the jail state entries."""
         return self.data.__iter__()
 
+    def __repr__(self) -> str:
+        """Return the state in humand and robot friendly format."""
+        if self._data is None:
+            return "None"
+        else:
+            return str(iocage.helpers.to_json(self._data))
+
     def keys(self) -> typing.List[str]:  # noqa: T484
         """Return all available jail state keys."""
         return list(self.data.keys())


### PR DESCRIPTION
Enhances the developer experience by providing human readable output for the `jail.state` and `jail.config` objects.

```python3
>>> import iocage
>>> j = iocage.Jail("test4")
>>> j.config
{
    "basejail": "yes",
    "basejail_type": "nullfs",
    "id": "test4",
    "ip4_addr": "vnet0|dhcp",
    "release": "11.1-RELEASE"
}
>>> j.state
{}
>>> j.start()
[<iocage.events.JailResolverConfig object at 0x808310860>, <iocage.events.JailResolverConfig object at 0x808310860>, <iocage.events.JailLaunch object at 0x8083108d0>, <iocage.events.JailLaunch object at 0x8083108d0>]
>>> j.state.query()
{
    "cpusetid": "3",
    "hostname": "test4",
    "jid": "3",
    "name": "ioc-test4",
    "path": "/zroot/iocage/jails/test4/root",
    "state": "ACTIVE"
}
>>> j.state
{}
```