### PR TITLE
simplify jail exec interfaces

### DIFF
--- a/iocage/Config/Jail/BaseConfig.py
+++ b/iocage/Config/Jail/BaseConfig.py
@@ -128,7 +128,8 @@ class BaseConfig(dict):
             key, value = items.pop()
 
             if type(value) == dict:
-                items += [(f"{key}.{k}", v) for k, v in value.items()]
+                _subitems = value.items()  # noqa: T484
+                items += [(f"{key}.{k}", v) for k, v in _subitems]
                 continue
 
             if (key in ["id", "name", "uuid"]) and (current_id is not None):

--- a/iocage/Config/Jail/BaseConfig.py
+++ b/iocage/Config/Jail/BaseConfig.py
@@ -90,7 +90,13 @@ class BaseConfig(dict):
 
     def clone(
         self,
-        data: typing.Dict[str, typing.Any],
+        data: typing.Dict[str, typing.Union[
+            iocage.Config.Jail.Properties.Property,
+            str,
+            int,
+            bool,
+            typing.Dict[str, typing.Union[str, int, bool]]
+        ]],
         skip_on_error: bool=False
     ) -> None:
         """

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -1320,6 +1320,11 @@ class JailGenerator(JailResource):
         env (dict):
             The dictionary may contain env variables that will be forwarded to
             the executed jail command.
+
+        passthru (bool): (default=False)
+            When enabled the commands stdout and stderr are directory forwarded
+            to the attached terminal. The results will not be included in the
+            CommandOutput, so that (None, None, <returncode>) is returned.
         """
         command = ["/usr/sbin/jexec", str(self.jid)] + command
 

--- a/iocage/helpers.py
+++ b/iocage/helpers.py
@@ -483,7 +483,7 @@ def exec_passthru(
     command: typing.List[str],
     logger: typing.Optional['iocage.Logger.Logger']=None,
     **subprocess_args: typing.Any
-) -> None:
+) -> CommandOutput:
     """Execute a command in an interactive shell."""
     child = subprocess.Popen(  # nosec: B603
         command,
@@ -494,6 +494,7 @@ def exec_passthru(
         **subprocess_args
     )
     child.wait()
+    return None, None, child.returncode
 
 
 # ToDo: replace with (u)mount library


### PR DESCRIPTION
fixes #488

- The return type of iocage.helpers.exec_passthru was None, not iocage.helpers.CommandOutput
- Removed **kwargs that before could be passed to jail command execution. This is no longer required because either exec_generator or exec_passthru handle the necessary options
- Jail config properties are provided as environment variables