### PR TITLE
Enhance activation and root dataset creation

### DIFF
--- a/ioc/__init__.py
+++ b/ioc/__init__.py
@@ -34,7 +34,11 @@ import click
 
 from iocage.Logger import Logger
 from iocage.events import IocageEvent
-from iocage.errors import InvalidLogLevel, IocageNotActivated
+from iocage.errors import (
+    InvalidLogLevel,
+    IocageNotActivated,
+    ZFSSourceMountpoint
+)
 from iocage.ZFS import get_zfs
 from iocage.Datasets import Datasets
 from iocage.Host import HostGenerator
@@ -213,6 +217,6 @@ def cli(ctx, log_level: str, source: set) -> None:
             logger=ctx.logger,
             zfs=ctx.zfs
         )
-    except IocageNotActivated:
+    except (IocageNotActivated, ZFSSourceMountpoint):
         exit(1)
 

--- a/ioc/activate.py
+++ b/ioc/activate.py
@@ -61,7 +61,10 @@ def cli(ctx, zpool, mountpoint):
             zfs=zfs,
             logger=logger
         )
-        datasets.activate(mountpoint=mountpoint)
+        datasets.activate_pool(
+            pool=iocage_pool,
+            mountpoint=mountpoint
+        )
         logger.log(f"ZFS pool '{zpool}' activated")
     except iocage.errors.IocageException:
         exit(1)

--- a/ioc/activate.py
+++ b/ioc/activate.py
@@ -61,7 +61,6 @@ def cli(ctx, zpool, mountpoint):
             zfs=zfs,
             logger=logger
         )
-        datasets.attach_source("iocage", f"{iocage_pool.name}/iocage")
         datasets.activate(mountpoint=mountpoint)
         logger.log(f"ZFS pool '{zpool}' activated")
     except iocage.errors.IocageException:

--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -342,6 +342,7 @@ class Datasets(dict):
             self._set_pool_activation(other_pool, False)
 
         self._set_pool_activation(pool, True)
+        self.attach_source("iocage", f"{pool.name}/iocage")
 
         if self.main.root.mountpoint != mountpoint:
             zfs_property = libzfs.ZFSUserProperty(mountpoint)

--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -310,14 +310,25 @@ class Datasets(dict):
         self,
         pool: typing.Optional[libzfs.ZFSPool]=None
     ) -> bool:
-        """Return True if the pool is activated for iocage."""
-        if isinstance(pool, libzfs.ZFSPool):
-            _pool = pool
-        else:
-            _pool = self.main.root.pool
+        """
+        Return True if the pool is activated for iocage.
 
+        Args:
+
+            pool (libzfs.ZFSPool): (optional)
+
+                The specified pool is checked for being activated for iocage.
+                When the pool is unset, the main pool is tested against.
+
+        """
+        if isinstance(pool, libzfs.ZFSPool):
+            return self._is_pool_active(pool)
+        else:
+            return self._is_pool_active(self.main.root.pool)
+
+    def _is_pool_active(self, pool: libzfs.ZFSPool) -> bool:
         return iocage.helpers.parse_user_input(self._get_pool_property(
-            _pool,
+            pool,
             self.ZFS_POOL_ACTIVE_PROPERTY
         )) is True
 

--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -299,7 +299,28 @@ class Datasets(dict):
         pool: libzfs.ZFSPool,
         mountpoint: typing.Optional[iocage.Types.AbsolutePath]=None
     ) -> None:
-        """Activate the given pool and set its mountpoint."""
+        """
+        Activate the given pool and set its mountpoint.
+
+        Pool activation follows the traditional way of setting a ZFS property
+        on the pool that other iocage variants will detect.
+
+        The mechanism cannot be combined with iocage datasets defined in
+        /etc/rc.conf, so that using the Multi-Pool feature is not possible.
+        When attemptig to activate a pool on a system with such configuration
+        an ActivationFailed error is raised.
+
+        Args:
+
+            pool (libzfs.ZFSPool):
+
+                Target of the iocage activation on which an iocage dataset
+                is created on the top level (e.g. zfs create <pool>/iocage)
+
+            mountpoint (iocage.Types.AbsolutePath): (optional)
+
+                The desired mountpoint for the iocage dataset.
+        """
         if self._rc_conf_enabled is True:
             raise iocage.errors.ActivationFailed(
                 "iocage ZFS source datasets are managed in /etc/rc.conf",

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -584,8 +584,8 @@ class ZFSSourceMountpoint(IocageException):
         logger: typing.Optional['iocage.Logger.Logger']=None
     ) -> None:
         msg = (
-            f"The mountpoint of the iocage ZFS source dataset '{dataset_name}'"
-            " is not set and could not be determined automatically"
+            f"Mountpoint of iocage ZFS source dataset '{dataset_name}'"
+            " is unset and cannot be determined automatically"
         )
         super().__init__(message=msg, logger=logger)
 

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -561,6 +561,20 @@ class IocageNotActivated(IocageException):
         super().__init__(message=msg, logger=logger)
 
 
+class ActivationFailed(IocageException):
+    """Raised when ZFS pool activation failed."""
+
+    def __init__(
+        self,
+        reason: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        msg = "iocage ZFS pool activation failed"
+        if reason is not None:
+            msg += f": {reason}"
+        super().__init__(message=msg, logger=logger)
+
+
 class ZFSSourceCreation(IocageException):
     """Raised when iocage could not determine its mountpoint on creation."""
 

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -575,17 +575,18 @@ class ActivationFailed(IocageException):
         super().__init__(message=msg, logger=logger)
 
 
-class ZFSSourceCreation(IocageException):
-    """Raised when iocage could not determine its mountpoint on creation."""
+class ZFSSourceMountpoint(IocageException):
+    """Raised when iocage could not determine its mountpoint."""
 
     def __init__(
         self,
-        reason: typing.Optional[str]=None,
+        dataset_name: str,
         logger: typing.Optional['iocage.Logger.Logger']=None
     ) -> None:
-        msg = "iocage ZFS source could not be created"
-        if reason is not None:
-            msg += f": {reason}"
+        msg = (
+            f"The mountpoint of the iocage ZFS source dataset '{dataset_name}'"
+            " is not set and could not be determined automatically"
+        )
         super().__init__(message=msg, logger=logger)
 
 

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -561,6 +561,20 @@ class IocageNotActivated(IocageException):
         super().__init__(message=msg, logger=logger)
 
 
+class ZFSSourceCreation(IocageException):
+    """Raised when iocage could not determine its mountpoint on creation."""
+
+    def __init__(
+        self,
+        reason: typing.Optional[str]=None,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        msg = "iocage ZFS source could not be created"
+        if reason is not None:
+            msg += f": {reason}"
+        super().__init__(message=msg, logger=logger)
+
+
 class InvalidLogLevel(IocageException):
     """Raised when the logger was initialized with an invalid log level."""
 


### PR DESCRIPTION
- Claim `/iocage` for newly created iocage root datasets when the directory does not exist yet
- Raise an exception when no mountpoint was set on an existing root dataset
- Raise when the selected root dataset is not existing and its mountpoint cannot be automatically determined. (The ZFS pool has no mountpoint and `/iocage` is already existing)
- Never change the mountpoint of existing root datasets
- Refuse to activate a ZFS pool using the traditional methods (ZFS property on the pool dataset) when active pools are already managed from `/etc/rc.conf`
- Improve docstrings of Datasets.activate_pool()