### PR TITLE
make the release_name non-greedy

### DIFF
--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -309,7 +309,7 @@ class ReleaseGenerator(ReleaseResource):
         """Set the releases identifier (optionally including patchlevel)."""
         match = re.match((
             r"^(?:(?P<source_dataset_name>.*)/)?"
-            r"(?P<release_name>.*)"
+            r"(?P<release_name>.*?)"
             r"(?:-p(?P<patchlevel>[0-9]+))?$"
         ), value)
         if match is None:


### PR DESCRIPTION
When looking up a Release with the patchlevel included in the name, the regex matched the -p<N> suffix to the release_name group. By making the .* qualifier non-greedy, the -p<N> suffix of a release name is properly detected as patchlevel.