### PR TITLE
ignore ZFS pools that are not ONLINE

### DIFF
--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -402,7 +402,7 @@ class Datasets(dict):
         prop: str
     ) -> typing.Optional[str]:
 
-        if pool.status != "ONLINE":
+        if (pool.status != "ONLINE") and (pool.status != "DEGRADED"):
             self.logger.verbose(
                 f"The pool {pool.name} is {pool.status} and will be ignored"
             )

--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -402,6 +402,12 @@ class Datasets(dict):
         prop: str
     ) -> typing.Optional[str]:
 
+        if pool.status != "ONLINE":
+            self.logger.verbose(
+                f"The pool {pool.name} is {pool.status} and will be ignored"
+            )
+            return None
+
         if prop in pool.root_dataset.properties:
             zfs_prop = pool.root_dataset.properties[prop]
             return str(zfs_prop.value)


### PR DESCRIPTION
addresses #520

When a ZFS pools status is not `ONLINE`, the pool will be ignored for further actions from iocage. A message is printed to the verbose log level instead.