### PR TITLE
Use dedicated pkg.conf for package installation

### DIFF
--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -291,6 +291,7 @@ class JailGenerator(JailResource):
         logger: typing.Optional['iocage.Logger.Logger']=None,
         zfs: typing.Optional['iocage.ZFS.ZFS']=None,
         host: typing.Optional['iocage.Host.Host']=None,
+        fstab: typing.Optional['iocage.Config.Jail.File.Fstab.Fstab']=None,
         root_datasets_name: typing.Optional[str]=None,
         new: bool=False
     ) -> None:
@@ -334,6 +335,7 @@ class JailGenerator(JailResource):
             logger=self.logger,
             zfs=self.zfs,
             host=self.host,
+            fstab=fstab,
             root_datasets_name=root_datasets_name
         )
 

--- a/iocage/Pkg.py
+++ b/iocage/Pkg.py
@@ -67,7 +67,6 @@ class Pkg:
 
         packageFetchEvent = iocage.events.PackageFetch(
             packages=_packages,
-            logger=self.logger,
             scope=event_scope
         )
 
@@ -163,13 +162,11 @@ class Pkg:
         packageInstallEvent = iocage.events.PackageInstall(
             packages=_packages,
             jail=jail,
-            logger=self.logger,
             scope=event_scope
         )
 
         packageConfigurationEvent = iocage.events.PackageConfiguration(
             jail=jail,
-            logger=self.logger,
             scope=event_scope
         )
 


### PR DESCRIPTION
The package repo for the iocage release package mirroring is no longer propagated globally. Instead pkg is prefixed to use alternate directories.

```sh
pkg --config /iocage/pkg/11/pkg.conf -- repo-conf-dir /iocage/pkg/11/repos ...
```

### Summary
- Removed invalid logger argument from Pkg events
- Fix failing repo initialization
- Uses a dedicated `pkg.conf` independent from the host configuration