### PR TITLE
JailConfig option to temporary ignore host defaults

### DIFF
--- a/iocage/Config/Jail/JailConfig.py
+++ b/iocage/Config/Jail/JailConfig.py
@@ -37,6 +37,7 @@ class JailConfig(iocage.Config.Jail.BaseConfig.BaseConfig):
     legacy: bool = False
     jail: typing.Optional['iocage.Jail.JailGenerator']
     data: dict = {}
+    ignore_host_defaults: bool = False
 
     def __init__(
         self,
@@ -136,6 +137,8 @@ class JailConfig(iocage.Config.Jail.BaseConfig.BaseConfig):
         try:
             return super().__getitem__(key)
         except KeyError:
+            if self.ignore_host_defaults is True:
+                raise
             pass
 
         # fall back to default

--- a/iocage/Pkg.py
+++ b/iocage/Pkg.py
@@ -433,11 +433,6 @@ class Pkg:
                 "basejail": source_jail.config["basejail"],
                 "release": source_jail.release.name,
                 "exec_start": None,
-                "exec_prestart": None,
-                "exec_poststart": None,
-                "exec_prestop": None,
-                "exec_poststop": None,
-                "exec_timeout": 600,
                 "vnet": False,
                 "ip4_addr": None,
                 "ip6_addr": None,
@@ -452,6 +447,7 @@ class Pkg:
             host=source_jail.host,
             dataset=source_jail.dataset
         )
+        temporary_jail.config.ignore_host_defaults = True
 
         root_path = temporary_jail.root_path
         destination_dir = f"{root_path}{self.package_source_directory}"

--- a/iocage/ResourceUpdater.py
+++ b/iocage/ResourceUpdater.py
@@ -140,6 +140,7 @@ class Updater:
                 dataset=self.resource.dataset
             )
             temporary_jail.config.file = "config_update.json"
+            temporary_jail.config.ignore_host_defaults = True
 
             root_path = temporary_jail.root_path
             destination_dir = f"{root_path}{self.local_release_updates_dir}"


### PR DESCRIPTION
fixes #562
reverts #559 (workaround to override all `exec_*` properties)

- JailConfig.ignore_host_defaults can be set to temporary ignore the hosts defaults for the specified jail