### PR TITLE
require exact match or trailing / when finding source datasets

### DIFF
--- a/iocage/Datasets.py
+++ b/iocage/Datasets.py
@@ -219,7 +219,9 @@ class Datasets(dict):
     def find_root_datasets_name(self, dataset_name: str) -> str:
         """Return the name of the source containing the matching dataset."""
         for source_name, source_datasets in self.items():
-            if dataset_name.startswith(source_datasets.root.name):
+            if dataset_name == source_datasets.root.name:
+                return str(source_name)
+            elif dataset_name.startswith(f"{source_datasets.root.name}/"):
                 return str(source_name)
         raise iocage.errors.ResourceUnmanaged(
             dataset_name=dataset_name,


### PR DESCRIPTION
fixes #569 

When a secondary iocage datasets name began with a name that is a prefix of another dataset, the first touched was resolved to be matching a resource selected by dataset name.

```$console
$ sysrc ioc_dataset_one="zroot/iocage"
$ sysrc ioc_dataset_two="zroot/iocage2"
```

### Before

```python3
>>> import iocage
>>> host = iocage.Host()
>>> host.datasets.find_root_datasets("zroot/iocage2/foo").root.name
'zroot/iocage'
```

Detected dataset: 'zroot/iocage' (one)

### After

```python3
>>> import iocage
>>> host = iocage.Host()
>>> host.datasets.find_root_datasets("zroot/iocage2/foo").root.name
'zroot/iocage2'
```

Detected dataset: 'zroot/iocage2' (two)