### PR TITLE
support FreeBSD/HardenedBSD release 12 updates

### DIFF
--- a/iocage/Distribution.py
+++ b/iocage/Distribution.py
@@ -231,8 +231,11 @@ class DistributionGenerator:
         self.logger.verbose(f"Downloading EOL info from {self.eol_url}")
         with urllib.request.urlopen(request) as response:  # nosec: B310
 
-            if response.getcode() != 200:  # noqa: T484
-                iocage.errors.DistributionEOLWarningDownloadFailed(
+            response_code = response.getcode()
+            if response_code != 200:  # noqa: T484
+                iocage.errors.DownloadFailed(
+                    topic="EOL Warnings",
+                    code=response_code,
                     logger=self.logger,
                     level="warning"
                 )

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -2251,13 +2251,31 @@ class Jail(JailGenerator):
     def fork_exec(  # noqa: T484
         self,
         command: str,
+        passthru: bool=False,
+        event_scope: typing.Optional['iocage.events.Scope']=None,
+        start_dependant_jails: bool=True,
         **temporary_config_override
     ) -> str:
-        """Execute a one-shot jail and return its stdout."""
+        """
+        Start a jail, run a command and shut it down immediately.
+
+        Args:
+
+            command (string):
+                The command to execute in the jail
+
+            passthru (string):
+                Attach the command to the TTY of the executing process.
+
+            start_dependant_jails (bool):
+                When disabled, not dependant jails are started.
+        """
         events = JailGenerator.fork_exec(
             self,
             command=command,
-            passthru=False
+            passthru=passthru,
+            event_scope=event_scope,
+            start_dependant_jails=start_dependant_jails
         )
         for event in events:
             if isinstance(event, iocage.events.JailLaunch) and event.done:

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -749,7 +749,20 @@ class JailGenerator(JailResource):
         start_dependant_jails: bool=True,
         **temporary_config_override: typing.Any
     ) -> typing.Generator['iocage.events.IocageEvent', None, None]:
-        """Start a jail, run a command and shut it down immediately."""
+        """
+        Start a jail, run a command and shut it down immediately.
+
+        Args:
+
+            command (string):
+                The command to execute in the jail
+
+            passthru (string):
+                Attach the command to the TTY of the executing process.
+
+            start_dependant_jails (bool):
+                When disabled, no dependant jails are started.
+        """
         self.require_jail_existing()
         self.require_jail_stopped()
 

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -746,6 +746,7 @@ class JailGenerator(JailResource):
         command: str,
         passthru: bool=False,
         event_scope: typing.Optional['iocage.events.Scope']=None,
+        start_dependant_jails: bool=False,
         **temporary_config_override: typing.Any
     ) -> typing.Generator['iocage.events.IocageEvent', None, None]:
         """Start a jail, run a command and shut it down immediately."""
@@ -770,7 +771,8 @@ class JailGenerator(JailResource):
                 self,
                 single_command=command,
                 passthru=passthru,
-                event_scope=event_scope
+                event_scope=event_scope,
+                start_dependant_jails=start_dependant_jails
             )
             for event in fork_exec_events:
                 yield event

--- a/iocage/Jail.py
+++ b/iocage/Jail.py
@@ -746,7 +746,7 @@ class JailGenerator(JailResource):
         command: str,
         passthru: bool=False,
         event_scope: typing.Optional['iocage.events.Scope']=None,
-        start_dependant_jails: bool=False,
+        start_dependant_jails: bool=True,
         **temporary_config_override: typing.Any
     ) -> typing.Generator['iocage.events.IocageEvent', None, None]:
         """Start a jail, run a command and shut it down immediately."""

--- a/iocage/JailState.py
+++ b/iocage/JailState.py
@@ -151,7 +151,7 @@ class JailState(dict):
 
     def clear(self) -> None:
         """Clear the jail state."""
-        self._data = None
+        self._data = {}
 
     def __getitem__(self, name: str) -> str:
         """Get a value from the jail state."""

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -624,6 +624,8 @@ class ReleaseGenerator(ReleaseResource):
                 logger=self.logger
             )
 
+        iocage.helpers.require_no_symlink(source_file, logger=self.logger)
+
         with open(source_file, "r") as f:
             import ucl
             hbsd_update_conf = ucl.load(f.read())

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -720,8 +720,10 @@ class ReleaseGenerator(ReleaseResource):
             yield releaseConfigurationEvent.skip()
 
         if fetch_updates is True:
-            for event in self.updater.fetch(event_scope=_scope):
-                yield event
+            try:
+                yield from self.updater.fetch(event_scope=_scope)
+            except iocage.errors.IocageException:
+                update = False
 
         if update is True:
             for event in self.updater.apply():

--- a/iocage/Release.py
+++ b/iocage/Release.py
@@ -723,7 +723,11 @@ class ReleaseGenerator(ReleaseResource):
 
         if fetch_updates is True:
             try:
-                yield from self.updater.fetch(event_scope=_scope)
+                for event in self.updater.fetch(event_scope=_scope):
+                    if isinstance(event, iocage.events.ReleaseUpdateDownload):
+                        if (event.done and event.skipped) is True:
+                            update = False
+                    yield event
             except iocage.errors.IocageException:
                 update = False
 

--- a/iocage/ResourceUpdater.py
+++ b/iocage/ResourceUpdater.py
@@ -438,7 +438,7 @@ class Updater:
                     yield event
 
         if skipped is True:
-            yield executeResourceUpdateEvent.skip()
+            yield executeResourceUpdateEvent.skip("already up to date")
         else:
             yield executeResourceUpdateEvent.end()
 

--- a/iocage/ResourceUpdater.py
+++ b/iocage/ResourceUpdater.py
@@ -218,8 +218,8 @@ class Updater:
 
         _request = urllib.request  # type: ignore
         try:
+            self.logger.verbose(f"Downloading update assets from {url}")
             _request.urlretrieve(url, local)  # nosec: url validated
-            self.logger.verbose(f"Update assets downloaded from {url}")
         except urllib.error.HTTPError as http_error:
             raise iocage.errors.DownloadFailed(
                 url="EOL Warnings",

--- a/iocage/ResourceUpdater.py
+++ b/iocage/ResourceUpdater.py
@@ -246,9 +246,14 @@ class Updater:
             local=f"{self.host_updates_dir}/{self.update_script_name}"
         )
 
+        if self.release.version_number >= 12:
+            conf_path = f"usr.sbin/{self.update_name}/{self.update_conf_name}"
+        else:
+            conf_path = f"etc/{self.update_conf_name}"
+
         self._download_updater_asset(
             mode=0o644,
-            remote=f"etc/{self.update_conf_name}",
+            remote=conf_path,
             local=f"{self.host_updates_dir}/{self.update_conf_name}"
         )
 

--- a/iocage/ResourceUpdater.py
+++ b/iocage/ResourceUpdater.py
@@ -403,6 +403,7 @@ class Updater:
                 jail,
                 self._wrap_command(" ".join(self._update_command), "update"),
                 passthru=False,
+                start_dependant_jails=False,
                 event_scope=_scope
             ):
                 if isinstance(event, iocage.events.JailLaunch) is True:

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -1062,13 +1062,14 @@ class UpdateFailure(IocageException):
         self,
         name: str,
         reason: typing.Optional[str]=None,
-        logger: typing.Optional['iocage.Logger.Logger']=None
+        logger: typing.Optional['iocage.Logger.Logger']=None,
+        level: str="error"
     ) -> None:
 
         msg = f"Release update of '{name}' failed"
         if reason is not None:
             msg += f": {reason}"
-        super().__init__(message=msg, logger=logger)
+        super().__init__(message=msg, logger=logger, level=level)
 
 
 class InvalidReleaseAssetSignature(UpdateFailure):

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -683,15 +683,17 @@ class HostUserlandVersionUnknown(IocageException):
         super().__init__(message=msg, logger=logger)
 
 
-class DistributionEOLWarningDownloadFailed(IocageException):
+class DownloadFailed(IocageException):
     """Raised when downloading EOL warnings failed."""
 
     def __init__(
         self,
+        url: str,
+        code: int,
         logger: typing.Optional['iocage.Logger.Logger']=None,
         level: str="error"
     ) -> None:
-        msg = f"Failed to download the EOL warnings"
+        msg = f"Failed downloading {url}: {code}"
         super().__init__(message=msg, logger=logger, level=level)
 
 

--- a/iocage/events.py
+++ b/iocage/events.py
@@ -438,6 +438,12 @@ class ReleaseDownload(FetchRelease):
     pass
 
 
+class ReleaseAssetDownload(FetchRelease):
+    """Download release assets."""
+
+    pass
+
+
 class ReleaseExtraction(FetchRelease):
     """Extract a release asset."""
 


### PR DESCRIPTION
- The source path of `freebsd-update.conf` and `hbsd-update.conf` have changed with release version 12.
- Better error handling and messages on Release updates
- do not repeatedly check the state of stopped jails
- do not start dependant jails with temporary update jails
- fixes #378