### PR TITLE
remove duplicate .env import from start script when VNET is enabled

### DIFF
--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -483,7 +483,7 @@ class JailGenerator(JailResource):
         if self.config["vnet"]:
             _created, _start = self._start_vimage_network()
             exec_created += _created
-            exec_start += [f". {self._relative_hook_script_dir}/.env"] + _start
+            exec_start += _start
             exec_start += self._configure_localhost_commands()
             exec_start += self._configure_routes_commands()
             if self.host.ipfw_enabled is True:


### PR DESCRIPTION
closes #549

Sourcing the jails .env file happened twice when VNET was enabled. Because the environment variables became imported globally there was no need to do so specifically for the configuration of VNET devices.