### PR TITLE
Mention the Handbook in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ iocage is a jail/container manager fusioning some of the best features and techn
 
 This library provides programmatic access to iocage features and jails, while aiming to be compatible with iocage-legacy, and the current Python 3 version of iocage.
 
-### Latest News (August 7th, 2018)
-libiocage is making small but continuous steps to stabilize the interfaces and become used in [iocage/iocage](https://github.com/iocage/iocage). The project was first presented in the talk "[Imprisoning software with libiocage](https://www.bsdcan.org/2018/schedule/events/957.en.html)" at BSDCan 2018 (Video Recording on [YouTube](https://www.youtube.com/watch?v=CTGc3zYToh0)). There will be a Tutorial about [Advanced container management with libiocage](https://2018.eurobsdcon.org/tutorial-speakers/#StefanGronke) on September 20th, 2018 at EuroBSDCon in Bucharest.
+### Latest News (September 22nd, 2018)
+Progress towards the transition of [python-iocage](https://github.com/iocage/iocage) using libiocage has been made. Recent changes to both projects ensure compatibility running on the same host, so that it is now possible to partially utilize libiocage in iocage until a full migration is performed. Because some changes to the command line arguments and the script output will occur, @skarekrow will continue to maintain the current implementation until users had time to follow the deprecation warnings and suggestions.
 
-Ongoing preparations at this repository and iocage ensure that the transition to using libiocage under the hood of iocage go as smooth as possible for users. Features that exist in iocage will be further improved and tested or announced to be replaced or deprecated shortly. iXsystems let one imagine that libiocage once finds its way into FreeNAS where it can play its full strength behind a Web GUI.
+In terms of the "Advanced container management with libiocage" tutorial at EuroBSDCon 2018 the [Handbook](https://iocage.github.com/handbook) was published.
 
 ## Install
 
@@ -20,6 +20,11 @@ make install
 ```
 
 At the current time libiocage is not packaged or available in FreeBSD ports.
+
+## Documentation
+
+- Iocage Handbook: https://iocage.github.com/handbook
+- Reference Documentation: https://iocage.github.io/libiocage
 
 ## Configuration
 
@@ -148,6 +153,11 @@ make check
 ---
 
 ### Project Status (Archive)
+
+#### 2018-08-07
+libiocage is making small but continuous steps to stabilize the interfaces and become used in [iocage/iocage](https://github.com/iocage/iocage). The project was first presented in the talk "[Imprisoning software with libiocage](https://www.bsdcan.org/2018/schedule/events/957.en.html)" at BSDCan 2018 (Video Recording on [YouTube](https://www.youtube.com/watch?v=CTGc3zYToh0)). There will be a Tutorial about [Advanced container management with libiocage](https://2018.eurobsdcon.org/tutorial-speakers/#StefanGronke) on September 20th, 2018 at EuroBSDCon in Bucharest.
+
+Ongoing preparations at this repository and iocage ensure that the transition to using libiocage under the hood of iocage go as smooth as possible for users. Features that exist in iocage will be further improved and tested or announced to be replaced or deprecated shortly. iXsystems let one imagine that libiocage once finds its way into FreeNAS where it can play its full strength behind a Web GUI.
 
 #### 2017-11-14
 As of November 2017 this project is *working towards an alpha release*. This means stabilization of command-line and library interfaces, so that proper integration tests can be built. This phase requires manual verification and testing until reaching feature-completion and compatibility with Python [iocage](https://github.com/iocage/iocage) and prior iocage_legacy versions with [ZFS property](https://github.com/iocage/iocage_legacy/tree/master) and [UCL file](https://github.com/iocage/iocage_legacy) config storage.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Progress towards the transition of [python-iocage](https://github.com/iocage/ioc
 Recent changes to both projects ensure compatibility running on the same host, so that it is now possible to partially utilize libiocage in iocage until a full migration is performed.
 Because some changes to the command line arguments and the script output will occur, @skarekrow will continue to maintain the current implementation until users had time to follow the deprecation warnings and suggestions.
 
-In terms of the "Advanced container management with libiocage" tutorial at EuroBSDCon 2018 the [Handbook](https://iocage.github.com/handbook) was published.
+In terms of the "Advanced container management with libiocage" tutorial at EuroBSDCon 2018 the [Handbook](https://iocage.io/handbook) was published.
 
 ## Install
 
@@ -26,8 +26,8 @@ At the current time libiocage is not packaged or available in FreeBSD ports.
 
 ## Documentation
 
-- Iocage Handbook: https://iocage.github.com/handbook
-- Reference Documentation: https://iocage.github.io/libiocage
+- Iocage Handbook: https://iocage.io/handbook
+- Reference Documentation: https://iocage.io/libiocage
 
 ## Configuration
 
@@ -134,7 +134,7 @@ ioc fetch -r custom -b
 
 ## Documentation
 
-The [API Reference (html)](https://iocage.github.io/libiocage) documenting all public interfaces of libiocage is updated with every release.
+The [API Reference (html)](https://iocage.io/libiocage) documenting all public interfaces of libiocage is updated with every release.
 The information found in the reference is compiled from Python docstrings and MyPy typings using Sphinx.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 **Python Library to manage FreeBSD jails with libiocage.**
 
-iocage is a jail/container manager fusioning some of the best features and technologies the FreeBSD operating system has to offer. It is geared for ease of use with a simple and easy to understand command syntax.
+iocage is a jail/container manager fusioning some of the best features and technologies the FreeBSD operating system has to offer.
+It is geared for ease of use with a simple and easy to understand command syntax.
 
 This library provides programmatic access to iocage features and jails, while aiming to be compatible with iocage-legacy, and the current Python 3 version of iocage.
 
 ### Latest News (September 22nd, 2018)
-Progress towards the transition of [python-iocage](https://github.com/iocage/iocage) using libiocage has been made. Recent changes to both projects ensure compatibility running on the same host, so that it is now possible to partially utilize libiocage in iocage until a full migration is performed. Because some changes to the command line arguments and the script output will occur, @skarekrow will continue to maintain the current implementation until users had time to follow the deprecation warnings and suggestions.
+Progress towards the transition of [python-iocage](https://github.com/iocage/iocage) using libiocage has been made.
+Recent changes to both projects ensure compatibility running on the same host, so that it is now possible to partially utilize libiocage in iocage until a full migration is performed.
+Because some changes to the command line arguments and the script output will occur, @skarekrow will continue to maintain the current implementation until users had time to follow the deprecation warnings and suggestions.
 
 In terms of the "Advanced container management with libiocage" tutorial at EuroBSDCon 2018 the [Handbook](https://iocage.github.com/handbook) was published.
 
@@ -30,11 +33,13 @@ At the current time libiocage is not packaged or available in FreeBSD ports.
 
 ### Active ZFS pool
 
-libiocage iterates over existing ZFS pools and stops at the first one with ZFS property `org.freebsd.ioc:active` set to `yes`. This behavior is the default used by other iocage variants and is restricted to one pool managed by iocage
+libiocage iterates over existing ZFS pools and stops at the first one with ZFS property `org.freebsd.ioc:active` set to `yes`.
+This behavior is the default used by other iocage variants and is restricted to one pool managed by iocage
 
 ### Root Datasets configured in /etc/rc.conf
 
-When iocage datasets are specified in the jail hosts `/etc/rc.conf`, libiocage prefers them over activated pool lookups. Every ZFS filesystem that iocage should use as root dataset has a distinct name and is configured as `ioc_dataset_<NAME>="zroot/some-dataset/iocage"`, for example:
+When iocage datasets are specified in the jail hosts `/etc/rc.conf`, libiocage prefers them over activated pool lookups.
+Every ZFS filesystem that iocage should use as root dataset has a distinct name and is configured as `ioc_dataset_<NAME>="zroot/some-dataset/iocage"`, for example:
 
 ```
 $ cat /etc/rc.conf | grep ^ioc_dataset
@@ -129,7 +134,8 @@ ioc fetch -r custom -b
 
 ## Documentation
 
-The [API Reference (html)](https://iocage.github.io/libiocage) documenting all public interfaces of libiocage is updated with every release. The information found in the reference is compiled from Python docstrings and MyPy typings using Sphinx.
+The [API Reference (html)](https://iocage.github.io/libiocage) documenting all public interfaces of libiocage is updated with every release.
+The information found in the reference is compiled from Python docstrings and MyPy typings using Sphinx.
 
 ## Development
 
@@ -143,7 +149,8 @@ ZPOOL=zroot make test
 
 ### Static Code Analysis
 
-The project enforces PEP-8 code style and MyPy strong typing via flake8, that is required to pass before merging any changes. Together with Bandit checks for common security issues the static code analysis can be ran on Linux and BSD as both do not require py-libzfs or code execution.
+The project enforces PEP-8 code style and MyPy strong typing via flake8, that is required to pass before merging any changes.
+Together with Bandit checks for common security issues the static code analysis can be ran on Linux and BSD as both do not require py-libzfs or code execution.
 
 ```
 make install-dev
@@ -155,9 +162,15 @@ make check
 ### Project Status (Archive)
 
 #### 2018-08-07
-libiocage is making small but continuous steps to stabilize the interfaces and become used in [iocage/iocage](https://github.com/iocage/iocage). The project was first presented in the talk "[Imprisoning software with libiocage](https://www.bsdcan.org/2018/schedule/events/957.en.html)" at BSDCan 2018 (Video Recording on [YouTube](https://www.youtube.com/watch?v=CTGc3zYToh0)). There will be a Tutorial about [Advanced container management with libiocage](https://2018.eurobsdcon.org/tutorial-speakers/#StefanGronke) on September 20th, 2018 at EuroBSDCon in Bucharest.
+libiocage is making small but continuous steps to stabilize the interfaces and become used in [iocage/iocage](https://github.com/iocage/iocage).
+The project was first presented in the talk "[Imprisoning software with libiocage](https://www.bsdcan.org/2018/schedule/events/957.en.html)" at BSDCan 2018 (Video Recording on [YouTube](https://www.youtube.com/watch?v=CTGc3zYToh0)).
+There will be a Tutorial about [Advanced container management with libiocage](https://2018.eurobsdcon.org/tutorial-speakers/#StefanGronke) on September 20th, 2018 at EuroBSDCon in Bucharest.
 
-Ongoing preparations at this repository and iocage ensure that the transition to using libiocage under the hood of iocage go as smooth as possible for users. Features that exist in iocage will be further improved and tested or announced to be replaced or deprecated shortly. iXsystems let one imagine that libiocage once finds its way into FreeNAS where it can play its full strength behind a Web GUI.
+Ongoing preparations at this repository and iocage ensure that the transition to using libiocage under the hood of iocage go as smooth as possible for users.
+Features that exist in iocage will be further improved and tested or announced to be replaced or deprecated shortly.
+iXsystems let one imagine that libiocage once finds its way into FreeNAS where it can play its full strength behind a Web GUI.
 
 #### 2017-11-14
-As of November 2017 this project is *working towards an alpha release*. This means stabilization of command-line and library interfaces, so that proper integration tests can be built. This phase requires manual verification and testing until reaching feature-completion and compatibility with Python [iocage](https://github.com/iocage/iocage) and prior iocage_legacy versions with [ZFS property](https://github.com/iocage/iocage_legacy/tree/master) and [UCL file](https://github.com/iocage/iocage_legacy) config storage.
+As of November 2017 this project is *working towards an alpha release*.
+This means stabilization of command-line and library interfaces, so that proper integration tests can be built.
+This phase requires manual verification and testing until reaching feature-completion and compatibility with Python [iocage](https://github.com/iocage/iocage) and prior iocage_legacy versions with [ZFS property](https://github.com/iocage/iocage_legacy/tree/master) and [UCL file](https://github.com/iocage/iocage_legacy) config storage.


### PR DESCRIPTION
Parallel with the tutorial about iocage at EuroBSDCon on September 19th, 2018 in Bucharest, the initial version of the iocage handbook was published. This PR mentions the Handbook in the README so that it is possible for users to find it.