### PR TITLE
allow virtual <NIC>_mac jail config properties

### DIFF
--- a/iocage/Config/Jail/JailConfig.py
+++ b/iocage/Config/Jail/JailConfig.py
@@ -74,11 +74,27 @@ class JailConfig(iocage.Config.Jail.BaseConfig.BaseConfig):
     def _get_legacy(self) -> bool:
         return self.legacy
 
+    def _key_is_mac_config(self, key: str, explicit: bool=False) -> bool:
+        fragments = key.rsplit("_", maxsplit=1)
+        if len(fragments) < 2:
+            return False
+        elif fragments[1].lower() != "mac":
+            return False
+        elif explicit is False:
+            # do not explicitly check if the interface exists
+            return True
+        return (fragments[0] in self["interfaces"].keys()) is True
+
     def _is_known_property(self, key: str) -> bool:
         key_is_default = key in self.host.defaults.config.keys()
         key_is_setter = f"_set_{key}" in dict.__dir__(self)
         key_is_special = key in iocage.Config.Jail.Properties.properties
-        return (key_is_default or key_is_setter or key_is_special) is True
+        return any([
+            key_is_default,
+            key_is_setter,
+            key_is_special,
+            self._key_is_mac_config(key)
+        ]) is True
 
     def __setitem__(
         self,


### PR DESCRIPTION
fixes #517

- Jail properties ending with `_mac` are accepted in expectation they are configuring a NIC

Without the `explicit` argument being set it is not further checked whether the interface exists. Otherwise the jail configuration would depend on the order in the JSON, which can lead to unexpected results. The same applies when setting a whole bunch of properties on a jail - they would be order dependent. Improving this can be suspect of another Pull-Request after this bug fix.