### PR TITLE
Fix JailState object representation

### DIFF
--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -147,9 +147,9 @@ class JailState(dict):
     @property
     def data(self) -> typing.Dict[str, str]:
         """Return the jail state data that was previously queried."""
-        if self._data is None:
-            self._data = self.query()
-        return self._data
+        if self._data is not None:
+            return self._data
+        return self.query()
 
     def clear(self) -> None:
         """Clear the jail state."""

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -109,7 +109,7 @@ class JailState(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=None
+            logger=self.logger
         )
 
         if returncode > 0:
@@ -133,7 +133,7 @@ class JailState(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=None
+            logger=self.logger
         )
 
         if returncode > 0:
@@ -220,7 +220,7 @@ class JailStates(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=None
+            logger=self.logger
         )
 
         if returncode > 0:
@@ -241,7 +241,7 @@ class JailStates(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=None
+            logger=self.logger
         )
 
         if returncode > 0:

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -98,7 +98,6 @@ class JailState(dict):
             return self._query_list()
 
     def _query_libxo(self) -> typing.Dict[str, str]:
-        data: typing.Dict[str, str] = {}
         stdout, _, returncode = iocage.helpers.exec(
             [
                 "/usr/sbin/jls",
@@ -116,12 +115,11 @@ class JailState(dict):
             self.clear()
             return {}
 
-        new_state = _parse_json(stdout)[self.name]
-        self._data = new_state.data
-        return data
+        data = _parse_json(stdout)[self.name]._data
+        self._data = data
+        return data if (data is not None) else {}
 
     def _query_list(self) -> typing.Dict[str, str]:
-        data: typing.Dict[str, str] = {}
         stdout, _, returncode = iocage.helpers.exec(
             [
                 "/usr/sbin/jls",
@@ -140,9 +138,9 @@ class JailState(dict):
             self.clear()
             return {}
 
-        new_state = _parse(stdout)[self.name]
-        self._data = new_state.data
-        return data
+        data = _parse(stdout)[self.name]._data
+        self._data = data
+        return data if (data is not None) else {}
 
     @property
     def data(self) -> typing.Dict[str, str]:

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -178,7 +178,6 @@ class JailState(dict):
 class JailStates(dict):
     """A dictionary of JailStates."""
 
-    logger: typing.Optional['iocage.Logger.Logger']
     queried: bool
 
     def __init__(
@@ -195,21 +194,24 @@ class JailStates(dict):
 
     def query(
         self,
-        logger: 'iocage.Logger.Logger'=None
+        logger: typing.Optional['iocage.Logger.Logger']=None
     ) -> None:
         """Invoke update of the jail state from jls output."""
         if logger is not None:
             logger.verbose("Querying all running jails status")
         try:
             if _get_userland_version() >= 11:
-                self._query_libxo()
+                self._query_libxo(logger=logger)
             else:
-                self._query_list()
+                self._query_list(logger=logger)
         except BaseException:
             raise iocage.errors.JailStateUpdateFailed()
         self.queried = True
 
-    def _query_libxo(self) -> None:
+    def _query_libxo(
+        self,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
         stdout, _, returncode = iocage.helpers.exec(
             [
                 "/usr/sbin/jls",
@@ -218,7 +220,7 @@ class JailStates(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=self.logger
+            logger=logger
         )
 
         if returncode > 0:
@@ -229,7 +231,10 @@ class JailStates(dict):
         for name in output_data:
             dict.__setitem__(self, name, output_data[name])
 
-    def _query_list(self) -> None:
+    def _query_list(
+        self,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
         stdout, _, returncode = iocage.helpers.exec(
             [
                 "/usr/sbin/jls",
@@ -239,7 +244,7 @@ class JailStates(dict):
             ],
             stderr=subprocess.DEVNULL,
             ignore_error=True,
-            logger=self.logger
+            logger=logger
         )
 
         if returncode > 0:

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -116,8 +116,8 @@ class JailState(dict):
             self.clear()
             return {}
 
-        data = _parse_json(stdout)[self.name]
-        self._data = data
+        new_state = _parse_json(stdout)[self.name]
+        self._data = new_state.data
         return data
 
     def _query_list(self) -> typing.Dict[str, str]:
@@ -140,8 +140,8 @@ class JailState(dict):
             self.clear()
             return {}
 
-        data = _parse(stdout)[self.name]
-        self._data = data
+        new_state = _parse(stdout)[self.name]
+        self._data = new_state.data
         return data
 
     @property

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -170,7 +170,7 @@ class JailState(dict):
         if self._data is None:
             return "None"
         else:
-            return str(iocage.helpers.to_json(self._data))
+            return str(iocage.helpers.to_json(self.data))
 
     def keys(self) -> typing.List[str]:  # noqa: T484
         """Return all available jail state keys."""

--- a/iocage/decorators.py
+++ b/iocage/decorators.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2014-2018, iocage
+# Copyright (c) 2017-2018, Stefan Grönke
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Collection of iocage Python decorators."""
+import functools
+import time
+
+import iocage.helpers
+
+
+def json(fn):
+    """Return the functions output as JSON string."""
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):  # noqa: T484
+        return iocage.helpers.to_json(fn(*args, **kwargs))
+    return wrapped
+
+
+def timeit(fn):
+    """Measure and print the functions execution time."""
+    @functools.wraps(fn)
+    def wrapped(*args, **kwargs):  # noqa: T484
+        startTime = time.time()
+        try:
+            output = fn(*args, **kwargs)
+            error = None
+        except Exception as err:
+            error = err
+        elapsedTime = (time.time() - startTime) * 1000
+        print(f"function [{fn.__qualname__}] finished in {elapsedTime} ms")
+        if error is not None:
+            raise error
+        return output
+    return wrapped

--- a/iocage/helpers.py
+++ b/iocage/helpers.py
@@ -42,7 +42,7 @@ CommandOutput = typing.Tuple[typing.Optional[str], typing.Optional[str], int]
 
 
 def get_os_version(
-        version_file: str="/bin/freebsd-version"
+    version_file: str="/bin/freebsd-version"
 ) -> typing.Dict[str, typing.Union[str, int, float]]:
     """Get the hosts userland version."""
     f = open(version_file, "r", re.MULTILINE, encoding="utf-8")


### PR DESCRIPTION
- Don't set JailState._data twice
- Require a queried state when printing the JailState object representation