### PR TITLE
Fix config override when creating jails from a template

### DIFF
--- a/ioc/create.py
+++ b/ioc/create.py
@@ -133,7 +133,14 @@ def cli(
         )
         release = host.release_version
 
-    resource_selector = iocage.ResourceSelector.ResourceSelector(name)
+    try:
+        resource_selector = iocage.ResourceSelector.ResourceSelector(
+            name,
+            logger=logger
+        )
+    except iocage.errors.IocageException:
+        exit(1)
+
     jail_data["name"] = resource_selector.name
     root_datasets_name = resource_selector.source_name
 
@@ -167,13 +174,16 @@ def cli(
                 logger.log(f"Automatically fetching release '{resource.name}'")
                 resource.fetch()
     elif template is not None:
-        resource = iocage.Jail.JailGenerator(
-            template,
-            root_datasets_name=root_datasets_name,
-            logger=logger,
-            host=host,
-            zfs=zfs
-        )
+        try:
+            resource = iocage.Jail.JailGenerator(
+                template,
+                root_datasets_name=root_datasets_name,
+                logger=logger,
+                host=host,
+                zfs=zfs
+            )
+        except iocage.errors.IocageException:
+            exit(1)
     else:
         logger.error("No release or jail selected")
         exit(1)

--- a/iocage/Config/Jail/BaseConfig.py
+++ b/iocage/Config/Jail/BaseConfig.py
@@ -185,8 +185,8 @@ class BaseConfig(dict):
             self.data["id"] = None
             return
 
-        allowed_characters_pattern = "([^A-z0-9\\._\\-]|\\^)"
-        invalid_characters = re.findall(allowed_characters_pattern, name)
+        disallowed_characters_pattern = "([^A-Za-z0-9\\._\\-]|\\^)"
+        invalid_characters = re.findall(disallowed_characters_pattern, name)
         if len(invalid_characters) > 0:
             msg = (
                 f"Invalid character in name: "

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -200,11 +200,14 @@ class Terms(list):
     """
 
     def __init__(
-            self,
-            terms: typing.Optional[
-                typing.Iterable[typing.Union[Term, str]]
-            ]=None) -> None:
+        self,
+        terms: typing.Optional[
+            typing.Iterable[typing.Union[Term, str]]
+        ]=None,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
 
+        self.logger = logger
         data: typing.List[typing.Union[Term, str]] = []
 
         if terms is not None:
@@ -273,7 +276,10 @@ class Terms(list):
             value = user_input
 
         if prop == "name":
-            value = iocage.ResourceSelector.ResourceSelector(value)
+            value = iocage.ResourceSelector.ResourceSelector(
+                value,
+                logger=self.logger
+            )
 
         terms.append(Term(prop, value))
 

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -204,9 +204,12 @@ class JailResource(
         if self.root_datasets_name is None:
             base_name = self.host.datasets.main.jails.name
         else:
-            base_name = self.host.datasets.__getitem__(
-                self.root_datasets_name
-            ).jails.name
+            try:
+                base_name = self.host.datasets.__getitem__(
+                    self.root_datasets_name
+                ).jails.name
+            except KeyError:
+                raise iocage.errors.SourceNotFound(logger=self.logger)
         return f"{base_name}/{jail_id}"
 
     @property

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -1163,8 +1163,9 @@ class JailGenerator(JailResource):
     ) -> None:
         """Create a Jail from a template Jail."""
         template.require_jail_is_template()
+        existing_config_keys = list(self.config.keys())
         for key in template.config.keys():
-            if key in ["id", "name", "template"]:
+            if key in (["id", "name", "template"] + existing_config_keys):
                 continue
             self.config[key] = template.config[key]
         self.config['release'] = template.config['release']

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -1921,7 +1921,8 @@ class JailGenerator(JailResource):
             raise iocage.errors.JailNotSupplied(logger=self.logger)
 
         resource_selector = iocage.ResourceSelector.ResourceSelector(
-            name=text
+            name=text,
+            logger=self.logger
         )
 
         root_datasets = resource_selector.filter_datasets(self.host.datasets)

--- a/iocage/ListableResource.py
+++ b/iocage/ListableResource.py
@@ -71,7 +71,7 @@ class ListableResource(list):
         if isinstance(value, iocage.Filter.Terms):
             self._filters = value
         else:
-            self._filters = iocage.Filter.Terms(value)
+            self._filters = iocage.Filter.Terms(value, logger=self.logger)
 
     def destroy(self, force: bool=False) -> None:
         """Listable resources by itself cannot be destroyed."""

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -185,7 +185,10 @@ class ReleaseResource(iocage.LaunchableResource.LaunchableResource):
         if self.root_datasets_name is None:
             return self.host.datasets.main
         else:
-            return self.host.datasets.__getitem__(self.root_datasets_name)
+            try:
+                return self.host.datasets.__getitem__(self.root_datasets_name)
+            except KeyError:
+                raise iocage.errors.SourceNotFound(logger=self.logger)
 
     @property
     def source(self) -> str:

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -249,7 +249,10 @@ class ReleaseGenerator(ReleaseResource):
         self.zfs = iocage.helpers_object.init_zfs(self, zfs)
         self.host = iocage.helpers_object.init_host(self, host)
 
-        resource_selector = iocage.ResourceSelector.ResourceSelector(name)
+        resource_selector = iocage.ResourceSelector.ResourceSelector(
+            name,
+            logger=self.logger
+        )
         if resource_selector.source_name is not None:
             is_different = resource_selector.source_name != root_datasets_name
             if (root_datasets_name is not None) and (is_different is True):

--- a/iocage/Resource.py
+++ b/iocage/Resource.py
@@ -219,10 +219,12 @@ class Resource(metaclass=abc.ABCMeta):
         try:
             return self._dataset
         except AttributeError:
-            name = self.dataset_name
-            dataset: libzfs.ZFSDataset = self.zfs.get_dataset(name)
-            self._dataset = dataset
-            return dataset
+            pass
+
+        name = self.dataset_name
+        dataset: libzfs.ZFSDataset = self.zfs.get_dataset(name)
+        self._dataset = dataset
+        return dataset
 
     @dataset.setter
     def dataset(self, value: libzfs.ZFSDataset) -> None:

--- a/iocage/ResourceSelector.py
+++ b/iocage/ResourceSelector.py
@@ -63,7 +63,9 @@ class ResourceSelector:
             _name = value
             _source_name = None
 
-        if iocage.helpers.validate_name(_name) is False:
+        _name_without_globs = _name.replace("*", "").replace("+", "")
+        has_valid_name = iocage.helpers.validate_name(_name_without_globs)
+        if (_name not in ["*", "+"]) and (has_valid_name is False):
             raise iocage.errors.InvalidJailName(logger=self.logger)
 
         self.source_name = _source_name

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -1306,7 +1306,7 @@ class UnknownProvisioner(IocageException):
 # Sources
 
 
-class InvalidSourceName(JailConfigError):
+class InvalidSourceName(IocageException):
     """Raised when a source name is invalid."""
 
     def __init__(
@@ -1317,4 +1317,15 @@ class InvalidSourceName(JailConfigError):
             "Invalid source name: "
             "A source name may contain letters A-z, dash and lowdash"
         )
+        super().__init__(message=msg, logger=logger)
+
+
+class SourceNotFound(IocageException):
+    """Raised when a source was not found."""
+
+    def __init__(
+        self,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        msg = f"Jail source not found"
         super().__init__(message=msg, logger=logger)

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -1301,3 +1301,20 @@ class UnknownProvisioner(IocageException):
     ) -> None:
         msg = f"Unknown provisioner: {name}"
         IocageException.__init__(self, message=msg, logger=logger)
+
+
+# Sources
+
+
+class InvalidSourceName(JailConfigError):
+    """Raised when a source name is invalid."""
+
+    def __init__(
+        self,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        msg = (
+            "Invalid source name: "
+            "A source name may contain letters A-z, dash and lowdash"
+        )
+        super().__init__(message=msg, logger=logger)


### PR DESCRIPTION
- Prefers jail config properties over the template config (fixes #494)
- Jail config properties can be set when creating from a template
- Enhances name validation
  - source dataset name (fixes #495)
  - fix name parsing issue that does not filter backslash or backtick 

---

The parsing issue is quite interesting. The python regex pattern `[A-z]` not only patches characters from the english alphabet in uppercase and lowercase, but also characters like `[`, `\`, `]`, `^`, `_` or backtick. This change cause the PR to raise the security flag.