### PR TITLE
an `exec` command *cannot* be quoted with ""

### DIFF
--- a/ioc/exec.py
+++ b/ioc/exec.py
@@ -68,8 +68,6 @@ def cli(
     can be marked with a double-dash or the full command can be quoted:
 
         ioc exec myjail -- ps -aux
-
-        ioc exec myjail "ps -aux"
     """
     logger = ctx.parent.logger
 


### PR DESCRIPTION
if we pass "ps -aux" to exec, it will literally try to execute the
binary "ps -aux"