### PR TITLE
Handle non-existing bridge interfaces with IocageException

### DIFF
--- a/iocage/Network.py
+++ b/iocage/Network.py
@@ -167,8 +167,15 @@ class Network:
     def __autodetected_bridge_mtu(self) -> int:
         self.__require_bridge()
         bridge_name = str(self.bridge)
-        mtu = int(iocage.helpers_ioctl.get_interface_mtu(bridge_name))
-        self.logger.debug(f"Bridge {bridge_name} MTU detected: {mtu}")
+        try:
+            mtu = int(iocage.helpers_ioctl.get_interface_mtu(bridge_name))
+            self.logger.debug(f"Bridge {bridge_name} MTU detected: {mtu}")
+        except OSError:
+            self.logger.debug(f"Bridge {bridge_name} MTU detection failed")
+            raise iocage.errors.VnetBridgeDoesNotExist(
+                bridge_name=bridge_name,
+                logger=self.logger
+            )
         self._mtu = mtu
         return mtu
 

--- a/iocage/errors.py
+++ b/iocage/errors.py
@@ -973,6 +973,18 @@ class VnetBridgeMissing(IocageException):
         super().__init__(message=msg, logger=logger)
 
 
+class VnetBridgeDoesNotExist(IocageException):
+    """Raised when a vnet bridge is missing."""
+
+    def __init__(
+        self,
+        bridge_name: str,
+        logger: typing.Optional['iocage.Logger.Logger']=None
+    ) -> None:
+        msg = f"VNET bridge {bridge_name} does not exist"
+        super().__init__(message=msg, logger=logger)
+
+
 class InvalidNetworkBridge(IocageException, ValueError):
     """Raised when a network bridge is invalid."""
 


### PR DESCRIPTION
fixes #589

When a bridge device does not exist, the MTU lookup fails with an OSError. This error is now handled and a proper IocageException with an descriptive error message is raised.