### PR TITLE
Feature: Depends

### DIFF
--- a/ioc/start.py
+++ b/ioc/start.py
@@ -116,6 +116,9 @@ def _autostart(
     failed_jails = []
     for jail in jails:
         try:
+            if jail.running is True:
+                logger.log(f"{jail.name} is already running - skipping start")
+                continue
             jail.start()
         except iocage.errors.IocageException:
             failed_jails.append(jail)
@@ -162,6 +165,9 @@ def _normal(
             exit(1)
         try:
             jail.require_jail_not_template()
+            if jail.running is True:
+                logger.log(f"{jail.name} is already running - skipping start")
+                continue
             print_function(jail.start())
         except iocage.errors.IocageException:
             failed_jails.append(jail)

--- a/iocage/Config/Jail/BaseConfig.py
+++ b/iocage/Config/Jail/BaseConfig.py
@@ -193,7 +193,10 @@ class BaseConfig(dict):
                 " ".join(invalid_characters)
             )
             self.logger.error(msg)
-            raise iocage.errors.InvalidJailName(logger=self.logger)
+            raise iocage.errors.InvalidJailName(
+                name="INVALID",
+                logger=self.logger
+            )
 
         is_valid_name = iocage.helpers.validate_name(name)
         if is_valid_name is True:
@@ -202,7 +205,10 @@ class BaseConfig(dict):
             if iocage.helpers.is_uuid(name) is True:
                 self.data["id"] = name
             else:
-                raise iocage.errors.InvalidJailName(logger=self.logger)
+                raise iocage.errors.InvalidJailName(
+                    name=name,
+                    logger=self.logger
+                )
 
     def _get_name(self) -> str:
         return self._get_id()

--- a/iocage/Config/Jail/Defaults.py
+++ b/iocage/Config/Jail/Defaults.py
@@ -71,7 +71,7 @@ class JailConfigDefaults(iocage.Config.Jail.BaseConfig.BaseConfig):
         "priority": 0,
         "legacy": False,
         "priority": 0,
-        "depends": None,
+        "depends": [],
         "basejail": False,
         "basejail_type": "nullfs",
         "clonejail": False,

--- a/iocage/Config/Jail/Defaults.py
+++ b/iocage/Config/Jail/Defaults.py
@@ -71,6 +71,7 @@ class JailConfigDefaults(iocage.Config.Jail.BaseConfig.BaseConfig):
         "priority": 0,
         "legacy": False,
         "priority": 0,
+        "depends": None,
         "basejail": False,
         "basejail_type": "nullfs",
         "clonejail": False,

--- a/iocage/Config/Jail/Properties/Depends.py
+++ b/iocage/Config/Jail/Properties/Depends.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Jail config depends property."""
+import typing
+
+import iocage.helpers
+
+
+class DependsProp(iocage.Filter.Terms):
+    """Special jail config property Depends."""
+
+    config: 'iocage.Config.Jail.JailConfig.JailConfig'
+    property_name: str
+    logger: typing.Optional['iocage.Logger.Logger']
+    delimiter: str = ","
+
+    def __init__(
+        self,
+        config: typing.Optional[
+            'iocage.Config.Jail.JailConfig.JailConfig'
+        ]=None,
+        property_name: str="interfaces",
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        self.property_name = property_name
+        self.logger = logger
+        if config is not None:
+            self.config = config
+        iocage.Filter.Terms.__init__(self, logger=logger)
+
+    def set(
+        self,
+        data: typing.Optional[typing.Union[
+            str,
+            typing.Iterable[typing.Union[iocage.Filter.Term, str]]
+        ]],
+        skip_on_error: bool=False
+    ) -> None:
+        """Clear and set all terms from input data."""
+        try:
+            iocage.Filter.Terms.set(
+                self,
+                terms=data
+            )
+        except iocage.errors.IocageException:
+            if skip_on_error is False:
+                raise
+
+        self.__notify()
+
+    def add(
+        self,
+        term: typing.Union[iocage.Filter.Term, str],
+        notify: typing.Optional[bool]=True
+    ) -> None:
+        """
+        Add a Filter.Term to the depends Jail Config property.
+
+        Args:
+
+            term (iocage.Filter.Term, str):
+                Depends Filter.Term to add
+
+            notify (bool): (default=True)
+                Sends an update notification to the jail config instance
+        """
+        iocage.Filter.Terms.add(self, term)
+        if notify is True:
+            self.__notify()
+
+    def __delitem__(self, key: typing.Any) -> None:
+        """Remove a jail NIC."""
+        dict.__delitem__(self, key)
+        self.__notify()
+
+    def __notify(self) -> None:
+        self.config.update_special_property(self.property_name)
+
+    def __empty_prop(self, key: str) -> None:
+        dict.__setitem__(self, key, None)

--- a/iocage/Config/Jail/Properties/Depends.py
+++ b/iocage/Config/Jail/Properties/Depends.py
@@ -41,7 +41,7 @@ class DependsProp(iocage.Filter.Terms):
         config: typing.Optional[
             'iocage.Config.Jail.JailConfig.JailConfig'
         ]=None,
-        property_name: str="interfaces",
+        property_name: str="depends",
         logger: typing.Optional['iocage.Logger.Logger']=None
     ) -> None:
         self.property_name = property_name

--- a/iocage/Config/Jail/Properties/Depends.py
+++ b/iocage/Config/Jail/Properties/Depends.py
@@ -91,7 +91,7 @@ class DependsProp(iocage.Filter.Terms):
             self.__notify()
 
     def __delitem__(self, key: typing.Any) -> None:
-        """Remove a jail NIC."""
+        """Remove a jail dependency."""
         dict.__delitem__(self, key)
         self.__notify()
 

--- a/iocage/Config/Jail/Properties/Resolver.py
+++ b/iocage/Config/Jail/Properties/Resolver.py
@@ -97,7 +97,7 @@ class ResolverProp(collections.MutableSequence):
         )
 
         jailResolverConfigEvent = iocage.events.JailResolverConfig(
-            jail=self,
+            jail=jail,
             scope=event_scope
         )
         yield jailResolverConfigEvent.begin()

--- a/iocage/Config/Jail/Properties/__init__.py
+++ b/iocage/Config/Jail/Properties/__init__.py
@@ -29,11 +29,13 @@ import iocage.Config.Jail.Properties.Interfaces
 import iocage.Config.Jail.Properties.Resolver
 import iocage.Config.Jail.Properties.ResourceLimit
 import iocage.Config.Jail.Properties.Defaultrouter
+import iocage.Config.Jail.Properties.Depends
 
 Property = typing.Union[
     'iocage.Config.Jail.Properties.Addresses.AddressesProp',
     'iocage.Config.Jail.Properties.Interfaces.InterfaceProp',
-    'iocage.Config.Jail.Properties.Resolver.ResolverProp'
+    'iocage.Config.Jail.Properties.Resolver.ResolverProp',
+    'iocage.Config.Jail.Properties.Depends.DependsProp'
 ]
 
 properties: typing.List[str] = [
@@ -42,7 +44,8 @@ properties: typing.List[str] = [
     "interfaces",
     "defaultrouter",
     "defaultrouter6",
-    "resolver"
+    "resolver",
+    "depends"
 ] + ResourceLimit.properties
 
 def _get_class(property_name: str) -> Property:
@@ -62,6 +65,8 @@ def _get_class(property_name: str) -> Property:
         return DefaultrouterModule.DefaultrouterProp
     elif property_name == "defaultrouter6":
         return DefaultrouterModule.Defaultrouter6Prop
+    elif property_name == "depends":
+        return iocage.Config.Jail.Properties.Depends.DependsProp
     elif property_name in ResourceLimit.properties:
         return ResourceLimit.ResourceLimitProp
 
@@ -88,6 +93,7 @@ def init_property(
                 - resolver
                 - defaultrouter
                 - defaultrouter6
+                - depends
 
         config (iocage.Config.Jail.JailConfig.JailConfig):
             The special property keeps reference to this JailConfig instance
@@ -137,5 +143,4 @@ class JailConfigProperties(dict):
                 config=self.config,
                 logger=self.logger
             )
-
         return self[property_name]

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -339,3 +339,7 @@ class Terms(list):
     def __str__(self) -> str:
         """Return the Filter.Terms as string."""
         return " ".join([str(x) for x in self])
+
+    def __repr__(self) -> str:
+        """Return the Terms in human and robot friendly format."""
+        return self.__str__()

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -38,6 +38,8 @@ _TermValuesType = typing.Union[
     iocage.ResourceSelector.ResourceSelector
 ]
 
+_REGEX_PATTERN_SPLIT_COMMA = re.compile(r'(?<!\\),')
+
 
 def match_filter(value: str, filter_string: str) -> bool:
     """Return True when the value matches the filter string."""
@@ -158,7 +160,7 @@ class Term(list):
         return False
 
     def _split_filter_values(self, user_input: str) -> typing.List[str]:
-        return re.split(r'(?<!\\),', user_input)
+        return re.split(_REGEX_PATTERN_SPLIT_COMMA, user_input)
 
     def _validate_name_filter_string(self, filter_string: str) -> bool:
 
@@ -313,7 +315,10 @@ class Terms(list):
             value = [iocage.ResourceSelector.ResourceSelector(
                 partial_value,
                 logger=self.logger
-            ) for partial_value in re.split(r'(?<!\\),', value)]
+            ) for partial_value in re.split(
+                _REGEX_PATTERN_SPLIT_COMMA,
+                value
+            )]
         else:
             value = iocage.helpers.to_string(
                 iocage.helpers.parse_user_input(value)

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -158,21 +158,7 @@ class Term(list):
         return False
 
     def _split_filter_values(self, user_input: str) -> typing.List[str]:
-        values: typing.List[str] = []
-        escaped_comma_blocks = map(
-            lambda block: block.split(","),
-            user_input.split("\\,")
-        )
-        for block in escaped_comma_blocks:
-            n = len(values)
-            if n > 0:
-                index = n - 1
-                values[index] += f",{block[0]}"
-            else:
-                values.append(block[0])
-            if len(block) > 1:
-                values += block[1:]
-        return values
+        return re.split(r'(?<!\\),', user_input)
 
     def _validate_name_filter_string(self, filter_string: str) -> bool:
 

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -210,8 +210,6 @@ class Terms(list):
     ) -> None:
 
         self.logger = logger
-        data: typing.List[typing.Union[Term, str]] = []
-
         list.__init__(self, [])
         Terms.set(self, terms)
 
@@ -255,13 +253,8 @@ class Terms(list):
             term (iocage.Filter.Term, str):
                 Interface name inside the jail
         """
-        _term: Term
-        if isinstance(term, Term) is True:
-            _term = term
-        else:
-            _term = self._parse_term(term)
-
-        list.add(self, _term)
+        _term = term if isinstance(term, Term) else self._parse_term(term)
+        list.append(self, _term)
 
     def match_resource(
         self,
@@ -309,6 +302,7 @@ class Terms(list):
         return True
 
     def _parse_term(self, user_input: str) -> Term:
+        value: typing.Any
         try:
             prop, value = user_input.split("=", maxsplit=1)
         except ValueError:

--- a/iocage/Filter.py
+++ b/iocage/Filter.py
@@ -316,10 +316,10 @@ class Terms(list):
             value = user_input
 
         if prop == "name":
-            value = iocage.ResourceSelector.ResourceSelector(
-                value,
+            value = [iocage.ResourceSelector.ResourceSelector(
+                partial_value,
                 logger=self.logger
-            )
+            ) for partial_value in re.split(r'(?<!\\),', value)]
         else:
             value = iocage.helpers.to_string(
                 iocage.helpers.parse_user_input(value)

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -2150,6 +2150,12 @@ class JailGenerator(JailResource):
                 properties.add(prop)
         return list(properties)
 
+    def __eq__(self, other: typing.Any) -> bool:
+        """Compare two Jails by their name."""
+        if isinstance(other, JailGenerator):
+            return False
+        return (self.name == other.name) is True
+
 
 class Jail(JailGenerator):
     """Synchronous wrapper of JailGenerator."""

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -2163,10 +2163,15 @@ class JailGenerator(JailResource):
         return list(properties)
 
     def __eq__(self, other: typing.Any) -> bool:
-        """Compare two Jails by their name."""
+        """
+        Compare two Jails by their name.
+
+        The jail is identified by its full name, including the iocage root
+        dataset name in case there is more than one enabled on the host.
+        """
         if isinstance(other, JailGenerator):
             return False
-        return (self.name == other.name) is True
+        return (self.full_name == other.full_name) is True
 
 
 class Jail(JailGenerator):

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -1024,7 +1024,10 @@ class JailGenerator(JailResource):
         self.require_storage_backend()
 
         if iocage.helpers.validate_name(new_name) is False:
-            raise iocage.errors.InvalidJailName(logger=self.logger)
+            raise iocage.errors.InvalidJailName(
+                name=new_name,
+                logger=self.logger
+            )
 
         current_id = self.config["id"]
         current_mountpoint = self.dataset.mountpoint

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -629,6 +629,7 @@ class JailGenerator(JailResource):
                     scope=jailDependantsStartEvent.scope
                 )
                 yield jailDependantStartEvent.begin()
+                dependant_jail.state.query()
                 if dependant_jail.running is True:
                     yield jailDependantStartEvent.skip("already running")
                     continue

--- a/iocage/ResourceSelector.py
+++ b/iocage/ResourceSelector.py
@@ -67,7 +67,7 @@ class ResourceSelector:
         has_valid_name = iocage.helpers.validate_name(_name_without_globs)
         is_valid_uuid = iocage.helpers.is_uuid(_name_without_globs)
         if (_name not in ["*", "+"]) and not (has_valid_name or is_valid_uuid):
-            raise iocage.errors.InvalidJailName(logger=self.logger)
+            raise iocage.errors.InvalidJailName(name=_name,logger=self.logger)
 
         self.source_name = _source_name
         self._name = _name

--- a/iocage/ResourceSelector.py
+++ b/iocage/ResourceSelector.py
@@ -67,7 +67,7 @@ class ResourceSelector:
         has_valid_name = iocage.helpers.validate_name(_name_without_globs)
         is_valid_uuid = iocage.helpers.is_uuid(_name_without_globs)
         if (_name not in ["*", "+"]) and not (has_valid_name or is_valid_uuid):
-            raise iocage.errors.InvalidJailName(name=_name,logger=self.logger)
+            raise iocage.errors.InvalidJailName(name=_name, logger=self.logger)
 
         self.source_name = _source_name
         self._name = _name

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -370,10 +370,11 @@ class InvalidJailName(JailConfigError):
 
     def __init__(
         self,
+        name: str,
         logger: typing.Optional['iocage.Logger.Logger']=None
     ) -> None:
         msg = (
-            "Invalid jail name: "
+            f"Invalid jail name '{name}': "
             "Names have to begin and end with an alphanumeric character"
         )
         super().__init__(message=msg, logger=logger)

--- a/iocage/events.py
+++ b/iocage/events.py
@@ -815,13 +815,36 @@ class JailStart(JailEvent):
     pass
 
 
-class JailDependantsStart(JailStart):
+class JailDependantsStart(JailEvent):
     """Start dependant jails."""
 
-    pass
+    started_jails: typing.List['iocage.Jail.JailGenerator']
+
+    def __init__(
+        self,
+        jail: 'iocage.Jail.JailGenerator',
+        message: typing.Optional[str]=None,
+        scope: typing.Optional[Scope]=None
+    ) -> None:
+
+        try:
+            self.identifier = jail.full_name
+        except AttributeError:
+            self.identifier = None
+        self.started_jails = []
+        JailEvent.__init__(self, jail=jail, message=message, scope=scope)
+
+    def end(
+        self,
+        message: typing.Optional[str]=None,
+        started_jails: typing.List['iocage.Jail.JailGenerator']=[],
+    ) -> 'IocageEvent':
+        """Successfully finish starting dependant Jails."""
+        self.started_jails = started_jails
+        return JailEvent.end(self, message)
 
 
-class JailDependantStart(JailStart):
+class JailDependantStart(JailEvent):
     """Start one dependant jail."""
 
     pass

--- a/iocage/events.py
+++ b/iocage/events.py
@@ -814,6 +814,7 @@ class JailStart(JailEvent):
 
     pass
 
+
 class JailDependantsStart(JailStart):
     """Start dependant jails."""
 

--- a/iocage/events.py
+++ b/iocage/events.py
@@ -814,6 +814,17 @@ class JailStart(JailEvent):
 
     pass
 
+class JailDependantsStart(JailStart):
+    """Start dependant jails."""
+
+    pass
+
+
+class JailDependantStart(JailStart):
+    """Start one dependant jail."""
+
+    pass
+
 
 class JailProvisioning(JailEvent):
     """Provision a jail."""


### PR DESCRIPTION
related to #461

- [x] start dependant jails on start of a jail that has dependencies
- [x] stop jails that have been started as dependants if a following dependant fails to start
- [x] stop started dependants if the target jail fails to start
- [x] Resolve dependant jails dependencies to start everything in reasonable order
- [x] dependant jails can be selected using Filter.Terms
- [x] do not start already started jails in `ioc start --rc` command
- [x] resolve circular dependencies

This example shows how the database jail `mydatabase` is started before `mybackend`:

```
ioc create mydatabase tag=database user.customer=gronke
ioc create mybackend depends="tag=database user.customer=gronke" user.customer=gronke
ioc start mybackend
```