### PR TITLE
List active ZFS pools

### DIFF
--- a/ioc/get.py
+++ b/ioc/get.py
@@ -51,16 +51,10 @@ from .shared.click import IocageClickContext
     help="Get all properties for the specified jail.",
     is_flag=True
 )
-@click.option(
-    "--pool", "-p", "_pool",
-    help="Get the currently activated zpool.",
-    is_flag=True
-)
 def cli(
     ctx: IocageClickContext,
     prop: typing.Tuple[str],
     _all: bool,
-    _pool: bool,
     jail: typing.Optional[str]
 ) -> None:
     """Get a list of jails and print the property."""
@@ -68,14 +62,6 @@ def cli(
     host = iocage.Host.Host(logger=logger)
 
     _prop = None if len(prop) == 0 else prop[0]
-
-    if _pool is True:
-        try:
-            print(host.datasets.active_pool.name)
-        except Exception:
-            print("No active pool found")
-            exit(1)
-        exit(0)
 
     if _all is True:
         if jail is None:

--- a/ioc/get.py
+++ b/ioc/get.py
@@ -37,7 +37,11 @@ from .shared.click import IocageClickContext
 @click.command(
     context_settings=dict(max_content_width=400,),
     name="get",
-    help="Gets the specified property."
+    help="""Gets the specified property.
+
+    Specify an individual jail by its name or use `defaults` to get the host's
+    defaults from the main source dataset.
+    """
 )
 @click.pass_context
 @click.argument("prop", nargs=-1, required=False, default=None)

--- a/ioc/list.py
+++ b/ioc/list.py
@@ -239,8 +239,9 @@ def _lookup_resource_values(
 ) -> typing.List[str]:
     is_resorce = isinstance(resource, iocage.Resource.Resource)
     if is_resorce and ("getstring" in resource.__dir__()):
+        _resource = resource  # type: iocage.Resource.Resource
         return list(map(
-            lambda column: str(resource.getstring(column)),
+            lambda column: str(_resource.getstring(column)),
             columns
         ))
     else:

--- a/ioc/list.py
+++ b/ioc/list.py
@@ -237,7 +237,8 @@ def _lookup_resource_values(
     ],
     columns: typing.List[str]
 ) -> typing.List[str]:
-    if "getstring" in resource.__dir__():
+    is_resorce = isinstance(resource, iocage.Resource.Resource)
+    if is_resorce and ("getstring" in resource.__dir__()):
         return list(map(
             lambda column: str(resource.getstring(column)),
             columns

--- a/ioc/list.py
+++ b/ioc/list.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/ioc/list.py
+++ b/ioc/list.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2014-2018, iocage
-# Copyright (c) 2017-2018, Stefan Grönke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,6 +29,7 @@ import typing
 import iocage.errors
 import iocage.Logger
 import iocage.Host
+import iocage.Datasets
 import iocage.Resource
 import iocage.ListableResource
 import iocage.Jails
@@ -37,6 +37,8 @@ import iocage.Releases
 
 from .shared.output import print_table
 from .shared.click import IocageClickContext
+
+__rootcmd__ = True
 
 supported_output_formats = ['table', 'csv', 'list', 'json']
 
@@ -50,6 +52,8 @@ supported_output_formats = ['table', 'csv', 'list', 'json']
               flag_value="base", help="List all bases.")
 @click.option("--template", "-t", "dataset_type",
               flag_value="template", help="List all templates.")
+@click.option("--pools", "-p", "dataset_type",
+              flag_value="pool", help="List all iocage ZFS pools.")
 @click.option("--dataset", "-d", "dataset_type",
               flag_value="datasets", help="List all root data sources.")
 @click.option("--long", "-l", "_long", is_flag=True, default=False,
@@ -77,6 +81,7 @@ def cli(
 ) -> None:
     """List jails in various formats."""
     logger = ctx.parent.logger
+    zfs = ctx.parent.zfs
     host: iocage.Host.HostGenerator = ctx.parent.host
 
     if output is not None and _long is True:
@@ -99,6 +104,16 @@ def cli(
         if (dataset_type == "base") and (remote is True):
             columns = ["name", "eol"]
             resources = host.distribution.releases
+
+        elif (dataset_type == "pool"):
+            columns = ["name", "dataset"]
+            datasets = iocage.Datasets.Datasets(zfs=zfs, logger=logger)
+            resources = [
+                dict(
+                    name=name,
+                    dataset=x.root.name
+                ) for name, x in datasets.items()
+            ]
 
         else:
 
@@ -145,7 +160,10 @@ def cli(
 
 def _print_table(
     resources: typing.Generator[
-        iocage.ListableResource.ListableResource,
+        typing.Union[
+            iocage.ListableResource.ListableResource,
+            typing.List[typing.Dict[str, str]]
+        ],
         None,
         None
     ],
@@ -163,7 +181,10 @@ def _print_table(
 
 def _print_list(
     resources: typing.Generator[
-        iocage.Jails.JailsGenerator,
+        typing.Union[
+            iocage.ListableResource.ListableResource,
+            typing.List[typing.Dict[str, str]]
+        ],
         None,
         None
     ],
@@ -181,7 +202,10 @@ def _print_list(
 
 def _print_json(
     resources: typing.Generator[
-        iocage.Jails.JailsGenerator,
+        typing.Union[
+            iocage.ListableResource.ListableResource,
+            typing.List[typing.Dict[str, str]]
+        ],
         None,
         None
     ],
@@ -206,7 +230,10 @@ def _print_json(
 
 
 def _lookup_resource_values(
-    resource: 'iocage.Resource.Resource',
+    resource: typing.Union[
+        'iocage.Resource.Resource',
+        typing.Dict[str, str]
+    ],
     columns: typing.List[str]
 ) -> typing.List[str]:
     if "getstring" in resource.__dir__():


### PR DESCRIPTION
List all active pools maintained by libiocage with `ioc list --pools` instead of just a single pool using `ioc get --pool` (deprecared).

This changes are backported from https://github.com/iocage/iocage/pull/636