### PR TITLE
disable mailq cleanups and cron mailing

### DIFF
--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -215,6 +215,11 @@ class ReleaseGenerator(ReleaseResource):
         "sendmail_submit_enable": False,
         "sendmail_msp_queue_enable": False,
         "sendmail_outbound_enable": False,
+        "daily_clean_hoststat_enable": False,
+        "daily_status_mail_rejects_enable": False,
+        "daily_status_include_submit_mailq": False,
+        "daily_submit_queuerun": False,
+        "cron_flags": "-m ''",
         "syslogd_flags": "-ss"
     }
 


### PR DESCRIPTION
When disabling sendmail, certain periodic(8) components are still kept
running to do the cleanup.
Furthermore, we also disable cron's mailing.

This is a fix for #552