### PR TITLE
lazy-load UCL dependency on usage

### DIFF
--- a/iocage/Config/Jail/File/__init__.py
+++ b/iocage/Config/Jail/File/__init__.py
@@ -26,8 +26,6 @@
 import typing
 import os.path
 
-import ucl
-
 import iocage.helpers
 import iocage.helpers_object
 import iocage.LaunchableResource
@@ -161,6 +159,7 @@ class ConfigFile(dict):
             self._file_content_changed = False
 
     def _read(self, silent: bool=False) -> dict:
+        import ucl
         data = dict(ucl.load(open(self.path).read()))
         self.logger.spam(f"{self._file} was read from {self.path}")
         return data
@@ -174,7 +173,7 @@ class ConfigFile(dict):
             return False
 
         with open(self.path, "w") as rcconf:
-
+            import ucl
             output = ucl.dump(self, ucl.UCL_EMIT_CONFIG)
             output = output.replace(" = \"", "=\"")
             output = output.replace("\";\n", "\"\n")

--- a/iocage/Config/Type/UCL.py
+++ b/iocage/Config/Type/UCL.py
@@ -25,8 +25,6 @@
 """iocage configuration stored in an UCL file."""
 import typing
 
-import ucl
-
 import iocage.Config
 import iocage.Config.Prototype
 import iocage.Config.Dataset
@@ -40,6 +38,7 @@ class ConfigUCL(iocage.Config.Prototype.Prototype):
 
     def map_input(self, data: typing.TextIO) -> typing.Dict[str, typing.Any]:
         """Normalize data read from the UCL file."""
+        import ucl
         result = ucl.load(data.read())  # type: typing.Dict[str, typing.Any]
         result["legacy"] = True
         return result

--- a/iocage/Pkg.py
+++ b/iocage/Pkg.py
@@ -29,7 +29,6 @@ import os.path
 import re
 
 import libzfs
-import ucl
 
 import iocage.events
 import iocage.helpers
@@ -369,6 +368,7 @@ class Pkg:
                 reason="Refusing to write to a symlink",
                 logger=self.logger
             )
+        import ucl
         with open(filename, "w") as f:
             f.write(ucl.dump(data, ucl.UCL_EMIT_JSON))
 

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -32,7 +32,6 @@ import urllib.parse
 import re
 
 import libzfs
-import ucl
 
 import iocage.ZFS
 import iocage.errors
@@ -621,6 +620,7 @@ class ReleaseGenerator(ReleaseResource):
             )
 
         with open(source_file, "r") as f:
+            import ucl
             hbsd_update_conf = ucl.load(f.read())
             self._hbsd_release_branch = hbsd_update_conf["branch"]
             return str(self._hbsd_release_branch)

--- a/iocage/helpers.py
+++ b/iocage/helpers.py
@@ -30,7 +30,6 @@ import random
 import re
 import subprocess  # nosec: B404
 import sys
-import ucl
 import pty
 import select
 
@@ -326,6 +325,7 @@ def to_ucl(data: typing.Dict[str, typing.Any]) -> str:
             false="off",
             none="none"
         )
+    import ucl
     return str(ucl.dump(output_data))
 
 


### PR DESCRIPTION
closes #519

- makes code analysis on Linux hosts easier
- import `ucl` module only when it is needed