### PR TITLE
ListableResoueces list index access

### DIFF
--- a/iocage/Jails.py
+++ b/iocage/Jails.py
@@ -113,6 +113,12 @@ class JailsGenerator(iocage.ListableResource.ListableResource):
 
             yield jail
 
+    def __getitem__(self, index: int) -> 'iocage.Jail.JailGenerator':
+        """Return the JailGenerator at a certain index position."""
+        _getitem = iocage.ListableResource.ListableResource.__getitem__
+        jail = _getitem(self, index)  # type: iocage.Jail.JailGenerator
+        return jail
+
 
 class Jails(JailsGenerator):
     """Synchronous wrapper ofs JailsGenerator."""
@@ -120,3 +126,9 @@ class Jails(JailsGenerator):
     @property
     def _class_jail(self) -> iocage.Jail.Jail:
         return iocage.Jail.Jail
+
+    def __getitem__(self, index: int) -> 'iocage.Jail.Jail':
+        """Return the Jail object at a certain index position."""
+        _getitem = JailsGenerator.__getitem__
+        jail = _getitem(self, index)  # type: iocage.Jail.Jail
+        return jail

--- a/iocage/ListableResource.py
+++ b/iocage/ListableResource.py
@@ -26,6 +26,7 @@
 import typing
 import libzfs
 import abc
+import itertools
 
 import iocage.Filter
 import iocage.Resource
@@ -106,6 +107,20 @@ class ListableResource(list):
                 if self._filters is not None:
                     if self._filters.match_resource(resource):
                         yield resource
+
+    def __getitem__(  # noqa: T484
+        self,
+        index: int
+    ) -> 'iocage.Resource.Resource':
+        """Return the resource at a certain index position."""
+        items = self.__iter__()
+        try:
+            for _ in itertools.repeat(None, index):
+                next(items)
+            return next(items)
+        except StopIteration:
+            pass
+        raise IndexError("list index out of range")
 
     def __len__(self) -> int:
         """Return the number of resources matching the filters."""

--- a/iocage/ListableResource.py
+++ b/iocage/ListableResource.py
@@ -126,6 +126,11 @@ class ListableResource(list):
         """Return the number of resources matching the filters."""
         return len(list(self.__iter__()))
 
+    def __repr__(self) -> str:
+        """Return the resource list string representation."""
+        resource_names = ", ".join([x.name for x in self.__iter__()])
+        return f"[{resource_names}]"
+
     def _get_asset_name_from_dataset(
         self,
         dataset: libzfs.ZFSDataset

--- a/iocage/Releases.py
+++ b/iocage/Releases.py
@@ -105,6 +105,12 @@ class ReleasesGenerator(iocage.ListableResource.ListableResource):
             zfs=self.zfs
         )
 
+    def __getitem__(self, index: int) -> 'iocage.Release.ReleaseGenerator':
+        """Return the ReleaseGenerator at a certain index position."""
+        _getitem = iocage.ListableResource.ListableResource.__getitem__
+        r = _getitem(self, index)  # type: iocage.Release.ReleaseGenerator
+        return r
+
 
 class Releases(ReleasesGenerator):
     """Model of multiple iocage Releases."""
@@ -112,3 +118,9 @@ class Releases(ReleasesGenerator):
     @property
     def _class_release(self) -> 'iocage.Release.Release':
         return iocage.Release.Release
+
+    def __getitem__(self, index: int) -> 'iocage.Release.Release':
+        """Return the Jail object at a certain index position."""
+        _getitem = ReleasesGenerator.__getitem__
+        release = _getitem(self, index)  # type: iocage.Release.Release
+        return release


### PR DESCRIPTION
closes #583

```python-console
Python 3.6.7 (default, Dec  8 2018, 01:23:58) 
[GCC 4.2.1 Compatible FreeBSD Clang 6.0.1 (tags/RELEASE_601/final 335540)] on freebsd12
Type "help", "copyright", "credits" or "license" for more information.
>>> import iocage                                                                                                                                                                                                                           
>>> releases = iocage.Releases.ReleasesGenerator()                                                                                                                                                                                  
>>> len(releases)
2
>>> releases[0]
<iocage.Release.ReleaseGenerator object at 0x80243af60>
>>> releases[1]
<iocage.Release.ReleaseGenerator object at 0x80243aeb8>
>>> releases[2]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/src/libiocage/iocage/Releases.py", line 111, in __getitem__
    r = _getitem(self, index)  # type: iocage.Release.ReleaseGenerator
  File "/usr/local/src/libiocage/iocage/ListableResource.py", line 120, in __getitem__
    raise IndexError("list index out of range")
IndexError: list index out of range
>>> releases = iocage.Releases()
>>> type(releases[0])
<class 'iocage.Release.Release'>
```