### PR TITLE
package removal

### DIFF
--- a/iocage/Pkg.py
+++ b/iocage/Pkg.py
@@ -415,7 +415,6 @@ class Pkg:
         repo_ds = self._get_release_pkg_dataset(release_major_version)
         cache_ds = self.zfs.get_or_create_dataset(f"{repo_ds.name}/cache")
         try:
-            print("FSTAB THING")
             temporary_jail.fstab.new_line(
                 source=cache_ds.mountpoint,
                 destination=f"{destination_dir}",

--- a/iocage/events.py
+++ b/iocage/events.py
@@ -885,6 +885,21 @@ class PackageInstall(JailEvent):
         JailEvent.__init__(self, jail=jail, message=message, scope=scope)
 
 
+class PackageRemove(JailEvent):
+    """Remove packages from a jail."""
+
+    def __init__(
+        self,
+        packages: typing.List[str],
+        jail: 'iocage.Jail.JailGenerator',
+        message: typing.Optional[str]=None,
+        scope: typing.Optional[Scope]=None
+    ) -> None:
+
+        self.packages = packages
+        JailEvent.__init__(self, jail=jail, message=message, scope=scope)
+
+
 class PackageConfiguration(JailEvent):
     """Install packages in a jail."""
 


### PR DESCRIPTION
closes #526 

- Allows to remove packages from jails at runtime and when being stopped (via fork_exec)

```sh
ioc pkg -r <JAIL> <packages>
```