### PR TITLE
increase default Jail exec_timeout to 600 seconds

### DIFF
--- a/iocage/Config/Jail/Defaults.py
+++ b/iocage/Config/Jail/Defaults.py
@@ -120,7 +120,7 @@ class JailConfigDefaults(iocage.Config.Jail.BaseConfig.BaseConfig):
         "exec_stop": "/bin/sh /etc/rc.shutdown",
         "exec_poststop": None,
         "exec_jail_user": "root",
-        "exec_timeout": "60",
+        "exec_timeout": "600",
         "stop_timeout": "30",
         "mount_procfs": "0",
         "mount_devfs": "1",


### PR DESCRIPTION
A too low timeout was reported causing trouble installing packages, so that a default value increased by 10 should mitigate the problem.